### PR TITLE
fix #523: {MarisaDict,DartsDict}::Match() does not check for exact match

### DIFF
--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -54,10 +54,13 @@ size_t DartsDict::KeyMaxLength() const { return maxLength; }
 
 Optional<const DictEntry*> DartsDict::Match(const char* word,
                                             size_t len) const {
+  if (len > maxLength) {
+    return Optional<const DictEntry*>::Null();
+  }
   Darts::DoubleArray& dict = *internal->doubleArray;
   Darts::DoubleArray::result_pair_type result;
 
-  dict.exactMatchSearch(word, result, (std::min)(maxLength, len));
+  dict.exactMatchSearch(word, result, len);
   if (result.value != -1) {
     return Optional<const DictEntry*>(
         lexicon->At(static_cast<size_t>(result.value)));

--- a/src/DartsDictTest.cpp
+++ b/src/DartsDictTest.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "DartsDict.hpp"
+#include "TestUtilsUTF8.hpp"
 #include "TextDictTestBase.hpp"
 
 namespace opencc {
@@ -54,6 +55,17 @@ TEST_F(DartsDictTest, Deserialization) {
 
   const TextDictPtr deserializedTextDict(new TextDict(lex2));
   TestDict(deserializedTextDict);
+}
+
+TEST_F(DartsDictTest, ExactMatch) {
+  auto there = dartsDict->Match("積羽沉舟", 12);
+  EXPECT_FALSE(there.IsNull());
+  auto dictEntry = there.Get();
+  EXPECT_EQ(1, dictEntry->NumValues());
+  EXPECT_EQ(utf8("羣輕折軸"), dictEntry->GetDefault());
+
+  auto nowhere = dartsDict->Match("積羽沉舟衆口鑠金", 24);
+  EXPECT_TRUE(nowhere.IsNull());
 }
 
 } // namespace opencc

--- a/src/MarisaDict.cpp
+++ b/src/MarisaDict.cpp
@@ -47,9 +47,12 @@ size_t MarisaDict::KeyMaxLength() const { return maxLength; }
 
 Optional<const DictEntry*> MarisaDict::Match(const char* word,
                                              size_t len) const {
+  if (len > maxLength) {
+    return Optional<const DictEntry*>::Null();
+  }
   const marisa::Trie& trie = *internal->marisa;
   marisa::Agent agent;
-  agent.set_query(word, (std::min)(maxLength, len));
+  agent.set_query(word, len);
   if (trie.lookup(agent)) {
     return Optional<const DictEntry*>(lexicon->At(agent.key().id()));
   } else {

--- a/src/MarisaDictTest.cpp
+++ b/src/MarisaDictTest.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "MarisaDict.hpp"
+#include "TestUtilsUTF8.hpp"
 #include "TextDictTestBase.hpp"
 
 namespace opencc {
@@ -50,6 +51,17 @@ TEST_F(MarisaDictTest, Deserialization) {
     EXPECT_EQ(lex1->At(i)->Key(), lex2->At(i)->Key());
     EXPECT_EQ(lex1->At(i)->NumValues(), lex2->At(i)->NumValues());
   }
+}
+
+TEST_F(MarisaDictTest, ExactMatch) {
+  auto there = dict->Match("積羽沉舟", 12);
+  EXPECT_FALSE(there.IsNull());
+  auto dictEntry = there.Get();
+  EXPECT_EQ(1, dictEntry->NumValues());
+  EXPECT_EQ(utf8("羣輕折軸"), dictEntry->GetDefault());
+
+  auto nowhere = dict->Match("積羽沉舟衆口鑠金", 24);
+  EXPECT_TRUE(nowhere.IsNull());
 }
 
 } // namespace opencc

--- a/src/TextDictTest.cpp
+++ b/src/TextDictTest.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "TestUtilsUTF8.hpp"
 #include "TextDictTestBase.hpp"
 
 namespace opencc {
@@ -37,6 +38,17 @@ TEST_F(TextDictTest, Deserialization) {
   const TextDictPtr& deserialized =
       SerializableDict::NewFromFile<TextDict>(fileName);
   TestDict(deserialized);
+}
+
+TEST_F(TextDictTest, ExactMatch) {
+  auto there = textDict->Match("積羽沉舟", 12);
+  EXPECT_FALSE(there.IsNull());
+  auto dictEntry = there.Get();
+  EXPECT_EQ(1, dictEntry->NumValues());
+  EXPECT_EQ(utf8("羣輕折軸"), dictEntry->GetDefault());
+
+  auto nowhere = textDict->Match("積羽沉舟衆口鑠金", 24);
+  EXPECT_TRUE(nowhere.IsNull());
 }
 
 } // namespace opencc


### PR DESCRIPTION
if query is longer than the longest word in dictionary.