### PR TITLE
Do not output a trailing newline to the buffer.

### DIFF
--- a/src/tools/CommandLine.cpp
+++ b/src/tools/CommandLine.cpp
@@ -45,12 +45,17 @@ FILE* GetOutputStream() {
 void ConvertLineByLine() {
   std::istream& inputStream = std::cin;
   FILE* fout = GetOutputStream();
+  bool isFirstLine = true;
   while (!inputStream.eof()) {
+    if (!isFirstLine) {
+      fputs("\n", fout);
+    } else {
+      isFirstLine = false;
+    }
     string line;
     std::getline(inputStream, line);
     const string& converted = converter->Convert(line);
     fputs(converted.c_str(), fout);
-    fputs("\n", fout);
     if (!noFlush) {
       // Flush every line if the output stream is stdout.
       fflush(fout);


### PR DESCRIPTION
This makes it more convenient for buffer editing with VIM or other editors.