### PR TITLE
prebuild on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,43 @@
-language: cpp
-compiler:
-  - gcc
-sudo: required
+language: node_js
+node_js:
+  - "stable"
+  - "6"
+  - "4"
+  - "0.12"
+  - "0.10"
+  - "iojs"
+
+compiler: gcc
+sudo: false
+
+os:
+  - linux
+  - osx
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - doxygen
+      - gcc-4.8
+      - g++-4.8
+
 before_install:
-  - sudo add-apt-repository -y ppa:chris-lea/node.js
-  - sudo apt-get update
-  - sudo apt-get install nodejs -y
-  - sudo apt-get install doxygen -y
-  - sudo npm install -g mocha
-  - sudo npm install -g node-gyp
-  - sudo npm install
-script: make test VERBOSE=1 && make package VERBOSE=1 && make node-test
+  - npm config set python `which python`
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CC="gcc-4.8";
+      export CXX="g++-4.8";
+      export LINK="gcc-4.8";
+      export LINKXX="g++-4.8";
+    fi
+
+# Install scripts. (runs after repo cloning)
+install:
+  - npm install
+
+# Post-install test scripts.
+script:
+  - npm run test
+  - npm run package
+  - npm run deploy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Open Chinese Convert 開放中文轉換
 
 [ ![Download](https://api.bintray.com/packages/byvoid/opencc/OpenCC/images/download.svg) ](https://bintray.com/byvoid/opencc/OpenCC/_latestVersion)
-[![Build Status](https://travis-ci.org/BYVoid/OpenCC.svg?branch=master)](https://travis-ci.org/BYVoid/OpenCC)
+[![Travis](https://img.shields.io/travis/BYVoid/OpenCC.svg)](https://travis-ci.org/BYVoid/OpenCC)
+[![AppVeyor](https://img.shields.io/appveyor/ci/BYVoid/OpenCC.svg)](https://ci.appveyor.com/project/BYVoid/OpenCC)
 
 ## Introduction 介紹
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - CI_NODE_VERSION: "stable"
+    - CI_NODE_VERSION: "6"
+platform:
+  - x64
+  - x86
+
+# scripts that run after cloning repository
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:CI_NODE_VERSION $env:platform
+  # install modules
+  - npm install
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - npm run test
+
+# to run your custom scripts instead of provider deployments
+deploy_script:
+  - npm run package
+  - npm run deploy
+
+# Don't actually build.
+build: off

--- a/package.json
+++ b/package.json
@@ -6,7 +6,17 @@
   "license": "Apache-2.0",
   "main": "node/opencc.js",
   "scripts": {
-    "test": "mocha -R spec node/test.js"
+    "pretest": "node-pre-gyp rebuild",
+    "test": "mocha -R spec node/test.js",
+    "package": "node-pre-gyp package",
+    "deploy": "node-pre-gyp-github publish --release || echo github publish failed!",
+    "install": "node-pre-gyp install --fallback-to-build"
+  },
+  "binary": {
+    "module_name": "binding",
+    "module_path": "./build/Release/",
+    "host": "https://github.com/BYVoid/OpenCC/releases/download/",
+    "remote_path": "{version}"
   },
   "repository": {
     "type": "git",
@@ -24,9 +34,11 @@
     "Traditional Chinese"
   ],
   "devDependencies": {
-    "mocha": "2.2.5"
+    "mocha": "2.2.5",
+    "node-pre-gyp-github": "^1.3.1"
   },
   "dependencies": {
-    "nan": "^2.5.1"
+    "nan": "^2.5.1",
+    "node-pre-gyp": "^0.6.34"
   }
 }

--- a/src/BinaryDict.cpp
+++ b/src/BinaryDict.cpp
@@ -24,7 +24,7 @@ using namespace opencc;
 size_t BinaryDict::KeyMaxLength() const {
   size_t maxLength = 0;
   for (const DictEntry* entry : *lexicon) {
-    maxLength = std::max(maxLength, entry->KeyLength());
+    maxLength = (std::max)(maxLength, entry->KeyLength());
   }
   return maxLength;
 }

--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -135,7 +135,7 @@ DartsDictPtr DartsDict::NewFromDict(const Dict& thatDict) {
   for (size_t i = 0; i < lexiconCount; i++) {
     const DictEntry* entry = lexicon->At(i);
     keys[i] = entry->Key();
-    maxLength = std::max(entry->KeyLength(), maxLength);
+    maxLength = (std::max)(entry->KeyLength(), maxLength);
   }
   doubleArray->build(lexicon->Length(), &keys[0]);
   dict->lexicon = lexicon;

--- a/src/TextDict.cpp
+++ b/src/TextDict.cpp
@@ -25,7 +25,7 @@ static size_t GetKeyMaxLength(const LexiconPtr& lexicon) {
   size_t maxLength = 0;
   for (const auto& entry : *lexicon) {
     size_t keyLength = entry->KeyLength();
-    maxLength = std::max(keyLength, maxLength);
+    maxLength = (std::max)(keyLength, maxLength);
   }
   return maxLength;
 }


### PR DESCRIPTION
- 使用 `node-pre-gyp` #228
- 使用 [travis ci](https://travis-ci.org/gucong3000/OpenCC/builds/217117766) 来生成OS X和Linux下64位二进制包
- 使用 [appveyor](https://ci.appveyor.com/project/gucong3000/opencc/build/1.0.25) 来编译32位和64位windows下二进制包
- 使用`node-pre-gyp-github`将二进制包发布到[github releases](https://github.com/gucong3000/OpenCC/releases/tag/1.0.5)
- 解决Windows下编译失败的问题 #234
