### PR TITLE
SimpleConverter.hpp: fix missing include of <string>

### DIFF
--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <string>
 #include "Export.hpp"
 
 #ifndef __OPENCC_SIMPLECONVERTER_HPP_


### PR DESCRIPTION
When I compile `ibus-libzhuyin` source code, after update `opencc` version with `gcc` v10.1.0,
I enconter this problem:

```
/usr/include/opencc/SimpleConverter.hpp:42:30: error: ‘string’ in namespace ‘std’ does not name a type
   42 |   SimpleConverter(const std::string& configFileName);
      |                              ^~~~~~
/usr/include/opencc/SimpleConverter.hpp:1:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
  +++ |+#include <string>
    1 | /*
```

After adding `#include <string>` on the first line of `SimpleConverter.hpp` (The header file `ibus-libzhuyin` use), it seems the problem solved.

I'm not sure if there's same kind of problem exist in this source repository, just report this bug fyi.

Thanks!