### PR TITLE
Update for Mac OS X El Capitan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+PREFIX = /usr
+
 .PHONY: build clean node test xcode-build
 
 build:
@@ -24,12 +26,13 @@ build:
 	-DBUILD_DOCUMENTATION:BOOL=ON \
 	-DENABLE_GTEST:BOOL=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_INSTALL_PREFIX=${PREFIX} \
 	../..)
-	make -C build/rel VERBOSE=${VERBOSE}
+	make -C build/rel VERBOSE=${VERBOSE} PREFIX=${PREFIX}
 
 package: build
 	make -C build/rel package_source VERBOSE=${VERBOSE}
+	make -C build/rel package_source VERBOSE=${VERBOSE} PREFIX=${PREFIX}
 
 test:
 	mkdir -p build/dbg/root
@@ -65,4 +68,4 @@ clean:
 	rm -rf build xcode
 
 install: build
-	make -C build/rel install VERBOSE=${VERBOSE}
+	make -C build/rel install VERBOSE=${VERBOSE} PREFIX=${PREFIX}

--- a/README.md
+++ b/README.md
@@ -66,11 +66,18 @@ https://bintray.com/byvoid/opencc/OpenCC
 
 ### Build with CMake
 
-Linux/OSX (gcc 4.6 or clang 3.2 is required):
+Linux (gcc 4.6 is required):
 
 ```
 make
 sudo make install
+```
+
+Mac OS X (clang 3.2 is required):
+
+```
+make PREFIX=/usr/local
+sudo make PREFIX=/usr/local install
 ```
 
 Windows MSYS:


### PR DESCRIPTION
Because of [System Integrity Protection](http://arstechnica.com/apple/2015/09/os-x-10-11-el-capitan-the-ars-technica-review/8/), root users cannot modify all files inside `/usr` directly on Mac OS 10.11. But we can still install opencc in `/usr/local`.

These changes make the build process more flexible to solve this problem, while leaving other systems unaffected.