### PR TITLE
Fix build error on nodejs 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,9 +1103,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {


### PR DESCRIPTION
`npm install` would result in below error on nodejs 24
```
make: *** [opencc.target.mk:123: Release/obj.target/opencc/node/opencc.o] Error 1
make: Leaving directory '/home/user/project/OpenCC/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack at ChildProcess.<anonymous> (/home/user/.nvm/versions/node/v24.0.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
gyp ERR! System Linux 6.14.2-300.fc42.x86_64
gyp ERR! command "/home/user/.nvm/versions/node/v24.0.0/bin/node" "/home/user/.nvm/versions/node/v24.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--module=/home/user/project/OpenCC/build/Release/opencc.node" "--module_name=opencc" "--module_path=/home/user/project/OpenCC/build/Release" "--napi_version=10" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v137"
gyp ERR! cwd /home/user/project/OpenCC
gyp ERR! node -v v24.0.0
gyp ERR! node-gyp -v v11.2.0
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/home/user/.nvm/versions/node/v24.0.0/bin/node /home/user/.nvm/versions/node/v24.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --module=/home/user/project/OpenCC/build/Release/opencc.node --module_name=opencc --module_path=/home/user/project/OpenCC/build/Release --napi_version=10 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v137' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/user/project/OpenCC/node_modules/@mapbox/node-pre-gyp/lib/util/compile.js:89:23)
node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:507:28)
node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1101:16)
node-pre-gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:305:5)
node-pre-gyp ERR! System Linux 6.14.2-300.fc42.x86_64
node-pre-gyp ERR! command "/home/user/.nvm/versions/node/v24.0.0/bin/node" "/home/user/project/OpenCC/node_modules/.bin/node-pre-gyp" "rebuild"
node-pre-gyp ERR! cwd /home/user/project/OpenCC
node-pre-gyp ERR! node -v v24.0.0
node-pre-gyp ERR! node-pre-gyp -v v1.0.11
node-pre-gyp ERR! not ok 
Failed to execute '/home/user/.nvm/versions/node/v24.0.0/bin/node /home/user/.nvm/versions/node/v24.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --module=/home/user/project/OpenCC/build/Release/opencc.node --module_name=opencc --module_path=/home/user/project/OpenCC/build/Release --napi_version=10 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v137' (1)
npm error code 1
npm error path /home/user/project/OpenCC
npm error command failed
npm error command sh -c node-pre-gyp install --fallback-to-build || node-pre-gyp rebuild
npm error A complete log of this run can be found in: /home/user/.npm/_logs/2025-05-08T08_42_14_710Z-debug-0.log
```

This can be fixed by updating the nan npm package.
