### PR TITLE
build: Update to `manylinux2014` in build scripts and setup.py (#874)

### DIFF
--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -35,7 +35,7 @@ for VERSION in 3.8 3.9 3.10 3.11 3.12; do
     # Build and package
     pip install --no-cache-dir setuptools wheel cmake
     python setup.py build_ext bdist_wheel \
-        --plat-name manylinux1_x86_64
+        --plat-name manylinux2014_x86_64
 
     # Cleanup
     conda deactivate

--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -35,7 +35,7 @@ for VERSION in 3.8 3.9 3.10 3.11 3.12; do
     # Build and package
     pip install --no-cache-dir setuptools wheel cmake
     python setup.py build_ext bdist_wheel \
-        --plat-name manylinux2014_x86_64
+        --plat-name "manylinux2014_$(uname --machine)"
 
     # Cleanup
     conda deactivate

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ class BDistWheelCommand(wheel.bdist_wheel.bdist_wheel, object):
                 
         if os.name == 'posix':
             _, _, _, _, machine = os.uname()
-            return 'manylinux1-{}'.format(machine)
+            return 'manylinux2014-{}'.format(machine)
 
         warnings.warn(
             'Windows macos and linux are all not detected, '


### PR DESCRIPTION
Update the platform name from manylinux1 to manylinux2014 in the Linux build scripts and setup.py to comply with the updated Python wheel specification. This change ensures that the built packages are compatible with the newer manylinux2014 standard, which provides better support for newer Linux distributions and wheel formats.