### PR TITLE
Add missing configurations (t2hkp, t2jp)

### DIFF
--- a/data/config/t2hkp.json
+++ b/data/config/t2hkp.json
@@ -1,0 +1,22 @@
+{
+  "name": "Traditional Chinese to Traditional Chinese (Hong Kong standard, with phrases)",
+  "segmentation": {
+    "type": "mmseg",
+    "dict": {
+      "type": "ocd",
+      "file": "TSPhrases.ocd"
+    }
+  },
+  "conversion_chain": [{
+    "dict": {
+      "type": "group",
+      "dicts": [{
+        "type": "txt",
+        "file": "HKVariantsPhrases.txt"
+      }, {
+        "type": "txt",
+        "file": "HKVariants.txt"
+      }]
+    }
+  }]
+}

--- a/data/config/t2jp.json
+++ b/data/config/t2jp.json
@@ -1,0 +1,16 @@
+{
+  "name": "Traditional Chinese Characters to Japanese Kanji",
+  "segmentation": {
+    "type": "mmseg",
+    "dict": {
+      "type": "text",
+      "file": "JPVariants.txt"
+    }
+  },
+  "conversion_chain": [{
+    "dict": {
+      "type": "text",
+      "file": "JPVariants.txt"
+    }
+  }]
+}


### PR DESCRIPTION
`t2hkp.json`: Used in [sgalal/rime-cantonese](https://github.com/sgalal/rime-cantonese), related issue: https://github.com/sgalal/rime-cantonese/issues/7

`t2jp.json`: Used in [sgalal/rime-kunyomi](https://github.com/sgalal/rime-kunyomi)

Both of them are very useful configurations.
