### PR TITLE
node: fix compatibility with iojs@3.0.0

### DIFF
--- a/node/binding.cc
+++ b/node/binding.cc
@@ -8,18 +8,19 @@
 
 using namespace v8;
 using namespace opencc;
+using namespace Nan;
 
 string ToUtf8String(const Local<String>& str) {
   v8::String::Utf8Value utf8(str);
   return std::string(*utf8);
 }
 
-class OpenccBinding : public node::ObjectWrap {
+class OpenccBinding : public Nan::ObjectWrap {
   struct ConvertRequest {
     OpenccBinding* instance;
     string input;
     string output;
-    Persistent<Function> callback;
+    Nan::Callback *callback;
     Optional<opencc::Exception> ex;
 
     ConvertRequest()
@@ -42,42 +43,42 @@ class OpenccBinding : public node::ObjectWrap {
   }
 
   static NAN_METHOD(New) {
-    NanScope();
+    Nan::HandleScope scope;
     OpenccBinding* instance;
 
     try {
-      if (args.Length() >= 1 && args[0]->IsString()) {
-        string configFile = ToUtf8String(args[0]->ToString());
+      if (info.Length() >= 1 && info[0]->IsString()) {
+        string configFile = ToUtf8String(info[0]->ToString());
         instance = new OpenccBinding(configFile);
       } else {
         instance = new OpenccBinding("s2t.json");
       }
     } catch (opencc::Exception& e) {
-      NanThrowError(e.what());
-      NanReturnUndefined();
+      Nan::ThrowError(e.what());
+      return;
     }
 
-    instance->Wrap(args.This());
-    NanReturnValue(args.This());
+    instance->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
   }
 
   static NAN_METHOD(Convert) {
-    NanScope();
-    if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsFunction()) {
-      NanThrowTypeError("Wrong arguments");
-      NanReturnUndefined();
+    Nan::HandleScope scope;
+    if (info.Length() < 2 || !info[0]->IsString() || !info[1]->IsFunction()) {
+      Nan::ThrowTypeError("Wrong arguments");
+      return;
     }
 
     ConvertRequest* conv_data = new ConvertRequest;
-    conv_data->instance = ObjectWrap::Unwrap<OpenccBinding>(args.This());
-    conv_data->input = ToUtf8String(args[0]->ToString());
-    NanAssignPersistent(conv_data->callback, Local<Function>::Cast(args[1]));
+    conv_data->instance = Nan::ObjectWrap::Unwrap<OpenccBinding>(info.This());
+    conv_data->input = ToUtf8String(info[0]->ToString());
+    conv_data->callback = new Nan::Callback(info[1].As<v8::Function>());
     conv_data->ex = Optional<opencc::Exception>::Null();
     uv_work_t* req = new uv_work_t;
     req->data = conv_data;
     uv_queue_work(uv_default_loop(), req, DoConvert, (uv_after_work_cb)AfterConvert);
 
-    NanReturnUndefined();
+    return;
   }
 
   static void DoConvert(uv_work_t* req) {
@@ -91,61 +92,57 @@ class OpenccBinding : public node::ObjectWrap {
   }
 
   static void AfterConvert(uv_work_t* req) {
-    NanScope();
+    Nan::HandleScope scope;
     ConvertRequest* conv_data = static_cast<ConvertRequest*>(req->data);
-    Local<Value> err = NanUndefined();
-    Local<String> converted = NanNew<String>(conv_data->output.c_str());
+    Local<Value> err = Nan::Undefined();
+    Local<String> converted = Nan::New<v8::String>(conv_data->output.c_str()).ToLocalChecked();
     if (!conv_data->ex.IsNull()) {
-      err = NanNew<String>(conv_data->ex.Get().what());
+      err = Nan::New<v8::String>(conv_data->ex.Get().what()).ToLocalChecked();
     }
     const unsigned argc = 2;
     Local<Value> argv[argc] = {
       err,
-      NanNew(converted)
+      converted
     };
-    NanMakeCallback(NanGetCurrentContext()->Global(), NanNew(conv_data->callback), argc, argv);
+    conv_data->callback->Call(argc, argv);
     delete conv_data;
     delete req;
   }
 
   static NAN_METHOD(ConvertSync) {
-    NanScope();
-    if (args.Length() < 1 || !args[0]->IsString()) {
-      NanThrowTypeError("Wrong arguments");
-      NanReturnUndefined();
+    Nan::HandleScope scope;
+    if (info.Length() < 1 || !info[0]->IsString()) {
+      Nan::ThrowTypeError("Wrong arguments");
+      return;
     }
 
-    OpenccBinding* instance = ObjectWrap::Unwrap<OpenccBinding>(args.This());
+    OpenccBinding* instance = Nan::ObjectWrap::Unwrap<OpenccBinding>(info.This());
 
-    string input = ToUtf8String(args[0]->ToString());
+    string input = ToUtf8String(info[0]->ToString());
     string output;
     try {
       output = instance->Convert(input);
     } catch (opencc::Exception& e) {
-      NanThrowError(e.what());
-      NanReturnUndefined();
+      Nan::ThrowError(e.what());
+      return;
     }
 
-    Local<String> converted = NanNew<String>(output.c_str());
-    NanReturnValue(converted);
+    Local<String> converted = Nan::New<v8::String>(output.c_str()).ToLocalChecked();
+    info.GetReturnValue().Set(converted);
   }
 
-  static void init(Handle<Object> target) {
-    NanScope();
+  static NAN_MODULE_INIT(Init) {
+    Nan::HandleScope scope;
     // Prepare constructor template
-    Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(OpenccBinding::New);
-    tpl->SetClassName(NanNew<String>("Opencc"));
+    Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(OpenccBinding::New);
+    tpl->SetClassName(Nan::New<v8::String>("Opencc").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
-    NODE_SET_PROTOTYPE_METHOD(tpl, "convert", Convert);
-    NODE_SET_PROTOTYPE_METHOD(tpl, "convertSync", ConvertSync);
+    Nan::SetPrototypeMethod(tpl, "convert", Convert);
+    Nan::SetPrototypeMethod(tpl, "convertSync", ConvertSync);
     // Constructor
-    target->Set(NanNew<String>("Opencc"), tpl->GetFunction());
+    Nan::Set(target, Nan::New<v8::String>("Opencc").ToLocalChecked(), tpl->GetFunction());
   }
 };
 
-void init(Handle<Object> target) {
-  OpenccBinding::init(target);
-}
-
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, OpenccBinding::Init);

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "Traditional Chinese"
   ],
   "devDependencies": {
-    "mocha": "1.8.1"
+    "mocha": "2.2.5"
   },
   "dependencies": {
-    "nan": "^1.6.2"
+    "nan": "^2.0.0"
   }
 }


### PR DESCRIPTION
iojs@3.0.0 requires nan@2.0.+ and g++-4.8

will fix installation failure on iojs@3.0.0

commit d6bf735f054d834dbb063bb4131261a9d92f555e
Author: Peter Cai <xqsx43cxy@126.com>
Date:   Fri Aug 14 20:24:28 2015 +0800

    remove useless lines

commit 11928c1c83837bf66fa50e0a26ce591b0e8deeea
Author: Peter Cai <xqsx43cxy@126.com>
Date:   Fri Aug 14 17:34:10 2015 +0800

    migrate to nan@2.0.0

    and update mocha.

    This fixes compatibility with iojs@3.0.0

    Signed-off-by: Peter Cai <xqsx43cxy@126.com>