### PR TITLE
Tear out remainders of Python 2 support

### DIFF
--- a/python/opencc/__init__.py
+++ b/python/opencc/__init__.py
@@ -1,25 +1,14 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
-import sys
 
-try:
-    import opencc_clib               
-except ImportError:
-    from opencc.clib import opencc_clib
+from opencc.clib import opencc_clib
 
-__all__ = ['OpenCC', 'CONFIGS', '__version__']
+__all__ = ['CONFIGS', 'OpenCC', '__version__']
 
 __version__ = opencc_clib.__version__
 _this_dir = os.path.dirname(os.path.abspath(__file__))
 _opencc_share_dir = os.path.join(_this_dir, 'clib', 'share', 'opencc')
-_opencc_rootdir =  os.path.abspath(os.path.join(_this_dir, '..', '..'))
+_opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
 _opencc_configdir = os.path.join(_opencc_rootdir, 'data', 'config')
-
-if sys.version_info.major == 2:
-    text_type = unicode  # noqa
-else:
-    text_type = str
 
 if os.path.isdir(_opencc_share_dir):
     CONFIGS = [f for f in os.listdir(_opencc_share_dir) if f.endswith('.json')]
@@ -36,7 +25,7 @@ def _append_path_to_env(name, path):
     if value == '':
         value = path
     else:
-        value += ':' + path
+        value += f':{path}'
     os.environ[name] = value
 
 
@@ -49,10 +38,9 @@ class OpenCC(opencc_clib._OpenCC):
             config_under_share_dir = os.path.join(_opencc_share_dir, config)
             if os.path.isfile(config_under_share_dir):
                 config = config_under_share_dir
-        super(OpenCC, self).__init__(config)
+        super().__init__(config)
         self.config = config
 
-    def convert(self, text):
-        if isinstance(text, text_type):
-            text = text.encode('utf-8')
-        return super(OpenCC, self).convert(text, len(text))
+    def convert(self, text: str):
+        byte_text = text.encode('utf-8')
+        return super().convert(byte_text, len(byte_text))

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 import pytest
 import sys


### PR DESCRIPTION
Remove bits of Python 2 support, people desiring to use an EOL version of Python with this library can choose the currently released version.