### PR TITLE
core: add segmentation plugin host for non-builtin segmenters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ option(BUILD_SHARED_LIBS "Build opencc as shared library" ON)
 option(ENABLE_GTEST "Build all tests." OFF)
 option(ENABLE_BENCHMARK "Build benchmark tests." OFF)
 option(ENABLE_DARTS "Build DartsDict (ocd format)." ON)
+option(ENABLE_JIEBA "Deprecated compatibility option. Use BUILD_OPENCC_JIEBA_PLUGIN." OFF)
+option(BUILD_OPENCC_JIEBA_PLUGIN "Build Jieba segmentation as a loadable plugin." OFF)
 option(BUILD_PYTHON "Build python library" OFF)
 option(USE_SYSTEM_DARTS "Use system version of Darts" OFF)
 option(USE_SYSTEM_GOOGLE_BENCHMARK "Use system version of Google Benchmark" OFF)
@@ -115,6 +117,11 @@ if (DEFINED LIB_INSTALL_DIR)
 endif (DEFINED LIB_INSTALL_DIR)
 
 set (DIR_SHARE_OPENCC ${DIR_SHARE}/opencc)
+if (WIN32)
+  set (DIR_PLUGIN bin/opencc/plugins)
+else ()
+  set (DIR_PLUGIN ${DIR_LIBRARY}/opencc/plugins)
+endif ()
 
 # Compute absolute paths needed for compile-time macros (PKGDATADIR/LOCALEDIR)
 # and for the pkg-config file.  We must handle both the GNUInstallDirs relative
@@ -129,6 +136,11 @@ endforeach ()
 
 set (DIR_SHARE_OPENCC_FULL ${DIR_SHARE_FULL}/opencc)
 set (DIR_SHARE_LOCALE_FULL ${DIR_SHARE_FULL}/locale)
+if (IS_ABSOLUTE "${DIR_PLUGIN}")
+  set (DIR_PLUGIN_FULL "${DIR_PLUGIN}")
+else ()
+  set (DIR_PLUGIN_FULL "${CMAKE_INSTALL_PREFIX}/${DIR_PLUGIN}")
+endif ()
 
 ######## Configuration
 
@@ -229,6 +241,15 @@ if (ENABLE_DARTS)
   )
 endif()
 
+if (ENABLE_JIEBA)
+  message(WARNING "ENABLE_JIEBA is deprecated; enabling BUILD_OPENCC_JIEBA_PLUGIN for compatibility.")
+  set(BUILD_OPENCC_JIEBA_PLUGIN ON)
+endif()
+
+add_definitions(
+  -DOPENCC_SEGMENTATION_PLUGIN_DIR="${DIR_PLUGIN_FULL}"
+)
+
 
 ######## Dependencies
 
@@ -249,6 +270,7 @@ endif()
 add_subdirectory(src)
 add_subdirectory(doc)
 add_subdirectory(data)
+add_subdirectory(plugins)
 add_subdirectory(test)
 
 ######## Testing

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ graft src
 graft deps
 graft test
 graft data
+graft plugins
 graft doc
 graft cmake
 include AUTHORS CMakeLists.txt OpenCCConfig.cmake.in opencc.pc.in README* LICENSE*

--- a/node/opencc.cc
+++ b/node/opencc.cc
@@ -17,6 +17,7 @@
 #include "Lexicon.cpp"
 #include "MarisaDict.cpp"
 #include "MaxMatchSegmentation.cpp"
+#include "PluginSegmentation.cpp"
 #include "Segmentation.cpp"
 #include "SerializedValues.cpp"
 #include "TextDict.cpp"

--- a/opencc.pc.in
+++ b/opencc.pc.in
@@ -2,6 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@DIR_LIBRARY_FULL@
 includedir=@DIR_INCLUDE_FULL@
+plugindir=@DIR_PLUGIN_FULL@
 
 Name: opencc
 Description: Open Chinese Convert

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/jieba/CMakeLists.txt")
+  add_subdirectory(jieba)
+endif()

