### PR TITLE
Depend on cmake only if there is no system package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "cmake"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import sys
 import warnings
@@ -161,6 +162,10 @@ packages = ['opencc', 'opencc.clib']
 version_info = get_version_info()
 author_info = get_author_info()
 
+setup_requires = []
+if not shutil.which('cmake'):
+    setup_requires.append('cmake')
+
 setuptools.setup(
     name='OpenCC',
     version=version_info,
@@ -178,6 +183,7 @@ setuptools.setup(
         'build_ext': BuildExtCommand,
         'bdist_wheel': BDistWheelCommand
     },
+    setup_requires=setup_requires,
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Rather than requiring using `cmake` from PyPI unconditionally, check if `cmake` is available on the system, and add the dependency only if it is not.  This is the same approach as used e.g. by `scikit-build-core` build system.  Besides avoiding unnecessarily installing (or building) a second copy of CMake, it improves portability, as system CMake is often patched downstream whereas the CMake version found on PyPI is not.