### PR TITLE
Update version for 1.1.4 release + clean obsoletes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -19,7 +19,7 @@ jobs:
         docker run --rm -v "${PWD}:/opt/OpenCC" \
           -e TWINE_USERNAME=__token__ \
           -e TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }} \
-          ubuntu:16.04 /bin/bash /opt/OpenCC/release-pypi-linux.sh
+          ubuntu:18.04 /bin/bash /opt/OpenCC/release-pypi-linux.sh
 
     - name: Build package and upload (macOS)
       if: runner.os == 'macOS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
   - 16
   - 14
   - 12
-  - 10
 
 os:
   - linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set (PACKAGE_URL https://github.com/BYVoid/Opencc)
 set (PACKAGE_BUGREPORT https://github.com/BYVoid/Opencc/issues)
 set (OPENCC_VERSION_MAJOR 1)
 set (OPENCC_VERSION_MINOR 1)
-set (OPENCC_VERSION_REVISION 3)
+set (OPENCC_VERSION_REVISION 4)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   set (version_suffix .Debug)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Change History of OpenCC
 
+## Version 1.1.4
+
+2022年6月4日
+
+* 支持Python 3.10（[#637](https://github.com/BYVoid/OpenCC/issues/637）。
+* Remove builds for Python 2.7, 3.5, 3.6 and Node 10. ([#690](https://github.com/BYVoid/OpenCC/issues/690), [#691](https://github.com/BYVoid/OpenCC/issues/691))
+* 若干其他小修復。
+
 ## Version 1.1.3
 
 2021年9月3日

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 2022年6月4日
 
 * 支持Python 3.10（[#637](https://github.com/BYVoid/OpenCC/issues/637）。
-* Remove builds for Python 2.7, 3.5, 3.6 and Node 10. ([#690](https://github.com/BYVoid/OpenCC/issues/690), [#691](https://github.com/BYVoid/OpenCC/issues/691))
+* 移除针对Python 2.7、3.5、3.6和Node 10的构建（[#690](https://github.com/BYVoid/OpenCC/issues/690), [#691](https://github.com/BYVoid/OpenCC/issues/691)）。
 * 若干其他小修復。
 
 ## Version 1.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencc",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Conversion between Traditional and Simplified Chinese",
   "author": "Carbo Kuo <byvoid@byvoid.com>",
   "license": "Apache-2.0",

--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -25,7 +25,7 @@ bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
 export PATH=$HOME/miniconda3/bin:$PATH
 eval "$(conda shell.bash hook)"
 
-for VERSION in 3.5 3.6 3.7 3.8 3.9 3.10; do
+for VERSION in 3.7 3.8 3.9 3.10; do
     # Create and activate environment
     conda create -y -n py$VERSION python=$VERSION
     conda activate py$VERSION

--- a/release-pypi-macos.sh
+++ b/release-pypi-macos.sh
@@ -12,7 +12,7 @@ bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
 export PATH=$HOME/miniconda3/bin:$PATH
 eval "$(conda shell.bash hook)"
 
-for VERSION in 3.5 3.6 3.7 3.8 3.9 3.10; do
+for VERSION in 3.7 3.8 3.9 3.10; do
     # Create and activate environment
     conda create -y -n py$VERSION python=$VERSION
     conda activate py$VERSION

--- a/release-pypi-windows.cmd
+++ b/release-pypi-windows.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-SET VERSIONS=3.5 3.6 3.7 3.8 3.9 3.10
+SET VERSIONS=3.7 3.8 3.9 3.10
 SET SOURCEDIR=%cd%
 
 REM Build packages

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,6 @@ setuptools.setup(
         'Natural Language :: Chinese (Simplified)',
         'Natural Language :: Chinese (Traditional)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
- Removal of Python 3.5, 3.6 and NodeJS 10
- Use ubuntu 18.04 instead of 16.04 for building and pushing to pypi

Fixes: https://github.com/BYVoid/OpenCC/issues/690
Fixes: https://github.com/BYVoid/OpenCC/issues/691