### PR TITLE
Fix build failures of tests.

### DIFF
--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Building the tests on g++ 8.2.0 on Alpine Linux results in error:

```
In file included from /root/OpenCC-ver.1.0.5/src/../deps/gtest-1.7.0/include/gtest/gtest.h:1929,
                 from /root/OpenCC-ver.1.0.5/src/TestUtils.hpp:22,
                 from /root/OpenCC-ver.1.0.5/src/PhraseExtractTest.cpp:20:
/root/OpenCC-ver.1.0.5/src/PhraseExtractTest.cpp: In member function 'virtual void opencc::PhraseExtractTest_CalculateCohesions_Test::TestBody()':
/root/OpenCC-ver.1.0.5/src/PhraseExtractTest.cpp:114:20: error: 'INFINITY' was not declared in this scope
   EXPECT_DOUBLE_EQ(INFINITY, phraseExtract.Cohesion("四"));
```

[`INFINITY` in PhraseExtractTest.cpp requires `<cmath>`](https://en.cppreference.com/w/cpp/numeric/math/INFINITY)