### PR TITLE
(MSVC) Build in VS2015 (commit 1) and Unicode filename support (commit 2)

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -168,19 +168,19 @@ public:
     std::ifstream ifs;
 
     // Working directory
-    ifs.open(fileName.c_str());
+    ifs.open(UTF8Util::GetPlatformString(fileName).c_str());
     if (ifs.is_open()) {
       return fileName;
     }
     // Package data directory
     if (PACKAGE_DATA_DIRECTORY != "") {
       string prefixedFileName = PACKAGE_DATA_DIRECTORY + fileName;
-      ifs.open(prefixedFileName.c_str());
+      ifs.open(UTF8Util::GetPlatformString(prefixedFileName).c_str());
       if (ifs.is_open()) {
         return prefixedFileName;
       }
       prefixedFileName += ".json";
-      ifs.open(prefixedFileName.c_str());
+      ifs.open(UTF8Util::GetPlatformString(prefixedFileName).c_str());
       if (ifs.is_open()) {
         return prefixedFileName;
       }
@@ -197,7 +197,7 @@ Config::~Config() { delete (ConfigInternal*)internal; }
 ConverterPtr Config::NewFromFile(const string& fileName) {
   ConfigInternal* impl = (ConfigInternal*)internal;
   string prefixedFileName = impl->FindConfigFile(fileName);
-  std::ifstream ifs(prefixedFileName);
+  std::ifstream ifs(UTF8Util::GetPlatformString(prefixedFileName));
   string content(std::istreambuf_iterator<char>(ifs),
                  (std::istreambuf_iterator<char>()));
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <unordered_map>
+
 #include "Config.hpp"
 #include "ConversionChain.hpp"
 #include "Converter.hpp"
@@ -25,8 +27,6 @@
 #include "TextDict.hpp"
 
 #include "document.h"
-
-#include <unordered_map>
 
 using namespace opencc;
 

--- a/src/SerializableDict.hpp
+++ b/src/SerializableDict.hpp
@@ -47,7 +47,15 @@ public:
   template <typename DICT>
   static bool TryLoadFromFile(const string& fileName,
                               std::shared_ptr<DICT>* dict) {
-    FILE* fp = fopen(fileName.c_str(), "rb");
+      FILE* fp =
+#ifdef _MSC_VER
+          // well, the 'GetPlatformString' shall return a 'wstring'
+          _wfopen(UTF8Util::GetPlatformString(fileName).c_str(), L"rb")
+#else
+          fopen(UTF8Util::GetPlatformString(fileName).c_str(), "rb")
+#endif // _MSC_VER
+          ;
+
     if (fp == NULL) {
       return false;
     }

--- a/src/UTF8Util.hpp
+++ b/src/UTF8Util.hpp
@@ -18,6 +18,12 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#define NOMINMAX
+#include <Windows.h>
+#undef NOMINMAX
+#endif // _MSC_VER
+
 #include "Common.hpp"
 
 namespace opencc {
@@ -241,5 +247,38 @@ public:
       pstr = NextChar(pstr);
     }
   }
+
+#ifdef _MSC_VER
+  static std::wstring GetPlatformString(const std::string& str) {
+    return U8ToU16(str);
+  }
+#else
+  static std::string GetPlatformString(const std::string& str) {
+    return str;
+  }
+#endif // _MSC_VER
+
+
+#ifdef _MSC_VER
+  static std::string U16ToU8(const std::wstring& wstr) {
+    std::string ret;
+    int convcnt = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wstr.length(), NULL, 0, NULL, NULL);
+    if (convcnt > 0) {
+      ret.resize(convcnt);
+      WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wstr.length(), &ret[0], convcnt, NULL, NULL);
+    }
+    return ret;
+  }
+
+  static std::wstring U8ToU16(const std::string& str) {
+    std::wstring ret;
+    int convcnt = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), NULL, 0);
+    if (convcnt > 0) {
+      ret.resize(convcnt);
+      MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), &ret[0], convcnt);
+    }
+    return ret;
+  }
+#endif // _MSC_VER
 };
 }

--- a/src/opencc.h
+++ b/src/opencc.h
@@ -71,6 +71,18 @@ typedef void* opencc_t;
 * @ingroup opencc_c_api
 */
 OPENCC_EXPORT opencc_t opencc_open(const char* configFileName);
+#ifdef _MSC_VER
+/**
+* Makes an instance of opencc (wide char / Unicode)
+*
+* @param configFileName Location of configuration file. If this is set to NULL,
+*                       OPENCC_DEFAULT_CONFIG_SIMP_TO_TRAD will be loaded.
+* @return            A description pointer of the newly allocated instance of
+*                    opencc. On error the return value will be (opencc_t) -1.
+* @ingroup opencc_c_api
+*/
+OPENCC_EXPORT opencc_t opencc_open_w(const wchar_t* configFileName);
+#endif /* _MSC_VER */
 
 /**
 * Destroys an instance of opencc


### PR DESCRIPTION
(commit 1) How to build in VS2015 - Reference: http://www.cnblogs.com/lin277541/p/4928630.html
(commit 2) 系统是英文代码页，所以加了unicode文件名支持

顺便附上一个C#调用接口：
https://github.com/sgqy/mycolle/blob/master/mine/OpenCCEntry.cs

简单测试结果：
和1.0.1版的exe放在一起会被系统崩掉（管道正常，-i -o 参数异常）
和1.0.3版的exe放在一起正常工作
使用C#调用宽字符接口正常工作

---

Issue:
有关词典生成器出现的问题。
`SerializableDict.hpp`里的`TryLoadFromFile`接受一个UTF-8串，`SerializeToFile`接受一个ANSI串。
在ANSI编码环境里`TryLoadFromFile`的功能受限。
一种修改方向：`SerializeToFile`与打开文件时一样，统一接受UTF-8串，opencc_dict.exe加入字符转换过程。
这个动作修改较多，先等一等。