### PR TITLE
Also recognize AppleClang compiler ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ add_definitions(
   -DPACKAGE_NAME="${PACKAGE_NAME}"
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   add_definitions(
     -std=c++11
     -Wall


### PR DESCRIPTION
If I build OpenCC specifying `-DCMAKE_POLICY_DEFAULT_CMP0025=NEW` when invoking `cmake` (to enable [CMake policy 25](https://cmake.org/cmake/help/latest/policy/CMP0025.html) which makes a distinction between open-source Clang and Apple's Xcode Clang), then building with AppleClang fails because the build system does not recognize AppleClang and therefore does not add the required `-std=c++11` compiler flag:

```
$ cd /path/to/OpenCC/
$ mkdir -p build/rel
$ (cd build/rel; cmake -DCMAKE_POLICY_DEFAULT_CMP0025=NEW ../..)
-- The CXX compiler identification is AppleClang 9.1.0.9020039
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Use bundled marisa library.
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Found PythonInterp: /usr/bin/python (found version "2.7.16")
-- Configuring done
-- Generating done
-- Build files have been written to: /path/to/OpenCC/build/rel
$ make -C build/rel VERBOSE=ON
/opt/local/bin/cmake -S/path/to/OpenCC -B/path/to/OpenCC/build/rel --check-build-system CMakeFiles/Makefile.cmake 0
/opt/local/bin/cmake -E cmake_progress_start /path/to/OpenCC/build/rel/CMakeFiles /path/to/OpenCC/build/rel/CMakeFiles/progress.marks
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/Makefile2 all
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f deps/marisa-0.2.5/CMakeFiles/marisa.dir/build.make deps/marisa-0.2.5/CMakeFiles/marisa.dir/depend
cd /path/to/OpenCC/build/rel && /opt/local/bin/cmake -E cmake_depends "Unix Makefiles" /path/to/OpenCC /path/to/OpenCC/deps/marisa-0.2.5 /path/to/OpenCC/build/rel /path/to/OpenCC/build/rel/deps/marisa-0.2.5 /path/to/OpenCC/build/rel/deps/marisa-0.2.5/CMakeFiles/marisa.dir/DependInfo.cmake --color=
Dependee "/path/to/OpenCC/build/rel/deps/marisa-0.2.5/CMakeFiles/marisa.dir/DependInfo.cmake" is newer than depender "/path/to/OpenCC/build/rel/deps/marisa-0.2.5/CMakeFiles/marisa.dir/depend.internal".
Dependee "/path/to/OpenCC/build/rel/deps/marisa-0.2.5/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/path/to/OpenCC/build/rel/deps/marisa-0.2.5/CMakeFiles/marisa.dir/depend.internal".
Scanning dependencies of target marisa
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f deps/marisa-0.2.5/CMakeFiles/marisa.dir/build.make deps/marisa-0.2.5/CMakeFiles/marisa.dir/build
[  1%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/trie.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/trie.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/trie.cc
[  3%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/agent.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/agent.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/agent.cc
[  5%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/io/reader.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/reader.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/io/reader.cc
[  6%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/io/writer.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/writer.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/io/writer.cc
[  8%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/io/mapper.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/mapper.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc
[ 10%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/louds-trie.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/louds-trie.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/trie/louds-trie.cc
[ 12%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/tail.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/tail.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/trie/tail.cc
[ 13%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/grimoire/vector/bit-vector.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/grimoire/vector/bit-vector.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/grimoire/vector/bit-vector.cc
[ 15%] Building CXX object deps/marisa-0.2.5/CMakeFiles/marisa.dir/lib/marisa/keyset.cc.o
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -I/path/to/OpenCC/deps/marisa-0.2.5/include -I/path/to/OpenCC/deps/marisa-0.2.5/lib  -fPIC   -o CMakeFiles/marisa.dir/lib/marisa/keyset.cc.o -c /path/to/OpenCC/deps/marisa-0.2.5/lib/marisa/keyset.cc
[ 17%] Linking CXX static library libmarisa.a
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /opt/local/bin/cmake -P CMakeFiles/marisa.dir/cmake_clean_target.cmake
cd /path/to/OpenCC/build/rel/deps/marisa-0.2.5 && /opt/local/bin/cmake -E cmake_link_script CMakeFiles/marisa.dir/link.txt --verbose=ON
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar qc libmarisa.a  CMakeFiles/marisa.dir/lib/marisa/trie.cc.o CMakeFiles/marisa.dir/lib/marisa/agent.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/reader.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/writer.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/io/mapper.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/louds-trie.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/trie/tail.cc.o CMakeFiles/marisa.dir/lib/marisa/grimoire/vector/bit-vector.cc.o CMakeFiles/marisa.dir/lib/marisa/keyset.cc.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib libmarisa.a
[ 17%] Built target marisa
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f src/CMakeFiles/libopencc.dir/build.make src/CMakeFiles/libopencc.dir/depend
cd /path/to/OpenCC/build/rel && /opt/local/bin/cmake -E cmake_depends "Unix Makefiles" /path/to/OpenCC /path/to/OpenCC/src /path/to/OpenCC/build/rel /path/to/OpenCC/build/rel/src /path/to/OpenCC/build/rel/src/CMakeFiles/libopencc.dir/DependInfo.cmake --color=
Dependee "/path/to/OpenCC/build/rel/src/CMakeFiles/libopencc.dir/DependInfo.cmake" is newer than depender "/path/to/OpenCC/build/rel/src/CMakeFiles/libopencc.dir/depend.internal".
Dependee "/path/to/OpenCC/build/rel/src/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/path/to/OpenCC/build/rel/src/CMakeFiles/libopencc.dir/depend.internal".
Scanning dependencies of target libopencc
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f src/CMakeFiles/libopencc.dir/build.make src/CMakeFiles/libopencc.dir/build
[ 18%] Building CXX object src/CMakeFiles/libopencc.dir/Config.cpp.o
cd /path/to/OpenCC/build/rel/src && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DENABLE_DARTS -DLOCALEDIR=\"/usr/local/share//locale/\" -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/usr/local/share//opencc/\" -DVERSION=\"1.0.6\" -Dlibopencc_EXPORTS -I/path/to/OpenCC/src/../deps/marisa-0.2.5/include -I/path/to/OpenCC/src/../deps/rapidjson-1.1.0 -I/path/to/OpenCC/src/../deps/tclap-1.2.2 -I/path/to/OpenCC/src/../deps/darts-clone  -fPIC   -o CMakeFiles/libopencc.dir/Config.cpp.o -c /path/to/OpenCC/src/Config.cpp
In file included from /path/to/OpenCC/src/Config.cpp:23:
In file included from /path/to/OpenCC/src/Config.hpp:21:
In file included from /path/to/OpenCC/src/Common.hpp:43:
/path/to/OpenCC/src/Exception.hpp:42:35: error: expected ';' at end of declaration list
  virtual const char* what() const noexcept { return message.c_str(); }
                                  ^
                                  ;
/path/to/OpenCC/src/Exception.hpp:40:44: error: member initializer 'message' does not name a non-static data member or base class
  Exception(const std::string& _message) : message(_message) {}
                                           ^~~~~~~~~~~~~~~~~
/path/to/OpenCC/src/Exception.hpp:72:5: error: use of undeclared identifier 'message'; did you mean '_message'?
    message = buffer.str();
    ^~~~~~~
    _message
/path/to/OpenCC/src/Exception.hpp:68:44: note: '_message' declared here
  InvalidTextDictionary(const std::string& _message, size_t lineNum)
                                           ^
/path/to/OpenCC/src/Exception.hpp:72:13: error: no viable overloaded '='
    message = buffer.str();
    ~~~~~~~ ^ ~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:818:19: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >'), but method is not marked const
    basic_string& operator=(const basic_string& __str);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:824:19: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >'), but method is not marked const
    basic_string& operator=(__self_view __sv)  {return assign(__sv);}
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:832:45: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >'), but method is not marked const
    _LIBCPP_INLINE_VISIBILITY basic_string& operator=(const value_type* __s) {return assign(__s);}
                                            ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:833:19: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >'), but method is not marked const
    basic_string& operator=(value_type __c);
                  ^
In file included from /path/to/OpenCC/src/Config.cpp:26:
In file included from /path/to/OpenCC/src/DictGroup.hpp:22:
In file included from /path/to/OpenCC/src/Dict.hpp:22:
In file included from /path/to/OpenCC/src/DictEntry.hpp:22:
/path/to/OpenCC/src/Segments.hpp:32:17: error: no template named 'initializer_list' in namespace 'std'
  Segments(std::initializer_list<const char*> initList) {
           ~~~~~^
/path/to/OpenCC/src/Segments.hpp:38:17: error: no template named 'initializer_list' in namespace 'std'
  Segments(std::initializer_list<string> initList) {
           ~~~~~^
/path/to/OpenCC/src/Segments.hpp:110:32: error: a space is required between consecutive right angle brackets (use '> >')
  vector<std::pair<size_t, bool>> indexes;
                               ^~
                               > >
/path/to/OpenCC/src/Segments.hpp:33:29: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
    for (const string& item : initList) {
                            ^
/path/to/OpenCC/src/Segments.hpp:39:29: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
    for (const string& item : initList) {
                            ^
/path/to/OpenCC/src/Segments.hpp:80:11: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    const auto& index = indexes[cursor];
          ^
/path/to/OpenCC/src/Segments.hpp:98:30: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
    for (const char* segment : *this) {
                             ^
In file included from /path/to/OpenCC/src/Config.cpp:26:
In file included from /path/to/OpenCC/src/DictGroup.hpp:22:
In file included from /path/to/OpenCC/src/Dict.hpp:22:
In file included from /path/to/OpenCC/src/DictEntry.hpp:23:
/path/to/OpenCC/src/UTF8Util.hpp:218:16: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    for (const auto& str : strings) {
               ^
/path/to/OpenCC/src/UTF8Util.hpp:218:26: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
    for (const auto& str : strings) {
                         ^
/path/to/OpenCC/src/UTF8Util.hpp:233:16: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    for (const auto& str : strings) {
               ^
/path/to/OpenCC/src/UTF8Util.hpp:233:26: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
    for (const auto& str : strings) {
                         ^
In file included from /path/to/OpenCC/src/Config.cpp:26:
In file included from /path/to/OpenCC/src/DictGroup.hpp:22:
In file included from /path/to/OpenCC/src/Dict.hpp:22:
/path/to/OpenCC/src/DictEntry.hpp:81:31: error: expected '(' for function-style cast or type construction
    return vector<std::string>{Value()};
           ~~~~~~~~~~~~~~~~~~~^
/path/to/OpenCC/src/DictEntry.hpp:159:13: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
      const auto svEntry = static_cast<const SingleValueDictEntry*>(entry);
            ^
/path/to/OpenCC/src/DictEntry.hpp:162:13: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
      const auto mvEntry = static_cast<const MultiValueDictEntry*>(entry);
            ^
/path/to/OpenCC/src/Config.cpp:35:53: error: a space is required between consecutive right angle brackets (use '> >')
typedef rapidjson::GenericValue<rapidjson::UTF8<char>> JSONValue;
                                                    ^~
                                                    > >
/path/to/OpenCC/src/Config.cpp:45:76: error: a space is required between consecutive right angle brackets (use '> >')
      string, std::unordered_map<string, std::unordered_map<string, DictPtr>>>
                                                                           ^~
                                                                           > >
10 warnings and 10 errors generated.
make[2]: *** [src/CMakeFiles/libopencc.dir/Config.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/libopencc.dir/all] Error 2
make: *** [all] Error 2
```

This PR fixes the problem by making the build system recognize AppleClang as well.