### PR TITLE
Update CI/CD to build wheels for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/deps/pybind11-2.13.1/tools/pybind11Tools.cmake
+++ b/deps/pybind11-2.13.1/tools/pybind11Tools.cmake
@@ -43,7 +43,7 @@ endif()
 
 # A user can set versions manually too
 set(Python_ADDITIONAL_VERSIONS
-    "3.12;3.11;3.10;3.9;3.8;3.7"
+    "3.14;3.13;3.12;3.11;3.10;3.9;3.8;3.7"
     CACHE INTERNAL "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -29,7 +29,7 @@ eval "$(conda shell.bash hook)"
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
 
-for VERSION in 3.8 3.9 3.10 3.11 3.12; do
+for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do
     # Create and activate environment
     conda config --add channels conda-forge
     conda config --set channel_priority strict

--- a/release-pypi-macos.sh
+++ b/release-pypi-macos.sh
@@ -23,7 +23,7 @@ eval "$(conda shell.bash hook)"
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
 
-for VERSION in 3.8 3.9 3.10 3.11 3.12; do
+for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do
     # Create and activate environment
     conda config --add channels conda-forge
     conda config --set channel_priority strict

--- a/release-pypi-windows.cmd
+++ b/release-pypi-windows.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-SET VERSIONS=3.8 3.9 3.10 3.11 3.12
+SET VERSIONS=3.8 3.9 3.10 3.11 3.12 3.13 3.14
 SET SOURCEDIR=%cd%
 
 REM Accept conda Terms of Service for required channels


### PR DESCRIPTION
It is found that the CI/CD scripts did not build wheels for the latest Python versions for PyPI release, which results in e.g. #955.

This PR fixes that.

I am not sure whether the Bazel part needs updating, or how the Bazel update needs to be done.

-------

Notes:

- Python 3.12 was released in October 2023
- Python 3.13 was released in October 2024 (available on Conda https://conda-forge.org/blog/2024/09/26/python-313/ )
- Python 3.14 was released in October 2025 (available on Conda https://conda-forge.org/blog/2025/10/09/python-314/ )