### PR TITLE
修复此项目作为子其他cmake项目的子项目时，导致install失败的问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ configure_file(
 
 install(
   FILES
-    ${CMAKE_BINARY_DIR}/opencc.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/opencc.pc
   DESTINATION
     ${DIR_LIBRARY}/pkgconfig
 )


### PR DESCRIPTION
cmake的官方文档：
https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html
https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_BINARY_DIR.html

这两个变量在顶级项目中是相同的，在子项目中应该用CMAKE_CURRENT_BINARY_DIR。