### PR TITLE
Add: Swift Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ cmake --build build --config Release --target install
 
 See https://github.com/gelosie/OpenCC/tree/master/iOS
 
+Or [SwiftyOpenCC](https://github.com/XQS6LB3A/SwiftyOpenCC)
+
 ### Android
 
 See [android-opencc](https://github.com/qichuan/android-opencc)


### PR DESCRIPTION
Add a link to [SwiftyOpenCC](https://github.com/XQS6LB3A/SwiftyOpenCC), a simple, elegant way to use OpenCC on Apple devices.
