### PR TITLE
Fix macos not building with cpp 14 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ include(CPack)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_MACOSX_RPATH 1)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 ######## Directory


### PR DESCRIPTION
Fixes https://github.com/BYVoid/OpenCC/issues/743

From my testing this forces both the macos-11 and macos-12 github build images to use the proper compatibility, and builds all wheels for mac successfully.