--- a/plugins/jieba/src/JiebaSegmentationPlugin.cpp
+++ b/plugins/jieba/src/JiebaSegmentationPlugin.cpp
@@ -1,0 +1,341 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Exception.hpp"
+#include "JiebaSegmentation.hpp"
+#include "Segments.hpp"
+#include "plugin/OpenCCPlugin.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Application.hpp"
+
+struct opencc_segmentation_handle {
+  explicit opencc_segmentation_handle(
+      std::unique_ptr<opencc::Segmentation> segmentation)
+      : segmentation(std::move(segmentation)) {}
+
+  std::unique_ptr<opencc::Segmentation> segmentation;
+};
+
+namespace {
+
+bool IsAbsolutePath(const std::string& path) {
+  if (path.empty()) {
+    return false;
+  }
+  if (path[0] == '/' || path[0] == '\\') {
+    return true;
+  }
+  return path.size() > 1 && path[1] == ':';
+}
+
+bool IsReadableFile(const std::string& path) {
+  std::ifstream ifs(path.c_str());
+  return ifs.is_open();
+}
+
+std::string ParentDir(const std::string& path) {
+  std::string normalized = path;
+  while (!normalized.empty() &&
+         (normalized.back() == '/' || normalized.back() == '\\')) {
+    normalized.pop_back();
+  }
+  const std::string::size_type pos = normalized.find_last_of("/\\");
+  if (pos == std::string::npos) {
+    return "";
+  }
+  return normalized.substr(0, pos);
+}
+
+std::string JoinPath(const std::string& left, const std::string& right) {
+  if (left.empty()) {
+    return right;
+  }
+  const char last = left.back();
+  if (last == '/' || last == '\\') {
+    return left + right;
+  }
+  return left + "/" + right;
+}
+
+void SetError(opencc_error_t* error,
+              int code,
+              const std::string& message) {
+  if (error == nullptr) {
+    return;
+  }
+  if (error->message != nullptr) {
+    delete[] error->message;
+    error->message = nullptr;
+  }
+  error->code = code;
+  char* buffer = new char[message.size() + 1];
+  std::memcpy(buffer, message.c_str(), message.size() + 1);
+  error->message = buffer;
+}
+
+bool ReadConfigValue(const opencc_kv_pair_t* config,
+                     size_t size,
+                     const char* key,
+                     std::string* value) {
+  for (size_t i = 0; i < size; i++) {
+    if (config[i].key != nullptr && std::string(config[i].key) == key) {
+      *value = config[i].value == nullptr ? "" : config[i].value;
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string ResolveResourcePath(const std::string& rawPath,
+                                const std::string& configDir) {
+  if (rawPath.empty()) {
+    return rawPath;
+  }
+  if (IsAbsolutePath(rawPath) && IsReadableFile(rawPath)) {
+    return rawPath;
+  }
+  if (IsReadableFile(rawPath)) {
+    return rawPath;
+  }
+  if (!configDir.empty()) {
+    const std::string candidate = JoinPath(configDir, rawPath);
+    if (IsReadableFile(candidate)) {
+      return candidate;
+    }
+    const std::string parent = ParentDir(configDir);
+    if (!parent.empty()) {
+      const std::string parentCandidate = JoinPath(parent, rawPath);
+      if (IsReadableFile(parentCandidate)) {
+        return parentCandidate;
+      }
+    }
+  }
+  const char* dataDir = std::getenv("OPENCC_DATA_DIR");
+  if (dataDir != nullptr && *dataDir != '\0') {
+    const std::string candidate = JoinPath(dataDir, rawPath);
+    if (IsReadableFile(candidate)) {
+      return candidate;
+    }
+  }
+  if (!PACKAGE_DATA_DIRECTORY.empty()) {
+    const std::string candidate = JoinPath(PACKAGE_DATA_DIRECTORY, rawPath);
+    if (IsReadableFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  const std::string devFallback = JoinPath("deps/libcppjieba/dict/",
+                                           rawPath.substr(rawPath.find_last_of("/\\") == std::string::npos
+                                                              ? 0
+                                                              : rawPath.find_last_of("/\\") + 1));
+  if (IsReadableFile(devFallback)) {
+    return devFallback;
+  }
+  return rawPath;
+}
+
+std::string ResolveAuxPath(const std::string& dictPath,
+                           const std::string& configDir,
+                           const std::string& fileName) {
+  const std::string::size_type pos = dictPath.find_last_of("/\\");
+  if (pos != std::string::npos) {
+    const std::string candidate = dictPath.substr(0, pos + 1) + fileName;
+    if (IsReadableFile(candidate)) {
+      return candidate;
+    }
+  }
+  const std::string needle = "data/jieba_dict/";
+  const std::string::size_type needlePos = dictPath.find(needle);
+  if (needlePos != std::string::npos) {
+    std::string alt = dictPath;
+    alt.replace(needlePos, needle.size(), "deps/libcppjieba/dict/");
+    const std::string::size_type altPos = alt.find_last_of("/\\");
+    if (altPos != std::string::npos) {
+      const std::string altCandidate = alt.substr(0, altPos + 1) + fileName;
+      if (IsReadableFile(altCandidate)) {
+        return altCandidate;
+      }
+    }
+  }
+  return ResolveResourcePath("jieba_dict/" + fileName, configDir);
+}
+
+int CreateJiebaSegmentation(opencc_segmentation_create_args_t* args) {
+  if (args == nullptr || args->struct_size < sizeof(*args) ||
+      args->out == nullptr) {
+    SetError(args == nullptr ? nullptr : args->error,
+             OPENCC_ERROR_INVALID_ARGUMENT, "Output handle is null.");
+    return -1;
+  }
+
+  std::string configDir;
+  std::string dictPath;
+  std::string modelPath;
+  std::string userDictPath;
+  ReadConfigValue(args->config, args->config_size, "__config_dir", &configDir);
+  if (!ReadConfigValue(args->config, args->config_size, "dict_path", &dictPath) ||
+      dictPath.empty()) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RESOURCE_MISSING,
+             "Required resource missing: dict_path");
+    return -1;
+  }
+  if (!ReadConfigValue(args->config, args->config_size, "model_path", &modelPath) ||
+      modelPath.empty()) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RESOURCE_MISSING,
+             "Required resource missing: model_path");
+    return -1;
+  }
+  ReadConfigValue(args->config, args->config_size, "user_dict_path", &userDictPath);
+
+  dictPath = ResolveResourcePath(dictPath, configDir);
+  modelPath = ResolveResourcePath(modelPath, configDir);
+  userDictPath = userDictPath.empty() ? "" : ResolveResourcePath(userDictPath, configDir);
+  const std::string idfPath = ResolveAuxPath(dictPath, configDir, "idf.utf8");
+  const std::string stopWordsPath =
+      ResolveAuxPath(dictPath, configDir, "stop_words.utf8");
+
+  if (!IsReadableFile(dictPath) || !IsReadableFile(modelPath) ||
+      (!userDictPath.empty() && !IsReadableFile(userDictPath)) ||
+      !IsReadableFile(idfPath) || !IsReadableFile(stopWordsPath)) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RESOURCE_MISSING,
+             "Failed to locate Jieba resource files.");
+    return -1;
+  }
+
+  try {
+    std::unique_ptr<CppJieba::Application> app(
+        new CppJieba::Application(dictPath, modelPath, userDictPath, idfPath,
+                                  stopWordsPath));
+    class PluginJiebaSegmentation : public opencc::Segmentation {
+    public:
+      explicit PluginJiebaSegmentation(std::unique_ptr<CppJieba::Application> app)
+          : app_(std::move(app)) {}
+      opencc::SegmentsPtr Segment(const std::string& text) const override {
+        opencc::SegmentsPtr segments(new opencc::Segments);
+        std::vector<std::string> words;
+        app_->cut(text, words, CppJieba::METHOD_MIX);
+        for (const auto& word : words) {
+          segments->AddSegment(word);
+        }
+        return segments;
+      }
+
+    private:
+      std::unique_ptr<CppJieba::Application> app_;
+    };
+    std::unique_ptr<opencc::Segmentation> segmentation(
+        new PluginJiebaSegmentation(std::move(app)));
+    *args->out = new opencc_segmentation_handle(std::move(segmentation));
+    return 0;
+  } catch (const std::exception& ex) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE, ex.what());
+    return -1;
+  } catch (...) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE,
+             "Unknown error while creating Jieba segmentation.");
+    return -1;
+  }
+}
+
+opencc::Segmentation* GetSegmentation(opencc_segmentation_handle_t* handle) {
+  return handle->segmentation.get();
+}
+
+int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
+  if (args == nullptr || args->struct_size < sizeof(*args) ||
+      args->handle == nullptr || args->token_array == nullptr ||
+      args->token_array->struct_size < sizeof(*args->token_array) ||
+      args->utf8_text == nullptr) {
+    SetError(args == nullptr ? nullptr : args->error,
+             OPENCC_ERROR_INVALID_ARGUMENT,
+             "Segment arguments are invalid.");
+    return -1;
+  }
+  try {
+    opencc::SegmentsPtr segments =
+        GetSegmentation(args->handle)->Segment(args->utf8_text);
+    args->token_array->tokens = nullptr;
+    args->token_array->token_count = segments->Length();
+    args->token_array->tokens = new char*[args->token_array->token_count];
+    for (size_t i = 0; i < args->token_array->token_count; i++) {
+      const char* token = segments->At(i);
+      const size_t length = std::strlen(token);
+      args->token_array->tokens[i] = new char[length + 1];
+      std::memcpy(args->token_array->tokens[i], token, length + 1);
+    }
+    return 0;
+  } catch (const std::exception& ex) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE, ex.what());
+    return -1;
+  } catch (...) {
+    SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE,
+             "Unknown error while segmenting text.");
+    return -1;
+  }
+}
+
+void FreeTokens(opencc_token_array_t* tokenArray) {
+  if (tokenArray == nullptr || tokenArray->tokens == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < tokenArray->token_count; i++) {
+    delete[] tokenArray->tokens[i];
+  }
+  delete[] tokenArray->tokens;
+  tokenArray->tokens = nullptr;
+  tokenArray->token_count = 0;
+}
+
+void DestroyJiebaSegmentation(opencc_segmentation_handle_t* handle) {
+  delete handle;
+}
+
+void FreeError(opencc_error_t* error) {
+  if (error == nullptr || error->message == nullptr) {
+    return;
+  }
+  delete[] error->message;
+  error->message = nullptr;
+}
+
+const opencc_segmentation_plugin_v1 kJiebaPlugin = {
+    sizeof(opencc_segmentation_plugin_v1),
+    OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR,
+    OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR,
+    "opencc-jieba",
+    "jieba",
+    &CreateJiebaSegmentation,
+    &SegmentWithJieba,
+    &FreeTokens,
+    &DestroyJiebaSegmentation,
+    &FreeError,
+};
+
+} // namespace
+
+extern "C" OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v1*
+opencc_get_segmentation_plugin_v1(void) {
+  return &kJiebaPlugin;
+}

