### PR TITLE
Allow ext-less config filenames for package data.

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -179,6 +179,11 @@ public:
       if (ifs.is_open()) {
         return prefixedFileName;
       }
+      prefixedFileName += ".json";
+      ifs.open(prefixedFileName.c_str());
+      if (ifs.is_open()) {
+        return prefixedFileName;
+      }
     }
     throw FileNotFound(fileName);
   }


### PR DESCRIPTION
Now we can run

```
opencc -c t2s -i input -o output
```

instead of

```
opencc -c t2s.json -i input -o output
```

with the builtin config files.