### PR TITLE
在文档上添加wasm版本的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Or [SwiftyOpenCC](https://github.com/XQS6LB3A/SwiftyOpenCC)
 
 See [android-opencc](https://github.com/qichuan/android-opencc)
 
+### Browser
+
+See [wasm-opencc](https://github.com/oyyd/wasm-opencc)
+
 ## Projects using Opencc 使用OpenCC的項目
 
 * [ibus-pinyin](https://github.com/ibus/ibus-pinyin)


### PR DESCRIPTION
Hi, Byvoid.

这两天用emscripten编译了项目。https://oyyd.github.io/wasm-opencc/ 这个wasm的版本可以直接在浏览器上运行，在node上运行可以避免addon编译，降低部署难度。

希望能加到文档里，让更多有类似需要的用户看到。