### PR TITLE
Update node.js versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ language: node_js
 
 node_js:
   - stable
-  - 7
+  - 8
   - 6
-  - 5
   - 4
-  - 0
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ build: off
 environment:
   matrix:
     - nodejs_version: stable
-    - nodejs_version: 7
+    - nodejs_version: 8
     - nodejs_version: 6
-    - nodejs_version: 5
+    - nodejs_version: 4
 
 platform:
   - x64


### PR DESCRIPTION
Version `0`, `5` & `7` is dated.

Ref: https://github.com/nodejs/Release