### PR TITLE
* include <cmath> to get INFINITY defined

### DIFF
--- a/src/PhraseExtractTest.cpp
+++ b/src/PhraseExtractTest.cpp
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <cmath>
+
 #include "PhraseExtract.hpp"
 #include "TestUtils.hpp"
 


### PR DESCRIPTION
With gcc 8.2.0 on aarch64-linux-gnu, my build fails due to undefined INFINITY.  Including `<cmath>` corrects this.

Be aware, `<cmath>` is only guaranteed to supply INFINITY in C++11 or later (at least by my understanding).  gcc `<cmath>` supplies it with or without C++11 at least as far back as 4.3, but I don't know about other compilers.