### PR TITLE
fix errors when build is required during "npm install opencc"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,7 +19,6 @@ CMakeLists.txt
 /src/*TestBase.cpp
 /doc
 /data/scheme
-/data/scripts
 /deps/google-benchmark
 /deps/googletest*
 /deps/pybind*


### PR DESCRIPTION
npm install opencc
...
npm ERR!   python: can't open file 'C:\\souce code\\dbmigrate\\node_modules\\opencc\\data\\scripts\\reverse.py': [Errno 2] No such file or directory
...
The following is my environment:
Node v20.11.1
Npm 10.2.4
Windows 11
Visual C++ 2022
Python 3.11.6