### PR TITLE
Set missing OPENCC_INCLUDE_DIR for CMake config modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ configure_package_config_file(
   OpenCCConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfig.cmake
   INSTALL_DESTINATION ${DIR_LIBRARY}/cmake/opencc
+  PATH_VARS DIR_INCLUDE
 )
 
 install(

--- a/OpenCCConfig.cmake.in
+++ b/OpenCCConfig.cmake.in
@@ -1,4 +1,7 @@
 @PACKAGE_INIT@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+
+set_and_check(OPENCC_INCLUDE_DIR @PACKAGE_DIR_INCLUDE@opencc)
+
 check_required_components(OpenCC)


### PR DESCRIPTION
Ref: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html