### PR TITLE
Unify macOS naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ include(CPack)
 #  set(CMAKE_STATIC_LIBRARY_PREFIX ${CMAKE_INSTALL_PREFIX})
 #endif (WIN32)
 
-######## Mac OS X
+######## macOS
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_MACOSX_RPATH 1)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Discussion (Telegram): https://t.me/open_chinese_convert
 * [Ubuntu](https://launchpad.net/ubuntu/+source/opencc)
 * [Fedora](https://packages.fedoraproject.org/pkgs/opencc/opencc/)
 * [Arch Linux](https://archlinux.org/packages/extra/x86_64/opencc/)
-* [Mac](https://formulae.brew.sh/formula/opencc)
+* [macOS](https://formulae.brew.sh/formula/opencc)
 * [Bazel](https://registry.bazel.build/modules/opencc)
 * [Node.js](https://npmjs.org/package/opencc)
 * [Python](https://pypi.org/project/OpenCC/)
@@ -78,7 +78,7 @@ See [demo.js](https://github.com/BYVoid/OpenCC/blob/master/node/demo.js) and [ts
 
 ### Python
 
-`pip install opencc` (Windows, Linux, Mac)
+`pip install opencc` (Windows, Linux, macOS)
 
 ```python
 import opencc
@@ -160,7 +160,7 @@ Document 文檔: https://byvoid.github.io/OpenCC/
 
 ### Build with CMake
 
-#### Linux & Mac OS X
+#### Linux & macOS
 
 g++ 4.6+ or clang 3.2+ is required.
 
@@ -183,7 +183,7 @@ bazel test --test_output=all //src/... //data/... //test/...
 
 ### Test 測試
 
-#### Linux & Mac OS X
+#### Linux & macOS
 
 ```
 make test


### PR DESCRIPTION
macOS is no longer called Mac OS X or any other variations, and do not refer to macOS the OS as Mac the hardware.