### PR TITLE
Add nodejs 20.x and remove 16.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,8 @@ environment:
   matrix:
     # Build Node.js
     - nodejs_version: stable
+    - nodejs_version: 20
     - nodejs_version: 18
-    - nodejs_version: 16
 
     # Build plain C++
     - nodejs_version: none

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 
 node_js:
   - stable
+  - 20
   - 18
-  - 16
 
 os:
   - linux


### PR DESCRIPTION
16.x is End-of-Life, see https://nodejs.org/en/blog/announcements/nodejs16-eol