### PR TITLE
Provide the duplicate key when Lexicon.IsUnique check fails

### DIFF
--- a/src/Lexicon.cpp
+++ b/src/Lexicon.cpp
@@ -30,9 +30,12 @@ bool Lexicon::IsSorted() {
                         DictEntry::UPtrLessThan);
 }
 
-bool Lexicon::IsUnique() {
+bool Lexicon::IsUnique(std::string* dupkey) {
   for (size_t i = 1; i < entries.size(); ++i) {
     if (entries[i - 1]->Key() == entries[i]->Key()) {
+      if (dupkey) {
+        *dupkey = entries[i]->Key();
+      }
       return false;
     }
   }

--- a/src/Lexicon.hpp
+++ b/src/Lexicon.hpp
@@ -47,7 +47,8 @@ public:
   bool IsSorted();
 
   // Returns true if every key unique (after sorted).
-  bool IsUnique();
+  // When dupkey is set, it is set to the duplicate key.
+  bool IsUnique(std::string* dupkey = nullptr);
 
   const DictEntry* At(size_t index) const { return entries.at(index).get(); }
 

--- a/src/TextDict.cpp
+++ b/src/TextDict.cpp
@@ -94,8 +94,10 @@ TextDictPtr TextDict::NewFromSortedFile(FILE* fp) {
 TextDictPtr TextDict::NewFromFile(FILE* fp) {
   const LexiconPtr& lexicon = ParseLexiconFromFile(fp);
   lexicon->Sort();
-  if (!lexicon->IsUnique()) {
-    throw InvalidFormat("The text dictionary contains duplicated keys.");
+  std::string dupkey;
+  if (!lexicon->IsUnique(&dupkey)) {
+    throw InvalidFormat(
+        "The text dictionary contains duplicated keys: " + dupkey + ".");
   }
   return TextDictPtr(new TextDict(lexicon));
 }


### PR DESCRIPTION
Since the prohibition of duplicate keys in dicts is started from commit 3c33116694dd1bb938c0fe9ced11f23cc0beb719, the PR additionally adds the found duplicate key to output, which can help the migration of old config files.

The PR adds an optional arg `dupkey` to `Lexicon.IsUnique` to return the duplicate key, avoiding breaking existing code with best effort.