### PR TITLE
fix MSVC error C3829 C2206 C2039 C2873 about longjmp

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -18,6 +18,8 @@
 
 #include <unordered_map>
 
+#include "document.h"
+
 #include "Config.hpp"
 #include "ConversionChain.hpp"
 #include "Converter.hpp"
@@ -26,7 +28,7 @@
 #include "MaxMatchSegmentation.hpp"
 #include "TextDict.hpp"
 
-#include "document.h"
+
 
 using namespace opencc;
 


### PR DESCRIPTION
build command
```bat
set path=C:\Python36;C:\Program Files\CMake\bin;%path%
cd /d C:\repo\OpenCC
mkdir ..\OpenCC_32
cmake -H. -Bbuild -G "Visual Studio 15 2017" -DCMAKE_INSTALL_PREFIX="../OpenCC_32" -DUNICODE=ON -D_UNICODE=ON -DBUILD_SHARED_LIBS=OFF 
cmake --build build --config Release --target install
```
error log
```


"C:\repo\OpenCC\build\install.vcxproj" (default target) (1) ->
"C:\repo\OpenCC\build\ALL_BUILD.vcxproj" (default target) (3) ->
"C:\repo\OpenCC\build\data\Dictionaries.vcxproj" (default target) (4) ->
"C:\repo\OpenCC\build\src\libopencc.vcxproj" (default target) (5) ->
(ClCompile target) ->
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\setjmp.h(165): error
 C3829: standard attribute 'noreturn' may only be applied to functions [C:\repo\OpenCC\build\src\li
bopencc.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\setjmp.h(165): error
 C2206: 'longjmp': typedef cannot be used for function definition [C:\repo\OpenCC\build\src\libopen
cc.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\csetjmp(10): error C
2039: 'longjmp': is not a member of '`global namespace'' [C:\repo\OpenCC\build\src\libopencc.vcxpro
j]
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\csetjmp(10): error C
2873: 'longjmp': symbol cannot be used in a using-declaration [C:\repo\OpenCC\build\src\libopencc.v
cxproj]

    0 Warning(s)
    4 Error(s)
```
  
  

按照这个pull request里面换一下头文件的顺序，就一切正常了。 三方的依赖库头文件，感觉应该放到项目头文件之前。据我观察，引起问题就是`Config.hpp`里面引入的`Common.hpp`引起的，它和rapidjson里面引入的好像哪里冲突了。