### PR TITLE
Add support for python linux-arm64 build via qemu

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -20,6 +20,13 @@ jobs:
           -e TWINE_USERNAME=__token__ \
           -e TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }} \
           ubuntu:18.04 /bin/bash /opt/OpenCC/release-pypi-linux.sh
+          
+    - name: Build package and upload from docker (Linux ARM)
+      if: runner.os == 'Linux'
+      run: bash release-pypi-linux-arm.sh
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
     - name: Build package and upload (macOS)
       if: runner.os == 'macOS'

--- a/build-wheel-linux-arm.sh
+++ b/build-wheel-linux-arm.sh
@@ -1,0 +1,9 @@
+apt update && apt install -y build-essential cmake
+
+# Build and package
+pip install -y --no-cache-dir setuptools wheel cmake
+python setup.py build_ext bdist_wheel \
+    --plat-name manylinux_2_17_aarch64
+
+# Cleanup
+rm -rf build python/opencc/clib OpenCC.egg-info

--- a/release-pypi-linux-arm.sh
+++ b/release-pypi-linux-arm.sh
@@ -1,0 +1,10 @@
+sudo apt-get install qemu binfmt-support qemu-user-static # Install the qemu packages
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+for VERSION in 3.7.14 3.8.14 3.9.14 3.10.7; do
+    docker run --rm -t --platform linux/arm64/v8 -v $PWD:/opencc python:$VERSION sh -c "cd opencc && sh build-wheel-linux-arm.sh"  
+done
+
+# Upload to PyPI
+python -m pip install twine
+python -m twine upload dist/*


### PR DESCRIPTION
這個 PR 通過 QEMU 在 gihub runner 的 x86_64 機器上建構 linux-arm64 python 套件 (#565 )
由於我並沒有專案權限，所以無法完整的測試github workflow，但是我想應該是可以work的 😉

因為是在x86_64模擬arm環境並且建構套件，所以執行的非常緩慢，整個流程大約會需要40-50分鐘

新增的`release-pypi-linux-arm.sh`在docker(arm64)環境中執行`build-wheel-linux-arm.sh`，建構輸出會在原本的工作目錄底下(dist)