### PR TITLE
Add link to opencc-extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Example results (from Github CI):
 * [ibus-libpinyin](https://github.com/libpinyin/ibus-libpinyin)
 * [alfred-chinese-converter](https://github.com/amowu/alfred-chinese-converter)
 * [GoldenDict](https://github.com/goldendict/goldendict)
+* [opencc-extension](https://github.com/tnychn/opencc-extension)
 
 ## License 許可協議
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Document 文檔: https://byvoid.github.io/OpenCC/
 * PHP: [opencc4php](https://github.com/nauxliu/opencc4php)
 * Pure JavaScript: [opencc-js](https://github.com/nk2028/opencc-js)
 * WebAssembly: [wasm-opencc](https://github.com/oyyd/wasm-opencc)
+* Browser Extension: [opencc-extension](https://github.com/tnychn/opencc-extension)
 
 ### Configurations 配置文件
 
@@ -208,7 +209,6 @@ Example results (from Github CI):
 * [ibus-libpinyin](https://github.com/libpinyin/ibus-libpinyin)
 * [alfred-chinese-converter](https://github.com/amowu/alfred-chinese-converter)
 * [GoldenDict](https://github.com/goldendict/goldendict)
-* [opencc-extension](https://github.com/tnychn/opencc-extension)
 
 ## License 許可協議
 


### PR DESCRIPTION
#562: 添加 [opencc-extension](https://github.com/tnychn/opencc-extension) 到 README 中的 `Projects using OpenCC 使用 OpenCC 的項目` 部分