### PR TITLE
Config::NewFromString throws the exception when path does not contain trailing slash

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -232,7 +232,10 @@ ConverterPtr Config::NewFromString(const string& json,
   }
 
   ConfigInternal* impl = (ConfigInternal*)internal;
-  impl->configDirectory = configDirectory;
+  if (configDirectory.back() == '/' || configDirectory.back() == '\\')
+    impl->configDirectory = configDirectory;
+  else
+    impl->configDirectory = configDirectory + '/';
 
   // Required: segmentation
   SegmentationPtr segmentation =

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -57,4 +57,14 @@ TEST_F(ConfigTest, NonexistingPath) {
   }
 }
 
+TEST_F(ConfigTest, NewFromStringWitoutTrailingSlash) {
+  std::ifstream ifs(CONFIG_TEST_PATH);
+  string content(std::istreambuf_iterator<char>(ifs),
+                 (std::istreambuf_iterator<char>()));
+  string pathWithoutTrailingSlash = CMAKE_SOURCE_DIR "/test/config_test";
+
+  const ConverterPtr converter = config.NewFromString(
+      content, pathWithoutTrailingSlash);
+}
+
 } // namespace opencc


### PR DESCRIPTION
issue: #219 