### PR TITLE
Release 1.1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set (PACKAGE_URL https://github.com/BYVoid/Opencc)
 set (PACKAGE_BUGREPORT https://github.com/BYVoid/Opencc/issues)
 set (OPENCC_VERSION_MAJOR 1)
 set (OPENCC_VERSION_MINOR 1)
-set (OPENCC_VERSION_REVISION 5)
+set (OPENCC_VERSION_REVISION 6)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   set (version_suffix .Debug)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Change History of OpenCC
 
+## Version 1.1.6
+
+2022年12月08日
+
+* 修复python3.11 macos构建 ([#744](https://github.com/BYVoid/OpenCC/pull/744))。
+
 ## Version 1.1.5
 
 2022年12月03日

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencc",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opencc",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencc",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Conversion between Traditional and Simplified Chinese",
   "author": "Carbo Kuo <byvoid@byvoid.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
A new release is required so pypi won't break the release script for builds that didn't upload correctly