### PR TITLE
update rimeime link  [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [android-opencc](https://github.com/qichuan/android-opencc)
 
 * [ibus-pinyin](https://github.com/ibus/ibus-pinyin)
 * [fcitx](https://github.com/fcitx/fcitx)
-* [rimeime](http://code.google.com/p/rimeime/)
+* [rimeime](https://rime.im/)
 * [libgooglepinyin](http://code.google.com/p/libgooglepinyin/)
 * [ibus-libpinyin](https://github.com/libpinyin/ibus-libpinyin)
 * [BYVBlog](https://github.com/byvoid/byvblog)


### PR DESCRIPTION
Rime IME has moved to a new location on the internet. Its new home is at:
https://rime.im/