### PR TITLE
Set default language version through variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,9 @@ add_definitions(
   -DPACKAGE_NAME="${PACKAGE_NAME}"
 )
 
+set(CMAKE_CXX_STANDARD 14) # default C++ version for new target afterward
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   add_definitions(
-    -std=c++14
     -Wall
   )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
@@ -163,7 +163,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   add_definitions(
-    -std=c++14
     -Wall
   )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")


### PR DESCRIPTION
Use CMake reserved variable to specify default C++ language version,
so version can be adjust later by each target accordingly.

Recently I noticed that we can not change the C++ language version for targets
through `target_compile_features`. It turns out that setting language version
with `add_definitions` is incompatible with `target_compile_features`, as
the definition flags got propagated to actual command unconditionally.

This PR try to set the language version in a way that CMake awares.

see also:

- https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html
