### PR TITLE
Port to node.js v0.10

### DIFF
--- a/node/binding.cc
+++ b/node/binding.cc
@@ -68,7 +68,7 @@ class Opencc : public node::ObjectWrap {
     conv_data->callback = Persistent<Function>::New(Local<Function>::Cast(args[1]));
     uv_work_t* req = new uv_work_t;
     req->data = conv_data;
-    uv_queue_work(uv_default_loop(), req, DoConnect, AfterConvert);
+    uv_queue_work(uv_default_loop(), req, DoConnect, (uv_after_work_cb)AfterConvert);
 
     return Undefined();
   }


### PR DESCRIPTION
There is an API signature change in v0.10 that causes OpenCC to fail to install with an error:

>   CXX(target) Release/obj.target/binding/node/binding.o
> ../node/binding.cc:71:5: error: no matching function for call to 'uv_queue_work'
>     uv_queue_work(uv_default_loop(), req, DoConnect, AfterConvert);
>     ^~~~~~~~~~~~~
> /Users/lalau/.node-gyp/0.10.0/deps/uv/include/uv.h:1397:15: note: candidate function not viable: no known conversion from 'void (uv_work_t _)' to 'uv_after_work_cb' (aka 'void (_)(uv_work_t _, int)') for
>       4th argument
> UV_EXTERN int uv_queue_work(uv_loop_t_ loop, uv_work_t\* req,
>               ^
> 1 error generated.
> make: **\* [Release/obj.target/binding/node/binding.o] Error 1

API signature change in v0.10:
https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10
https://github.com/rbranson/node-ffi/commit/fdeff41ae8b1cca31d4707d7b61253c45181b8fa
