### PR TITLE
fix access violation when configDirectory is empty

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -255,10 +255,14 @@ ConverterPtr Config::NewFromString(const std::string& json,
   }
 
   ConfigInternal* impl = (ConfigInternal*)internal;
-  if (configDirectory.back() == '/' || configDirectory.back() == '\\')
-    impl->configDirectory = configDirectory;
-  else
-    impl->configDirectory = configDirectory + '/';
+  if (!configDirectory.empty()) {
+    if (configDirectory.back() == '/' || configDirectory.back() == '\\')
+      impl->configDirectory = configDirectory;
+    else
+      impl->configDirectory = configDirectory + '/';
+  } else {
+    impl->configDirectory.clear();
+  }
 
   // Required: segmentation
   SegmentationPtr segmentation =


### PR DESCRIPTION
`configDirectory` may be empty, and accessing `back()` will make it crash