### PR TITLE
Fix `make test' in a clean system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@
 cmake_minimum_required(VERSION 2.8)
 set (PACKAGE_NAME opencc)
 project (${PACKAGE_NAME} C)
+include (CTest)
 enable_testing()
 
 ######## Package information

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -93,3 +93,9 @@ install(
 	DESTINATION
 		${DIR_SHARE_OPENCC}
 )
+
+if (BUILD_TESTING)
+	foreach (DICT ${TAIWAN_DICT_FILES} ${CHINA_DICT_FILES})
+		configure_file(${DICT} ${PROJECT_BINARY_DIR}/data COPYONLY)
+	endforeach (DICT)
+endif (BUILD_TESTING)


### PR DESCRIPTION
Without this patch `make test' fail with segmentation faults.
