### PR TITLE
Add support for apple silicon build tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,8 +151,13 @@ class BDistWheelCommand(wheel.bdist_wheel.bdist_wheel, object):
 
         if sys.platform == 'darwin':
             _, _, _, _, machine = os.uname()
-            return 'macosx-10.9-{}'.format(machine)
-
+            if machine == 'x86_64':
+                return 'macosx-10.9-{}'.format(machine)
+            if machine == 'arm64':
+                return 'macosx-11.0-{}'.format(machine)
+            else:
+                raise NotImplementedError
+                
         if os.name == 'posix':
             _, _, _, _, machine = os.uname()
             return 'manylinux1-{}'.format(machine)


### PR DESCRIPTION
 在使用 Apple M1 build wheel 時會因為錯誤的 `platform_tag` 導致建立出來的 `.whl`  無法安裝

這個 PR  讓 build 出來的 `.whl` 能夠被正確安裝。應該可以幫助到需要自行編譯套件的使用者(#565 )

> 測試目前自行編譯的版本可以運行在m1底下了