### PR TITLE
Be a bit more defensive about how dict is loaded

### DIFF
--- a/src/config_reader.c
+++ b/src/config_reader.c
@@ -53,9 +53,10 @@ static int load_dictionary(Config* config) {
       last_index = config->dicts[i].index;
       group = dict_chain_add_group(config->dict_chain);
     }
-    dict_group_load(group,
-                    config->dicts[i].file_name,
-                    config->dicts[i].dict_type);
+    if (dict_group_load(group,
+                        config->dicts[i].file_name,
+                        config->dicts[i].dict_type) == -1)
+      return -1;
   }
   return 0;
 }
@@ -185,7 +186,10 @@ DictChain* config_get_dict_chain(Config* config) {
     dict_chain_delete(config->dict_chain);
   }
   config->dict_chain = dict_chain_new(config);
-  load_dictionary(config);
+  if (load_dictionary(config) == -1) {
+    dict_chain_delete(config->dict_chain);
+    config->dict_chain = NULL;
+  }
   return config->dict_chain;
 }
 

--- a/src/converter.c
+++ b/src/converter.c
@@ -326,13 +326,15 @@ static size_t segment(Converter* converter,
       }
       start = i;
     }
-    size_t match_len;
-    dict_group_match_longest(
+    size_t match_len = 0;
+    const ucs4_t* const* match_rs = dict_group_match_longest(
       converter->current_dict_group,
       inbuf_start + i,
       0,
       &match_len
       );
+    if (match_rs == (const ucs4_t* const*)-1)
+      return (size_t)-1;
     if (match_len == 0) {
       match_len = 1;
     }
@@ -347,7 +349,7 @@ static size_t segment(Converter* converter,
                            outbuf,
                            outbuf_left,
                            bound - start);
-    if (sp_seg_length ==  (size_t)-1) {
+    if (sp_seg_length == (size_t)-1) {
       return (size_t)-1;
     }
     if (sp_seg_length == 0) {

--- a/src/opencc.c
+++ b/src/opencc.c
@@ -160,6 +160,10 @@ opencc_t opencc_open(const char* config_file) {
       return (opencc_t)-1;
     }
     opencc->dict_chain = config_get_dict_chain(config);
+    if (opencc->dict_chain == NULL) {
+      free(opencc);
+      return (opencc_t)-1;
+    }
     converter_assign_dictionary(opencc->converter, opencc->dict_chain);
     config_close(config);
   }


### PR DESCRIPTION
When config is loaded but dict is not, these situations aren't properly
checked in code, resulting all sorts of weird memory access errors, more
strict checking could avoid these.
