### PR TITLE
[Bugfix] setup.py syntax errors

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,9 +8,6 @@ import warnings
 
 import setuptools
 import setuptools.command.build_py
-import setuptools.command.develop
-import setuptools.command.install
-import setuptools.command.test
 import wheel.bdist_wheel
 
 from opencc import _libopenccfile
@@ -203,9 +200,6 @@ setuptools.setup(
         'build_py': BuildPyCommand,
         'bdist_wheel': BDistWheelCommand
     },
-
-    tests_require=['pytest'],
-    test_suite='tests',
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,7 @@ def build_libopencc():
         )
         errno = subprocess.call(cmd, shell=True)
         assert errno == 0, 'Build failed'
-    
+
     def build_on_posix():
         assert subprocess.call('command -v make', shell=True) == 0, \
             'Build requires `make`'
@@ -222,5 +222,5 @@ setuptools.setup(
         'Topic :: Software Development :: Localization',
     ],
     license='Apache License 2.0',
-    keywords='opencc convert chinese'
+    keywords=['opencc', 'convert', 'chinese']
 )


### PR DESCRIPTION
`keywords` field in `setup` function changed from `string` to `List<string>`

Fix https://github.com/BYVoid/OpenCC/issues/405
Reference https://docs.python.org/3/distutils/setupscript.html#additional-meta-data