### PR TITLE
Build opencc as shared or static library in respect of CMake option...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ project (${PACKAGE_NAME} CXX)
 include (CTest)
 enable_testing()
 
+option(BUILD_SHARED_LIBS "Build opencc as shared library" ON)
+
 ######## Package information
 set (PACKAGE_URL https://github.com/BYVoid/Opencc)
 set (PACKAGE_BUGREPORT https://github.com/BYVoid/Opencc/issues)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,6 @@ include_directories(../deps/tclap-1.2.1)
 
 add_library(
   libopencc
-  SHARED
   ${LIBOPENCC_SOURCES}
 )
 
@@ -61,7 +60,6 @@ GENERATE_EXPORT_HEADER(
 
 set_target_properties(
   libopencc
-  # libopencc_static
   PROPERTIES
     LINKER_LANGUAGE
       CXX


### PR DESCRIPTION
CMake option: BUILD_SHARED_LIBS (by default ON).