--- a/plugins/jieba/src/JiebaSegmentationPlugin.cpp
+++ b/plugins/jieba/src/JiebaSegmentationPlugin.cpp
@@ -263,6 +263,18 @@ opencc::Segmentation* GetSegmentation(opencc_segmentation_handle_t* handle) {
   return handle->segmentation.get();
 }
 
+void FreeTokens(opencc_token_array_t* tokenArray) {
+  if (tokenArray == nullptr || tokenArray->tokens == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < tokenArray->token_count; i++) {
+    delete[] tokenArray->tokens[i];
+  }
+  delete[] tokenArray->tokens;
+  tokenArray->tokens = nullptr;
+  tokenArray->token_count = 0;
+}
+
 int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
   if (args == nullptr || args->struct_size < sizeof(*args) ||
       args->handle == nullptr || args->token_array == nullptr ||
@@ -278,7 +290,7 @@ int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
         GetSegmentation(args->handle)->Segment(args->utf8_text);
     args->token_array->tokens = nullptr;
     args->token_array->token_count = segments->Length();
-    args->token_array->tokens = new char*[args->token_array->token_count];
+    args->token_array->tokens = new char*[args->token_array->token_count]();
     for (size_t i = 0; i < args->token_array->token_count; i++) {
       const char* token = segments->At(i);
       const size_t length = std::strlen(token);
@@ -287,25 +299,15 @@ int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
     }
     return 0;
   } catch (const std::exception& ex) {
+    FreeTokens(args->token_array);
     SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE, ex.what());
     return -1;
   } catch (...) {
+    FreeTokens(args->token_array);
     SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE,
              "Unknown error while segmenting text.");
     return -1;
   }
