### PR TITLE
For opencc::ConvertDictionary() parameters, pass references instead of values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ All these libraries are statically linked by default.
 * [Cychih](https://github.com/pi314)
 * [kyleskimo](https://github.com/kyleskimo)
 * [Ryuan Choi](https://github.com/bunhere)
+* [Prcuvu](https://github.com/Prcuvu)
 * [Tony Able](https://github.com/TonyAble)
 * [Xiao Liang](https://github.com/yxliang01)
 

--- a/src/DictConverter.cpp
+++ b/src/DictConverter.cpp
@@ -58,10 +58,10 @@ SerializableDictPtr ConvertDict(const std::string& format, const DictPtr dict) {
 }
 
 namespace opencc {
-void ConvertDictionary(const std::string inputFileName,
-                       const std::string outputFileName,
-                       const std::string formatFrom,
-                       const std::string formatTo) {
+void ConvertDictionary(const std::string& inputFileName,
+                       const std::string& outputFileName,
+                       const std::string& formatFrom,
+                       const std::string& formatTo) {
   DictPtr dictFrom = LoadDictionary(formatFrom, inputFileName);
   SerializableDictPtr dictTo = ConvertDict(formatTo, dictFrom);
   dictTo->SerializeToFile(outputFileName);

--- a/src/DictConverter.hpp
+++ b/src/DictConverter.hpp
@@ -25,8 +25,8 @@ namespace opencc {
  * Converts a dictionary from a format to another.
  * @ingroup opencc_cpp_api
  */
-OPENCC_EXPORT void ConvertDictionary(const std::string inputFileName,
-                                     const std::string outputFileName,
-                                     const std::string formatFrom,
-                                     const std::string formatTo);
+OPENCC_EXPORT void ConvertDictionary(const std::string& inputFileName,
+                                     const std::string& outputFileName,
+                                     const std::string& formatFrom,
+                                     const std::string& formatTo);
 } // namespace opencc


### PR DESCRIPTION
This fixes a specific crash on Windows.

When `BUILD_SHARED_LIBS` is `ON` and CRT is statically linked (`/MT`), both libopencc (built as `opencc.dll`) and opencc_dict (built as `opencc_dict.exe`) contain separate CRT contexts.

https://github.com/BYVoid/OpenCC/blob/47d750462b4b057e7519b04ccfd4282409062f7c/src/tools/DictConverter.cpp#L48-L49

The call above allocates a new block for `inputArg._value`'s string content in `opencc_dict.exe` context.

https://github.com/BYVoid/OpenCC/blob/47d750462b4b057e7519b04ccfd4282409062f7c/src/DictConverter.cpp#L61-L68

At the end of `opencc::ConvertDictionary()` function, `inputFileName` (copied from `inputArg._value`) gets destroyed, its string content block (allocated by `opencc_dict.exe`) is freed in `opencc.dll` context. There will be an erroneous cross-linkage between the two CRT memory block header linked lists and `opencc_dict.exe` will eventually crash.

The `opencc::ConvertDictionary()` parameters are now passed as references to avoid cross-context memory allocation and release.