### PR TITLE
Support promise for node low version

### DIFF
--- a/node/test.js
+++ b/node/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
-var fs = require('fs');
+var fs = require('fs-extra');
+var Promise = require('any-promise');
 var OpenCC = require('./opencc');
 
 var configs = [
@@ -43,6 +44,21 @@ var testAsync = function (config, done) {
   });
 };
 
+var testPromise = function (config) {
+  var inputName = 'test/testcases/' + config + '.in';
+  var outputName = 'test/testcases/' + config + '.ans';
+  var configName = config + '.json';
+  var opencc = new OpenCC(configName);
+  return fs.readFile(inputName, 'utf-8').then(function(text) {
+    return Promise.all([
+      opencc.convert(text),
+      fs.readFile(outputName, 'utf-8'),
+    ])
+  }).then(function(result) {
+    assert.equal(result[0], result[1]);
+  });
+};
+
 describe('Sync API', function () {
   configs.forEach(function (config) {
     it(config, function (done) {
@@ -55,6 +71,14 @@ describe('Async API', function () {
   configs.forEach(function (config) {
     it(config, function (done) {
       testAsync(config, done);
+    });
+  });
+});
+
+describe('Promise API', function () {
+  configs.forEach(function (config) {
+    it(config, function () {
+      return testPromise(config);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -32,11 +32,14 @@
     "Traditional Chinese"
   ],
   "devDependencies": {
-    "mocha": "^3.5.0",
+    "bluebird": "^3.5.0",
+    "fs-extra": "^4.0.2",
+    "mocha": "^3.5.3",
     "node-pre-gyp-github": "^1.3.1"
   },
   "dependencies": {
+    "any-promise": "^1.3.0",
     "nan": "^2.7.0",
-    "node-pre-gyp": "^0.6.36"
+    "node-pre-gyp": "^0.6.37"
   }
 }


### PR DESCRIPTION
- Add support: Promise for node.js low version
- API change: Merg two of functions `OpenCC.prototype.convert` and `OpenCC.prototype.convertPromise` to one
- Add test: for Promise API