-}
-
-void FreeTokens(opencc_token_array_t* tokenArray) {
-  if (tokenArray == nullptr || tokenArray->tokens == nullptr) {
-    return;
-  }
-  for (size_t i = 0; i < tokenArray->token_count; i++) {
-    delete[] tokenArray->tokens[i];
-  }
-  delete[] tokenArray->tokens;
-  tokenArray->tokens = nullptr;
-  tokenArray->token_count = 0;
 }
 
 void DestroyJiebaSegmentation(opencc_segmentation_handle_t* handle) {

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
         ":lexicon",
         ":marisa_dict",
         ":max_match_segmentation",
+        ":plugin_segmentation",
         ":phrase_extract",
         ":segmentation",
         ":segments",
@@ -86,6 +87,7 @@ cc_library(
         ":dict_group",
         ":marisa_dict",
         ":max_match_segmentation",
+        ":plugin_segmentation",
         ":text_dict",
         "@rapidjson",
     ],
@@ -340,6 +342,30 @@ cc_library(
         ":common",
         ":marisa_dict",
         ":utf8_string_slice",
+    ],
+)
+
+cc_library(
+    name = "plugin_api",
+    hdrs = ["plugin/OpenCCPlugin.h"],
+)
+
+cc_library(
+    name = "plugin_segmentation",
+    srcs = ["PluginSegmentation.cpp"],
+    hdrs = ["PluginSegmentation.hpp"],
+    linkopts = select({
+        "@platforms//os:linux": ["-ldl"],
+        "@platforms//os:osx": [],
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-ldl"],
+    }),
+    deps = [
+        ":common",
+        ":exception",
+        ":plugin_api",
+        ":segmentation",
+        ":segments",
     ],
 )
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -353,7 +353,10 @@ cc_library(
 cc_library(
     name = "plugin_segmentation",
     srcs = ["PluginSegmentation.cpp"],
-    hdrs = ["PluginSegmentation.hpp"],
+    hdrs = [
+        "PluginSegmentation.hpp",
+        "WinUtil.hpp",
+    ],
     linkopts = select({
         "@platforms//os:linux": ["-ldl"],
         "@platforms//os:osx": [],

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(
   MarisaDict.hpp
   MaxMatchSegmentation.hpp
   Optional.hpp
+  PluginSegmentation.hpp
   PhraseExtract.hpp
   Segmentation.hpp
   Segments.hpp
@@ -58,6 +59,7 @@ set(
   Lexicon.cpp
   MarisaDict.cpp
   MaxMatchSegmentation.cpp
+  PluginSegmentation.cpp
   PhraseExtract.cpp
   SerializedValues.cpp
   SimpleConverter.cpp
@@ -130,6 +132,15 @@ add_library(OpenCC::OpenCC ALIAS libopencc)
 set_target_properties(libopencc PROPERTIES POSITION_INDEPENDENT_CODE ON)
 source_group(libopencc FILES ${LIBOPENCC_SOURCES} ${LIBOPENCC_HEADERS})
 target_link_libraries(libopencc marisa)
+# PluginSegmentation.cpp uses LoadLibrary on _WIN32 (MSVC and MinGW).
+# Only non-Windows targets may need libdl for dlopen.
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  include(CheckLibraryExists)
+  check_library_exists(dl dlopen "" HAVE_LIBDL)
+  if (HAVE_LIBDL)
+    target_link_libraries(libopencc dl)
+  endif ()
+endif ()
 target_include_directories(libopencc PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${DIR_INCLUDE}/opencc>
@@ -183,6 +194,11 @@ install(
 install(
   FILES ${LIBOPENCC_HEADERS}
   DESTINATION ${DIR_INCLUDE}/opencc
+)
+
+install(
+  FILES plugin/OpenCCPlugin.h
+  DESTINATION ${DIR_INCLUDE}/opencc/plugin
 )
 
 # Gtest

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -77,6 +77,13 @@ const std::string PACKAGE_DATA_DIRECTORY = "";
 const std::string PACKAGE_DATA_DIRECTORY = PKGDATADIR "/";
 #endif // ifndef PKGDATADIR
 
+#ifndef OPENCC_SEGMENTATION_PLUGIN_DIR
+const std::string PACKAGE_SEGMENTATION_PLUGIN_DIRECTORY = "";
+#else
+const std::string PACKAGE_SEGMENTATION_PLUGIN_DIRECTORY =
+    OPENCC_SEGMENTATION_PLUGIN_DIR "/";
+#endif
+
 #ifndef VERSION
 #define VERSION "1.0.*"
 #endif // ifndef VERSION

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -22,10 +22,7 @@
 #include <unordered_map>
 
 #if defined(_WIN32) || defined(_WIN64)
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <Windows.h>
+#include "WinUtil.hpp"
 #endif
 
 #include <rapidjson/document.h>
@@ -37,6 +34,7 @@
 #include "Exception.hpp"
 #include "MarisaDict.hpp"
 #include "MaxMatchSegmentation.hpp"
+#include "PluginSegmentation.hpp"
 #include "TextDict.hpp"
 
 #ifdef ENABLE_DARTS
@@ -52,36 +50,8 @@ namespace {
 std::string GetParentDirectory(const std::string& path);
 
 #if defined(_WIN32) || defined(_WIN64)
-std::string Utf8FromWide(const std::wstring& wide) {
-  if (wide.empty()) {
-    return "";
-  }
-  int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, nullptr,
-                                         0, nullptr, nullptr);
-  if (requiredSize <= 1) {
-    return "";
-  }
-  std::string utf8(static_cast<size_t>(requiredSize), '\0');
-  WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, utf8.data(), requiredSize,
-                      nullptr, nullptr);
-  utf8.resize(static_cast<size_t>(requiredSize - 1));
-  return utf8;
-}
-
-std::wstring WideFromUtf8(const std::string& utf8) {
-  if (utf8.empty()) {
-    return L"";
-  }
-  int requiredSize =
-      MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
-  if (requiredSize <= 1) {
-    return L"";
-  }
-  std::wstring wide(static_cast<size_t>(requiredSize), L'\0');
-  MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide.data(), requiredSize);
-  wide.resize(static_cast<size_t>(requiredSize - 1));
-  return wide;
-}
+using internal::Utf8FromWide;
+using internal::WideFromUtf8;
 
 std::string NormalizeModulePath(const std::string& path) {
   if (path.empty()) {
@@ -175,6 +145,7 @@ void AppendWindowsPortableSearchPaths(std::vector<std::string>& paths,
 class ConfigInternal {
 public:
   std::vector<std::string> paths;
+  std::string configDirectory;
 
   const JSONValue& GetProperty(const JSONValue& doc, const char* name) {
     if (!doc.HasMember(name)) {
@@ -275,7 +246,32 @@ public:
       DictPtr dict = ParseDict(GetObjectProperty(doc, "dict"));
       segmentation = SegmentationPtr(new MaxMatchSegmentation(dict));
     } else {
-      throw InvalidFormat("Unknown segmentation type: " + type);
+      PluginConfigPairs configPairs;
+      configPairs.push_back(std::make_pair("__config_dir", configDirectory));
+      if (doc.HasMember("resources")) {
+        const JSONValue& resources = GetObjectProperty(doc, "resources");
+        for (auto it = resources.MemberBegin(); it != resources.MemberEnd();
+             ++it) {
+          if (!it->value.IsString()) {
+            throw InvalidFormat("Segmentation resource must be a string: " +
+                                std::string(it->name.GetString()));
+          }
+          configPairs.push_back(std::make_pair(it->name.GetString(),
+                                               it->value.GetString()));
+        }
+      }
+      for (auto it = doc.MemberBegin(); it != doc.MemberEnd(); ++it) {
+        const std::string key = it->name.GetString();
+        if (key == "type" || key == "resources") {
+          continue;
+        }
+        if (!it->value.IsString()) {
+          throw InvalidFormat("Segmentation plugin property must be a string: " +
+                              key);
+        }
+        configPairs.push_back(std::make_pair(key, it->value.GetString()));
+      }
+      segmentation = CreatePluginSegmentation(type, configPairs);
     }
     return segmentation;
   }
@@ -415,6 +411,7 @@ ConverterPtr Config::NewFromFile(const std::string& fileName,
   if (!configDirectory.empty()) {
     impl->paths.push_back(configDirectory);
   }
+  impl->configDirectory = configDirectory;
   return NewFromString(content, impl->paths);
 }
 
@@ -451,6 +448,9 @@ ConverterPtr Config::NewFromString(const std::string& json,
 
   ConfigInternal* impl = reinterpret_cast<ConfigInternal*>(internal);
   impl->paths = paths;
+  if (impl->configDirectory.empty()) {
+    impl->configDirectory = paths.empty() ? "" : paths.front();
+  }
 
   // Required: segmentation
   SegmentationPtr segmentation =

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -1,0 +1,398 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PluginSegmentation.hpp"
+
+#include "Exception.hpp"
+#include "Segmentation.hpp"
+#include "Segments.hpp"
+#include "plugin/OpenCCPlugin.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+
+#if defined(_WIN32) || defined(_WIN64)
+#include "WinUtil.hpp"
+#else
+#include <dlfcn.h>
+#endif
+
+namespace opencc {
+
+namespace {
+
+std::string DirName(const std::string& path) {
+  const std::string::size_type pos = path.find_last_of("/\\");
+  if (pos == std::string::npos) {
+    return "";
+  }
+  return path.substr(0, pos);
+}
+
+std::string JoinPath(const std::string& left, const std::string& right) {
+  if (left.empty()) {
+    return right;
+  }
+  const char last = left.back();
+  if (last == '/' || last == '\\') {
+    return left + right;
+  }
+  return left + "/" + right;
+}
+
+void AppendUnique(std::vector<std::string>& values, const std::string& value) {
+  if (value.empty()) {
+    return;
+  }
+  for (const std::string& existing : values) {
+    if (existing == value) {
+      return;
+    }
+  }
+  values.push_back(value);
+}
+
+bool IsTruthy(const char* value) {
+  if (value == nullptr) {
+    return false;
+  }
+  const std::string text(value);
+  return text == "1" || text == "true" || text == "TRUE" || text == "yes" ||
+         text == "on";
+}
+
+std::vector<std::string> SplitSearchPath(const char* raw) {
+  std::vector<std::string> entries;
+  if (raw == nullptr || *raw == '\0') {
+    return entries;
+  }
+  const char separator =
+#if defined(_WIN32) || defined(_WIN64)
+      ';';
+#else
+      ':';
+#endif
+  std::string path(raw);
+  std::string::size_type start = 0;
+  while (start <= path.size()) {
+    const std::string::size_type end = path.find(separator, start);
+    const std::string entry = path.substr(start, end - start);
+    if (!entry.empty()) {
+      entries.push_back(entry);
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return entries;
+}
+
+#if defined(_WIN32) || defined(_WIN64)
+using internal::Utf8FromWide;
+using internal::WideFromUtf8;
+
+std::string GetCurrentLibraryDirectory() {
+  HMODULE module = nullptr;
+  if (!GetModuleHandleExW(
+          GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+          reinterpret_cast<LPCWSTR>(&GetCurrentLibraryDirectory), &module)) {
+    return "";
+  }
+  std::wstring buffer(MAX_PATH, L'\0');
+  for (;;) {
+    const DWORD copied = GetModuleFileNameW(module, buffer.data(),
+                                            static_cast<DWORD>(buffer.size()));
+    if (copied == 0) {
+      return "";
+    }
+    if (copied < buffer.size() - 1) {
+      buffer.resize(copied);
+      return DirName(Utf8FromWide(buffer));
+    }
+    buffer.resize(buffer.size() * 2);
+  }
+}
+#else
+std::string GetCurrentLibraryDirectory() {
+  Dl_info info;
+  if (dladdr(reinterpret_cast<void*>(&GetCurrentLibraryDirectory), &info) == 0 ||
+      info.dli_fname == nullptr) {
+    return "";
+  }
+  return DirName(info.dli_fname);
+}
+#endif
+
+class SharedLibrary {
+public:
+  explicit SharedLibrary(const std::string& path) {
+#if defined(_WIN32) || defined(_WIN64)
+    handle_ = LoadLibraryExW(
+        WideFromUtf8(path).c_str(), nullptr,
+        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (handle_ == nullptr) {
+      throw Exception("Failed to load plugin library: " + path);
+    }
+#else
+    handle_ = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle_ == nullptr) {
+      throw Exception("Failed to load plugin library: " + path);
+    }
+#endif
+  }
+
+  ~SharedLibrary() {
+#if defined(_WIN32) || defined(_WIN64)
+    if (handle_ != nullptr) {
+      FreeLibrary(handle_);
+    }
+#else
+    if (handle_ != nullptr) {
+      dlclose(handle_);
+    }
+#endif
+  }
+
+  void* FindSymbol(const char* symbolName) const {
+#if defined(_WIN32) || defined(_WIN64)
+    FARPROC symbol = GetProcAddress(handle_, symbolName);
+    if (symbol == nullptr) {
+      throw Exception("Plugin symbol not found: " + std::string(symbolName));
+    }
+    return reinterpret_cast<void*>(symbol);
+#else
+    dlerror();
+    void* symbol = dlsym(handle_, symbolName);
+    if (symbol == nullptr) {
+      throw Exception("Plugin symbol not found: " + std::string(symbolName));
+    }
+    return symbol;
+#endif
+  }
+
+private:
+#if defined(_WIN32) || defined(_WIN64)
+  HMODULE handle_ = nullptr;
+#else
+  void* handle_ = nullptr;
+#endif
+};
+
+struct PluginLibrary {
+  std::shared_ptr<SharedLibrary> library;
+  const opencc_segmentation_plugin_v1* descriptor = nullptr;
+};
+
+size_t RequiredDescriptorSize() {
+  return offsetof(opencc_segmentation_plugin_v1, free_error) +
+         sizeof(((opencc_segmentation_plugin_v1*)nullptr)->free_error);
+}
+
+std::string TakeErrorMessage(const opencc_segmentation_plugin_v1* descriptor,
+                             opencc_error_t* error,
+                             const std::string& fallback) {
+  if (error == nullptr) {
+    return fallback;
+  }
+  const std::string message =
+      error->message == nullptr ? fallback : std::string(error->message);
+  if (descriptor->free_error != nullptr) {
+    descriptor->free_error(error);
+  }
+  return message;
+}
+
+class PluginSegmentationAdapter : public Segmentation {
+public:
+  PluginSegmentationAdapter(std::shared_ptr<PluginLibrary> plugin,
+                            opencc_segmentation_handle_t* handle)
+      : plugin_(std::move(plugin)), handle_(handle) {}
+
+  ~PluginSegmentationAdapter() override {
+    if (handle_ != nullptr) {
+      plugin_->descriptor->destroy(handle_);
+      handle_ = nullptr;
+    }
+  }
+
+  SegmentsPtr Segment(const std::string& text) const override {
+    char** tokens = nullptr;
+    size_t tokenCount = 0;
+    opencc_error_t error = {};
+    error.struct_size = sizeof(error);
+    opencc_segmentation_segment_args_t args = {};
+    args.struct_size = sizeof(args);
+    args.handle = handle_;
+    args.utf8_text = text.c_str();
+    args.tokens = &tokens;
+    args.token_count = &tokenCount;
+    args.error = &error;
+    const int status = plugin_->descriptor->segment(&args);
+    if (status != 0) {
+      const std::string message =
+          TakeErrorMessage(plugin_->descriptor, &error, "unknown error");
+      throw Exception("Segmentation plugin '" +
+                      std::string(plugin_->descriptor->segmentation_type) +
+                      "' failed: " + message);
+    }
+
+    SegmentsPtr segments(new Segments);
+    for (size_t i = 0; i < tokenCount; i++) {
+      segments->AddSegment(std::string(tokens[i]));
+    }
+    plugin_->descriptor->free_tokens(tokens, tokenCount);
+    return segments;
+  }
+
+private:
+  std::shared_ptr<PluginLibrary> plugin_;
+  mutable opencc_segmentation_handle_t* handle_ = nullptr;
+};
+
+class PluginManager {
+public:
+  std::shared_ptr<PluginLibrary> LoadByType(const std::string& type) {
+    if (IsTruthy(std::getenv("OPENCC_DISABLE_PLUGINS"))) {
+      throw Exception("Segmentation plugin loading is disabled.");
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(type);
+    if (it != cache_.end()) {
+      return it->second;
+    }
+
+    const std::vector<std::string> searchDirs = BuildSearchDirs();
+    const std::string fileName = GetPluginFileName(type);
+    std::ostringstream attempted;
+    bool first = true;
+    for (const auto& dir : searchDirs) {
+      const std::string candidate = JoinPath(dir, fileName);
+      if (!first) {
+        attempted << ", ";
+      }
+      first = false;
+      attempted << candidate;
+      try {
+        std::shared_ptr<PluginLibrary> plugin = LoadFromPath(candidate, type);
+        cache_[type] = plugin;
+        return plugin;
+      } catch (const Exception&) {
+      }
+    }
+    throw Exception("Segmentation plugin '" + type +
+                    "' not found. Searched: " + attempted.str());
+  }
+
+private:
+  static std::string GetPluginFileName(const std::string& type) {
+#if defined(_WIN32) || defined(_WIN64)
+    return "opencc-" + type + ".dll";
+#elif defined(__APPLE__)
+    return "libopencc-" + type + ".dylib";
+#else
+    return "libopencc-" + type + ".so";
+#endif
+  }
+
+  static std::vector<std::string> BuildSearchDirs() {
+    std::vector<std::string> dirs =
+        SplitSearchPath(std::getenv("OPENCC_SEGMENTATION_PLUGIN_PATH"));
+    AppendUnique(dirs, PACKAGE_SEGMENTATION_PLUGIN_DIRECTORY);
+
+    const std::string currentLibraryDir = GetCurrentLibraryDirectory();
+    if (!currentLibraryDir.empty()) {
+      AppendUnique(dirs, JoinPath(currentLibraryDir, "opencc/plugins"));
+      AppendUnique(dirs, currentLibraryDir);
+    }
+    return dirs;
+  }
+
+  static std::shared_ptr<PluginLibrary> LoadFromPath(const std::string& path,
+                                                     const std::string& type) {
+    std::shared_ptr<SharedLibrary> library(new SharedLibrary(path));
+    typedef const opencc_segmentation_plugin_v1* (*EntryPoint)(void);
+    EntryPoint entryPoint = reinterpret_cast<EntryPoint>(
+        library->FindSymbol("opencc_get_segmentation_plugin_v1"));
+    const opencc_segmentation_plugin_v1* descriptor = entryPoint();
+    if (descriptor == nullptr) {
+      throw Exception("Plugin returned null descriptor.");
+    }
+    if (descriptor->struct_size < RequiredDescriptorSize()) {
+      throw Exception("Plugin descriptor is too small.");
+    }
+    if (descriptor->abi_major != OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR) {
+      throw Exception("Plugin ABI mismatch.");
+    }
+    if (descriptor->segmentation_type == nullptr ||
+        type != descriptor->segmentation_type) {
+      throw Exception("Plugin type mismatch.");
+    }
+    std::shared_ptr<PluginLibrary> plugin(new PluginLibrary);
+    plugin->library = library;
+    plugin->descriptor = descriptor;
+    return plugin;
+  }
+
+  std::mutex mutex_;
+  std::unordered_map<std::string, std::shared_ptr<PluginLibrary>> cache_;
+};
+
+PluginManager& GetPluginManager() {
+  static PluginManager manager;
+  return manager;
+}
+
+} // namespace
+
+SegmentationPtr CreatePluginSegmentation(const std::string& type,
+                                         const PluginConfigPairs& configPairs) {
+  std::shared_ptr<PluginLibrary> plugin = GetPluginManager().LoadByType(type);
+  std::vector<opencc_kv_pair_t> rawConfig;
+  rawConfig.reserve(configPairs.size());
+  for (const auto& pair : configPairs) {
+    rawConfig.push_back(
+        {sizeof(opencc_kv_pair_t), pair.first.c_str(), pair.second.c_str()});
+  }
+
+  opencc_segmentation_handle_t* handle = nullptr;
+  opencc_error_t error = {};
+  error.struct_size = sizeof(error);
+  opencc_segmentation_create_args_t args = {};
+  args.struct_size = sizeof(args);
+  args.config = rawConfig.empty() ? nullptr : rawConfig.data();
+  args.config_size = rawConfig.size();
+  args.out = &handle;
+  args.error = &error;
+  const int status = plugin->descriptor->create(&args);
+  if (status != 0 || handle == nullptr) {
+    const std::string message =
+        TakeErrorMessage(plugin->descriptor, &error, "unknown error");
+    throw InvalidFormat("Failed to initialize segmentation plugin '" + type +
+                        "': " + message);
+  }
+  return SegmentationPtr(new PluginSegmentationAdapter(plugin, handle));
+}
+
+} // namespace opencc

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -356,7 +356,10 @@ private:
       throw Exception("Plugin descriptor is too small.");
     }
     if (descriptor->abi_major != OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR) {
-      throw Exception("Plugin ABI mismatch.");
+      throw Exception("Plugin ABI major version mismatch.");
+    }
+    if (descriptor->abi_minor < OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR) {
+      throw Exception("Plugin ABI minor version is older than required by the host.");
     }
     if (descriptor->segmentation_type == nullptr ||
         type != descriptor->segmentation_type) {

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -223,6 +223,16 @@ std::string TakeErrorMessage(const opencc_segmentation_plugin_v1* descriptor,
   return message;
 }
 
+[[noreturn]] void ThrowPluginError(const opencc_segmentation_plugin_v1* descriptor,
+                                   opencc_error_t* error,
+                                   const std::string& pluginType,
+                                   const std::string& fallbackPrefix,
+                                   const std::string& fallbackMessage) {
+  const std::string message =
+      TakeErrorMessage(descriptor, error, fallbackMessage);
+  throw Exception(fallbackPrefix + " '" + pluginType + "': " + message);
+}
+
 class PluginSegmentationAdapter : public Segmentation {
 public:
   PluginSegmentationAdapter(std::shared_ptr<PluginLibrary> plugin,
@@ -237,31 +247,28 @@ public:
   }
 
   SegmentsPtr Segment(const std::string& text) const override {
-    char** tokens = nullptr;
-    size_t tokenCount = 0;
+    opencc_token_array_t tokenArray = {};
+    tokenArray.struct_size = sizeof(tokenArray);
     opencc_error_t error = {};
     error.struct_size = sizeof(error);
     opencc_segmentation_segment_args_t args = {};
     args.struct_size = sizeof(args);
     args.handle = handle_;
     args.utf8_text = text.c_str();
-    args.tokens = &tokens;
-    args.token_count = &tokenCount;
+    args.token_array = &tokenArray;
     args.error = &error;
     const int status = plugin_->descriptor->segment(&args);
     if (status != 0) {
-      const std::string message =
-          TakeErrorMessage(plugin_->descriptor, &error, "unknown error");
-      throw Exception("Segmentation plugin '" +
-                      std::string(plugin_->descriptor->segmentation_type) +
-                      "' failed: " + message);
+      ThrowPluginError(plugin_->descriptor, &error,
+                       plugin_->descriptor->segmentation_type,
+                       "Segmentation plugin failed", "unknown error");
     }
 
     SegmentsPtr segments(new Segments);
-    for (size_t i = 0; i < tokenCount; i++) {
-      segments->AddSegment(std::string(tokens[i]));
+    for (size_t i = 0; i < tokenArray.token_count; i++) {
+      segments->AddSegment(std::string(tokenArray.tokens[i]));
     }
-    plugin_->descriptor->free_tokens(tokens, tokenCount);
+    plugin_->descriptor->free_tokens(&tokenArray);
     return segments;
   }
 

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -258,8 +258,14 @@ public:
     args.token_array = &tokenArray;
     args.error = &error;
     const int status = plugin_->descriptor->segment(&args);
+
+    struct TokenGuard {
+      const opencc_segmentation_plugin_v1* desc;
+      opencc_token_array_t* arr;
+      ~TokenGuard() { desc->free_tokens(arr); }
+    } guard{plugin_->descriptor, &tokenArray};
+
     if (status != 0) {
-      plugin_->descriptor->free_tokens(&tokenArray);
       ThrowPluginError(plugin_->descriptor, &error,
                        plugin_->descriptor->segmentation_type,
                        "Segmentation plugin failed", "unknown error");
@@ -269,7 +275,6 @@ public:
     for (size_t i = 0; i < tokenArray.token_count; i++) {
       segments->AddSegment(std::string(tokenArray.tokens[i]));
     }
-    plugin_->descriptor->free_tokens(&tokenArray);
     return segments;
   }
 

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -259,6 +259,7 @@ public:
     args.error = &error;
     const int status = plugin_->descriptor->segment(&args);
     if (status != 0) {
+      plugin_->descriptor->free_tokens(&tokenArray);
       ThrowPluginError(plugin_->descriptor, &error,
                        plugin_->descriptor->segmentation_type,
                        "Segmentation plugin failed", "unknown error");

--- a/src/PluginSegmentation.hpp
+++ b/src/PluginSegmentation.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "Common.hpp"
+
+namespace opencc {
+
+typedef std::vector<std::pair<std::string, std::string>> PluginConfigPairs;
+
+SegmentationPtr CreatePluginSegmentation(const std::string& type,
+                                         const PluginConfigPairs& configPairs);
+
+} // namespace opencc

--- a/src/Segmentation.hpp
+++ b/src/Segmentation.hpp
@@ -27,6 +27,7 @@ namespace opencc {
  */
 class OPENCC_EXPORT Segmentation {
 public:
+  virtual ~Segmentation() {}
   virtual SegmentsPtr Segment(const std::string& text) const = 0;
 };
 } // namespace opencc

--- a/src/WinUtil.hpp
+++ b/src/WinUtil.hpp
@@ -1,0 +1,68 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+
+#include <string>
+
+namespace opencc {
+namespace internal {
+
+inline std::string Utf8FromWide(const std::wstring& wide) {
+  if (wide.empty()) {
+    return "";
+  }
+  const int required =
+      WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, nullptr, 0, nullptr,
+                          nullptr);
+  if (required <= 1) {
+    return "";
+  }
+  std::string utf8(static_cast<size_t>(required), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, utf8.data(), required,
+                      nullptr, nullptr);
+  utf8.resize(static_cast<size_t>(required - 1));
+  return utf8;
+}
+
+inline std::wstring WideFromUtf8(const std::string& utf8) {
+  if (utf8.empty()) {
+    return L"";
+  }
+  const int required =
+      MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+  if (required <= 1) {
+    return L"";
+  }
+  std::wstring wide(static_cast<size_t>(required), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide.data(), required);
+  wide.resize(static_cast<size_t>(required - 1));
+  return wide;
+}
+
+} // namespace internal
+} // namespace opencc
+
+#endif // defined(_WIN32) || defined(_WIN64)

--- a/src/plugin/OpenCCPlugin.h
+++ b/src/plugin/OpenCCPlugin.h
@@ -15,6 +15,18 @@
 extern "C" {
 #endif
 
+/*
+ * struct_size rules:
+ *
+ * - Caller must initialize struct_size to sizeof(struct) before passing
+ *   any structure across the ABI boundary.
+ *
+ * - Callee must validate struct_size is sufficient for fields it reads.
+ *
+ * - Future ABI-compatible extensions may append fields to the end.
+ *   Implementations must ignore unknown trailing fields.
+ */
+
 #define OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR 1
 #define OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR 0
 
@@ -42,6 +54,13 @@ typedef struct opencc_segmentation_handle opencc_segmentation_handle_t;
 typedef struct {
   size_t struct_size;
   int code;
+  /*
+   * On return, error->message may point either to:
+   * - a static constant string, or
+   * - plugin-owned dynamically allocated memory.
+   * free_error(error) must release any plugin-owned resources associated with
+   * the error object and leave it in a safely destructible state.
+   */
   const char* message;
 } opencc_error_t;
 
@@ -67,14 +86,73 @@ typedef struct {
   opencc_error_t* error;
 } opencc_segmentation_segment_args_t;
 
+/*
+ * ABI Layout & Alignment Rules:
+ * 1. Uses natural C struct alignment (no #pragma pack).
+ * 2. Field order must not be altered in future versions.
+ * 3. Extensions must strictly append fields to the end.
+ */
 typedef struct {
   size_t struct_size;
+
+  /*
+   * Versioning semantics:
+   * - abi_major:
+   *   Breaking ABI changes increment this value.
+   *   Host must require exact major match.
+   *
+   * - abi_minor:
+   *   Backward-compatible ABI additions increment this value.
+   *   Host may require plugin->abi_minor >= minimum_supported_minor.
+   *   Host should not reject a plugin solely because plugin->abi_minor is
+   *   newer.
+   */
   uint16_t abi_major;
   uint16_t abi_minor;
+
+  /*
+   * Must point to static, null-terminated constant strings.
+   * Host will not attempt to free() or delete[] these pointers.
+   */
   const char* plugin_name;
   const char* segmentation_type;
+
+  /*
+   * [ABI CONTRACT]
+   * create(args):
+   * On success:
+   * - returns 0
+   * - *args->out must be set to a valid handle
+   * - args->error->code should be 0 (or unchanged)
+   * - args->error->message may be NULL
+   *
+   * On failure:
+   * - returns non-zero
+   * - *args->out must be NULL
+   * - args->error must remain in a state safe for free_error()
+   */
   int (*create)(opencc_segmentation_create_args_t* args);
+
+  /*
+   * [ABI CONTRACT]
+   * segment(args):
+   * On success:
+   * - returns 0
+   * - token_array contains plugin-owned token storage until free_tokens() is called.
+   *
+   * On failure:
+   * - returns non-zero
+   * - token_array may be partially populated, but must remain safe for free_tokens().
+   */
   int (*segment)(opencc_segmentation_segment_args_t* args);
+
+  /*
+   * Cleanup Functions:
+   * 1. Must gracefully handle null pointers (count = 0, tokens = null).
+   * 2. Host promises to call these at most once per returned object.
+   * 3. free_tokens() must also accept token_array structures that were
+   *    partially initialized by segment() on failure.
+   */
   void (*free_tokens)(opencc_token_array_t* token_array);
   void (*destroy)(opencc_segmentation_handle_t* handle);
   void (*free_error)(opencc_error_t* error);

--- a/src/plugin/OpenCCPlugin.h
+++ b/src/plugin/OpenCCPlugin.h
@@ -18,6 +18,19 @@ extern "C" {
 #define OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR 1
 #define OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR 0
 
+enum {
+  OPENCC_ERROR_UNKNOWN = 1,
+  OPENCC_ERROR_INVALID_ARGUMENT = 2,
+  OPENCC_ERROR_PLUGIN_NOT_FOUND = 3,
+  OPENCC_ERROR_PLUGIN_LOAD_FAILED = 4,
+  OPENCC_ERROR_PLUGIN_SYMBOL_MISSING = 5,
+  OPENCC_ERROR_PLUGIN_ABI_MISMATCH = 6,
+  OPENCC_ERROR_PLUGIN_TYPE_MISMATCH = 7,
+  OPENCC_ERROR_PLUGIN_DESCRIPTOR_INVALID = 8,
+  OPENCC_ERROR_PLUGIN_RESOURCE_MISSING = 9,
+  OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE = 10,
+};
+
 typedef struct {
   size_t struct_size;
   const char* key;
@@ -34,6 +47,12 @@ typedef struct {
 
 typedef struct {
   size_t struct_size;
+  char** tokens;
+  size_t token_count;
+} opencc_token_array_t;
+
+typedef struct {
+  size_t struct_size;
   const opencc_kv_pair_t* config;
   size_t config_size;
   opencc_segmentation_handle_t** out;
@@ -44,8 +63,7 @@ typedef struct {
   size_t struct_size;
   opencc_segmentation_handle_t* handle;
   const char* utf8_text;
-  char*** tokens;
-  size_t* token_count;
+  opencc_token_array_t* token_array;
   opencc_error_t* error;
 } opencc_segmentation_segment_args_t;
 
@@ -57,7 +75,7 @@ typedef struct {
   const char* segmentation_type;
   int (*create)(opencc_segmentation_create_args_t* args);
   int (*segment)(opencc_segmentation_segment_args_t* args);
-  void (*free_tokens)(char** tokens, size_t token_count);
+  void (*free_tokens)(opencc_token_array_t* token_array);
   void (*destroy)(opencc_segmentation_handle_t* handle);
   void (*free_error)(opencc_error_t* error);
 } opencc_segmentation_plugin_v1;

--- a/src/plugin/OpenCCPlugin.h
+++ b/src/plugin/OpenCCPlugin.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32) && defined(OPENCC_PLUGIN_BUILD)
+#define OPENCC_PLUGIN_EXPORT __declspec(dllexport)
+#elif !defined(_WIN32)
+#define OPENCC_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define OPENCC_PLUGIN_EXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR 1
+#define OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR 0
+
+typedef struct {
+  size_t struct_size;
+  const char* key;
+  const char* value;
+} opencc_kv_pair_t;
+
+typedef struct opencc_segmentation_handle opencc_segmentation_handle_t;
+
+typedef struct {
+  size_t struct_size;
+  int code;
+  const char* message;
+} opencc_error_t;
+
+typedef struct {
+  size_t struct_size;
+  const opencc_kv_pair_t* config;
+  size_t config_size;
+  opencc_segmentation_handle_t** out;
+  opencc_error_t* error;
+} opencc_segmentation_create_args_t;
+
+typedef struct {
+  size_t struct_size;
+  opencc_segmentation_handle_t* handle;
+  const char* utf8_text;
+  char*** tokens;
+  size_t* token_count;
+  opencc_error_t* error;
+} opencc_segmentation_segment_args_t;
+
+typedef struct {
+  size_t struct_size;
+  uint16_t abi_major;
+  uint16_t abi_minor;
+  const char* plugin_name;
+  const char* segmentation_type;
+  int (*create)(opencc_segmentation_create_args_t* args);
+  int (*segment)(opencc_segmentation_segment_args_t* args);
+  void (*free_tokens)(char** tokens, size_t token_count);
+  void (*destroy)(opencc_segmentation_handle_t* handle);
+  void (*free_error)(opencc_error_t* error);
+} opencc_segmentation_plugin_v1;
+
+OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v1*
+opencc_get_segmentation_plugin_v1(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Keep built-in segmentation behavior unchanged, including mmseg and existing official configs.

Introduce a small C ABI for segmentation plugins plus a runtime loader that resolves non-builtin segmentation.type values through shared libraries.

Update the core config path so plugin-backed segmenters receive raw string properties from JSON, while preserving existing Bazel and CMake behavior for current users.