### PR TITLE
Fix broken DIR_LIBRARY usages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ write_basic_package_version_file(
 configure_package_config_file(
   OpenCCConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfig.cmake
-  INSTALL_DESTINATION lib/cmake/opencc
+  INSTALL_DESTINATION ${DIR_LIBRARY}/cmake/opencc
 )
 
 install(
@@ -139,7 +139,7 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfigVersion.cmake
   DESTINATION
-    lib/cmake/opencc
+    ${DIR_LIBRARY}/cmake/opencc
 )
 
 ######## Compiler flags

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,15 +150,15 @@ endif()
 
 install(
   TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION ${DIR_LIBRARY}
+  ARCHIVE DESTINATION ${DIR_LIBRARY}
   RUNTIME DESTINATION bin
 )
 
 install(
   EXPORT ${targets_export_name}
   FILE ${targets_export_name}.cmake
-  DESTINATION lib/cmake/opencc
+  DESTINATION ${DIR_LIBRARY}/cmake/opencc
   NAMESPACE OpenCC::
 )
 


### PR DESCRIPTION
In the commit a13ed0a6 (PR #763 ), some DIR_LIBRARY variable usages are modified to make install destination relative to be more portable, but this will break the original designed purpose of DIR_LIBRARY, so this commit will revert the changes.