### PR TITLE
解决node-gyp编译失败的错误

### DIFF
--- a/src/BinaryDict.cpp
+++ b/src/BinaryDict.cpp
@@ -24,7 +24,7 @@ using namespace opencc;
 size_t BinaryDict::KeyMaxLength() const {
   size_t maxLength = 0;
   for (const DictEntry* entry : *lexicon) {
-    maxLength = std::max(maxLength, entry->KeyLength());
+    maxLength = (std::max)(maxLength, entry->KeyLength());
   }
   return maxLength;
 }

--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -135,7 +135,7 @@ DartsDictPtr DartsDict::NewFromDict(const Dict& thatDict) {
   for (size_t i = 0; i < lexiconCount; i++) {
     const DictEntry* entry = lexicon->At(i);
     keys[i] = entry->Key();
-    maxLength = std::max(entry->KeyLength(), maxLength);
+    maxLength = (std::max)(entry->KeyLength(), maxLength);
   }
   doubleArray->build(lexicon->Length(), &keys[0]);
   dict->lexicon = lexicon;

--- a/src/TextDict.cpp
+++ b/src/TextDict.cpp
@@ -25,7 +25,7 @@ static size_t GetKeyMaxLength(const LexiconPtr& lexicon) {
   size_t maxLength = 0;
   for (const auto& entry : *lexicon) {
     size_t keyLength = entry->KeyLength();
-    maxLength = std::max(keyLength, maxLength);
+    maxLength = (std::max)(keyLength, maxLength);
   }
   return maxLength;
 }


### PR DESCRIPTION
解决在Windows平台下使用node-gyp编译失败的问题

错误日志如下：
```shell
λ node-gyp build
gyp info it worked if it ends with ok
gyp info using node-gyp@3.5.0
gyp info using node@6.10.0 | win32 | x64
gyp info spawn C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe
gyp info spawn args [ 'build/binding.sln',
gyp info spawn args   '/clp:Verbosity=minimal',
gyp info spawn args   '/nologo',
gyp info spawn args   '/p:Configuration=Release;Platform=x64' ]
在此解决方案中一次生成一个项目。若要启用并行生成，请添加“/m”开关。
  binding.cc
  win_delay_load_hook.cc
C:\open-source\OpenCC\src\BinaryDict.cpp(27): error C2589: “(”:“::”右边的非法标记 (编译源文件 ..\node\bindi
ng.cc) [C:\open
-source\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\src\BinaryDict.cpp(27): error C2059: 语法错误:“::” (编译源文件 ..\node\binding.cc) [C:\
open-sourc
e\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\deps\darts-clone\darts.h(759): warning C4334: “<<”: 32 位移位的结果被隐式转换为 64 位(
是否希望进行 64 位移位?)
 (编译源文件 ..\node\binding.cc) [C:\open-source\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\deps\darts-clone\darts.h(761): warning C4319: “~”: 将“unsigned int”扩展到更大的“Dart
s::Details:
:id_type”时为零 (编译源文件 ..\node\binding.cc) [C:\open-source\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\deps\darts-clone\darts.h(811): warning C4530: 使用了 C++ 异常处理程序，但未启用展开语义。
请指定 /EHsc (编译源文件 .
.\node\binding.cc) [C:\open-source\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\src\DartsDict.cpp(138): error C2589: “(”:“::”右边的非法标记 (编译源文件 ..\node\bindi
ng.cc) [C:\open
-source\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\src\DartsDict.cpp(138): error C2059: 语法错误:“::” (编译源文件 ..\node\binding.cc) [C:\
open-sourc
e\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\src\TextDict.cpp(28): error C2589: “(”:“::”右边的非法标记 (编译源文件 ..\node\binding
.cc) [C:\open-s
ource\OpenCC\build\binding.vcxproj]
C:\open-source\OpenCC\src\TextDict.cpp(28): error C2059: 语法错误:“::” (编译源文件 ..\node\binding.cc) [C:\op
en-source\
OpenCC\build\binding.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Users\JP\AppData\Roaming\npm\node_modules\node-gyp\lib\build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Windows_NT 10.0.14393
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\JP\\AppData\\Roaming\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "build"
gyp ERR! cwd C:\open-source\OpenCC
gyp ERR! node -v v6.10.0
gyp ERR! node-gyp -v v3.5.0
gyp ERR! not ok

```