### PR TITLE
Fix missing cstdint for GCC 15

### DIFF
--- a/src/SerializedValues.cpp
+++ b/src/SerializedValues.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 
 #include "Lexicon.hpp"


### PR DESCRIPTION
fix: https://github.com/BYVoid/OpenCC/issues/893
