### PR TITLE
Add wasm support

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,25 @@
+name: WASM CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install emsdk
+      run: |
+        git clone https://github.com/emscripten-core/emsdk.git
+        cd emsdk
+        ./emsdk install latest
+        ./emsdk activate latest
+    - name: Build wasm
+      run: |
+        . emsdk/emsdk_env.sh
+        bash wasm/build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     -std=c++14
     -Wall
   )
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+  if (NOT EMSCRIPTEN)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+  endif ()
   if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-O0 -g3)
   endif ()
@@ -196,9 +198,11 @@ endif()
 ######## Subdirectories
 
 add_subdirectory(src)
-add_subdirectory(doc)
-add_subdirectory(data)
-add_subdirectory(test)
+if (NOT EMSCRIPTEN)
+  add_subdirectory(doc)
+  add_subdirectory(data)
+  add_subdirectory(test)
+endif ()
 
 ######## Testing
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![C/C++ CI](https://github.com/BYVoid/OpenCC/actions/workflows/cmake.yml/badge.svg)](https://github.com/BYVoid/OpenCC/actions/workflows/cmake.yml)
 [![Node.js CI](https://github.com/BYVoid/OpenCC/actions/workflows/nodejs.yml/badge.svg)](https://github.com/BYVoid/OpenCC/actions/workflows/nodejs.yml)
 [![Python CI](https://github.com/BYVoid/OpenCC/actions/workflows/python.yml/badge.svg)](https://github.com/BYVoid/OpenCC/actions/workflows/python.yml)
+[![WASM CI](https://github.com/BYVoid/OpenCC/actions/workflows/wasm.yml/badge.svg)](https://github.com/BYVoid/OpenCC/actions/workflows/wasm.yml)
 
 ## Introduction 介紹
 
@@ -99,6 +100,10 @@ int main() {
 
 ```
 
+### WASM
+
+See [wasm.yml](https://github.com/BYVoid/OpenCC/blob/master/.github/workflows/wasm.yml).
+
 Document 文檔: https://byvoid.github.io/OpenCC/
 
 ### Command Line
@@ -115,7 +120,7 @@ Document 文檔: https://byvoid.github.io/OpenCC/
 * Android: [android-opencc](https://github.com/qichuan/android-opencc)
 * PHP: [opencc4php](https://github.com/nauxliu/opencc4php)
 * Pure JavaScript: [opencc-js](https://github.com/nk2028/opencc-js)
-* WebAssembly: [wasm-opencc](https://github.com/oyyd/wasm-opencc)
+* asm.js: [wasm-opencc](https://github.com/oyyd/wasm-opencc)
 * Browser Extension: [opencc-extension](https://github.com/tnychn/opencc-extension)
 * Go (Pure): [OpenCC for Go](https://github.com/longbridgeapp/opencc)
 
@@ -279,5 +284,6 @@ All these libraries are statically linked by default.
 * [Prcuvu](https://github.com/Prcuvu)
 * [Tony Able](https://github.com/TonyAble)
 * [Xiao Liang](https://github.com/yxliang01)
+* [Qijia Liu](https://github.com/eagleoflqj)
 
 Please feel free to update this list if you have contributed OpenCC.

--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,0 +1,3 @@
+demo.data
+demo.js
+demo.wasm

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,0 +1,35 @@
+root=$PWD
+
+# build data and share with wasm
+cmake . -B build/native \
+  -DCMAKE_INSTALL_PREFIX:PATH=$root/build/sysroot/usr
+make -C build/native/data install
+
+# build wasm libopencc.a and libmarisa.a
+emcmake cmake . -B build/wasm \
+  -DBUILD_SHARED_LIBS:BOOL=OFF \
+  -DCMAKE_BUILD_TYPE:STRING="Release" \
+  -DCMAKE_INSTALL_PREFIX:PATH=/usr
+make DESTDIR=$root/build/sysroot -C build/wasm install
+cp build/wasm/deps/marisa-0.2.6/libmarisa.a build/sysroot/usr/lib
+
+# build demo.js
+em++ -std=c++14 \
+  -I build/sysroot/usr/include/opencc \
+  --preload-file build/sysroot/usr/share/opencc@/usr/share/opencc \
+  -o wasm/demo.js \
+  wasm/demo.cpp \
+  -L build/sysroot/usr/lib \
+  -l opencc -l marisa
+
+# test demo.js
+expected="網路"
+actual=$(cd wasm; node demo.js)
+if [[ $actual != $expected ]]; then
+  echo Test failed.
+  echo expected: $expected
+  echo actual: $actual
+  exit 1
+else
+  echo Test passed.
+fi

--- a/wasm/demo.cpp
+++ b/wasm/demo.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include "opencc.h"
+
+int main() {
+  const opencc::SimpleConverter converter("s2twp.json");
+  std::cout << converter.Convert("网络") << std::endl;  // 網路
+  return 0;
+}


### PR DESCRIPTION
做了个网站，纯前端wasm转换繁简https://my-opencc.vercel.app/ 支持全部14个json配置
代码：https://github.com/LibreService/my_opencc
想把wasm构建部分合并到上游

跟https://github.com/oyyd/wasm-opencc 的区别：
* 使用wasm而非asm.js
* 仅改动最外层`CMakeLists.txt`~和`Makefile`~；wasm-opencc的改动比较大，基本没法合并
* 依赖最新的emscripten工具链