### PR TITLE
Remove builds for Python 2.7 and node 10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,6 @@ environment:
     - nodejs_version: 16
     - nodejs_version: 14
     - nodejs_version: 12
-    - nodejs_version: 10
 
     # Build plain C++
     - nodejs_version: none

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -25,7 +25,7 @@ bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
 export PATH=$HOME/miniconda3/bin:$PATH
 eval "$(conda shell.bash hook)"
 
-for VERSION in 2.7 3.5 3.6 3.7 3.8 3.9; do
+for VERSION in 3.5 3.6 3.7 3.8 3.9; do
     # Create and activate environment
     conda create -y -n py$VERSION python=$VERSION
     conda activate py$VERSION

--- a/release-pypi-macos.sh
+++ b/release-pypi-macos.sh
@@ -12,7 +12,7 @@ bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
 export PATH=$HOME/miniconda3/bin:$PATH
 eval "$(conda shell.bash hook)"
 
-for VERSION in 2.7 3.5 3.6 3.7 3.8 3.9; do
+for VERSION in 3.5 3.6 3.7 3.8 3.9; do
     # Create and activate environment
     conda create -y -n py$VERSION python=$VERSION
     conda activate py$VERSION

--- a/release-pypi-windows.cmd
+++ b/release-pypi-windows.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-SET VERSIONS=2.7 3.5 3.6 3.7 3.8 3.9
+SET VERSIONS=3.5 3.6 3.7 3.8 3.9
 SET SOURCEDIR=%cd%
 
 REM Build packages


### PR DESCRIPTION
- Python 2.7 is EOL and will soon be removed from PyPI
- Node 10 is EOL and has already been removed from npm, meaning appveyor
no longer allows ANY new commits to be merged.