### PR TITLE
jieba: use Unicode-safe file opens on Windows

### DIFF
--- a/plugins/jieba/deps/cppjieba/include/cppjieba/DictTrie.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/DictTrie.hpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include "limonp/StringUtil.hpp"
 #include "limonp/Logging.hpp"
+#include "UnicodeFile.hpp"
 #include "Unicode.hpp"
 #include "Trie.hpp"
 
@@ -151,7 +152,8 @@ class DictTrie {
   void LoadUserDict(const std::string& filePaths) {
     std::vector<std::string> files = limonp::Split(filePaths, "|;");
     for (size_t i = 0; i < files.size(); i++) {
-      std::ifstream ifs(files[i].c_str());
+      std::ifstream ifs;
+      OpenInputFile(files[i], ifs);
       XCHECK(ifs.is_open()) << "open " << files[i] << " failed";
       std::string line;
 
@@ -236,7 +238,8 @@ class DictTrie {
   static DictCacheEntry BuildDictCacheEntry(const std::string& filePath) {
     DictCacheEntry entry;
     std::vector<DictUnit> node_infos;
-    std::ifstream ifs(filePath.c_str());
+    std::ifstream ifs;
+    OpenInputFile(filePath, ifs);
     XCHECK(ifs.is_open()) << "open " << filePath << " failed.";
     std::string line;
     std::vector<std::string> buf;

--- a/plugins/jieba/deps/cppjieba/include/cppjieba/HMMModel.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/HMMModel.hpp
@@ -1,6 +1,7 @@
 #ifndef CPPJIEBA_HMMMODEL_H
 #define CPPJIEBA_HMMMODEL_H
 
+#include "UnicodeFile.hpp"
 #include "limonp/StringUtil.hpp"
 #include "Trie.hpp"
 
@@ -32,7 +33,8 @@ struct HMMModel {
   ~HMMModel() {
   }
   void LoadModel(const string& filePath) {
-    ifstream ifile(filePath.c_str());
+    ifstream ifile;
+    OpenInputFile(filePath, ifile);
     XCHECK(ifile.is_open()) << "open " << filePath << " failed";
     string line;
     vector<string> tmp;

--- a/plugins/jieba/deps/cppjieba/include/cppjieba/KeywordExtractor.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/KeywordExtractor.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "MixSegment.hpp"
+#include "UnicodeFile.hpp"
 
 namespace cppjieba {
 
@@ -91,7 +92,8 @@ class KeywordExtractor {
   }
  private:
   void LoadIdfDict(const std::string& idfPath) {
-    std::ifstream ifs(idfPath.c_str());
+    std::ifstream ifs;
+    OpenInputFile(idfPath, ifs);
     XCHECK(ifs.is_open()) << "open " << idfPath << " failed";
     std::string line ;
     std::vector<std::string> buf;
@@ -120,7 +122,8 @@ class KeywordExtractor {
     assert(idfAverage_ > 0.0);
   }
   void LoadStopWordDict(const std::string& filePath) {
-    std::ifstream ifs(filePath.c_str());
+    std::ifstream ifs;
+    OpenInputFile(filePath, ifs);
     XCHECK(ifs.is_open()) << "open " << filePath << " failed";
     std::string line ;
     while (getline(ifs, line)) {

--- a/plugins/jieba/deps/cppjieba/include/cppjieba/TextRankExtractor.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/TextRankExtractor.hpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include "Jieba.hpp"
+#include "UnicodeFile.hpp"
 
 namespace cppjieba {
   using namespace limonp;
@@ -163,7 +164,8 @@ namespace cppjieba {
     }
   private:
     void LoadStopWordDict(const string& filePath) {
-      ifstream ifs(filePath.c_str());
+      ifstream ifs;
+      OpenInputFile(filePath, ifs);
       XCHECK(ifs.is_open()) << "open " << filePath << " failed";
       string line ;
       while (getline(ifs, line)) {

--- a/plugins/jieba/deps/cppjieba/include/cppjieba/UnicodeFile.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/UnicodeFile.hpp
@@ -1,6 +1,7 @@
 #ifndef CPPJIEBA_UNICODE_FILE_HPP
 #define CPPJIEBA_UNICODE_FILE_HPP
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -30,7 +31,7 @@ inline std::wstring WidePathFromUtf8(const std::string& path) {
 inline void OpenInputFile(const std::string& path, std::ifstream& ifs,
                           std::ios_base::openmode mode = std::ios::in) {
 #if defined(_WIN32) || defined(_WIN64)
-  ifs.open(WidePathFromUtf8(path), mode);
+  ifs.open(std::filesystem::path(WidePathFromUtf8(path)), mode);
 #else
   ifs.open(path.c_str(), mode);
 #endif

--- a/plugins/jieba/deps/cppjieba/include/cppjieba/UnicodeFile.hpp
+++ b/plugins/jieba/deps/cppjieba/include/cppjieba/UnicodeFile.hpp
@@ -1,0 +1,41 @@
+#ifndef CPPJIEBA_UNICODE_FILE_HPP
+#define CPPJIEBA_UNICODE_FILE_HPP
+
+#include <fstream>
+#include <string>
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#endif
+
+namespace cppjieba {
+
+#if defined(_WIN32) || defined(_WIN64)
+inline std::wstring WidePathFromUtf8(const std::string& path) {
+  if (path.empty()) {
+    return L"";
+  }
+  const int size =
+      MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, nullptr, 0);
+  if (size <= 1) {
+    return L"";
+  }
+  std::wstring wide(static_cast<size_t>(size), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, &wide[0], size);
+  wide.resize(static_cast<size_t>(size - 1));
+  return wide;
+}
+#endif
+
+inline void OpenInputFile(const std::string& path, std::ifstream& ifs,
+                          std::ios_base::openmode mode = std::ios::in) {
+#if defined(_WIN32) || defined(_WIN64)
+  ifs.open(WidePathFromUtf8(path), mode);
+#else
+  ifs.open(path.c_str(), mode);
+#endif
+}
+
+} // namespace cppjieba
+
+#endif // CPPJIEBA_UNICODE_FILE_HPP

--- a/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
+++ b/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
@@ -27,6 +27,10 @@
 
 #include "test/PortableUtil.hpp"
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#endif
+
 #ifdef BAZEL
 #include "tools/cpp/runfiles/runfiles.h"
 using bazel::tools::cpp::runfiles::Runfiles;
@@ -206,6 +210,23 @@ protected:
            " --path " + QuotePath(dictionaryDir);
   }
 
+#if defined(_WIN32) || defined(_WIN64)
+  static int RunCommandUtf8(const std::string& command) {
+    const int size =
+        MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, nullptr, 0);
+    if (size <= 1) {
+      return -1;
+    }
+    std::wstring wide(static_cast<size_t>(size), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, &wide[0], size);
+    return _wsystem(wide.c_str());
+  }
+#else
+  static int RunCommandUtf8(const std::string& command) {
+    return system(command.c_str());
+  }
+#endif
+
   static CasesByConfig LoadCases(const std::string& jsonPath) {
     CasesByConfig cases;
     std::ifstream ifs(jsonPath);
@@ -268,7 +289,7 @@ TEST_F(JiebaPluginIntegrationTest, ConvertFromJsonCases) {
       }
     }
 
-    ASSERT_EQ(0, system(BuildCommand(config, inputFile, outputFile).c_str()));
+    ASSERT_EQ(0, RunCommandUtf8(BuildCommand(config, inputFile, outputFile)));
 
     std::ifstream ifs(outputFile, std::ios::binary);
     ASSERT_TRUE(ifs.is_open());
@@ -334,7 +355,7 @@ TEST_F(JiebaPluginIntegrationTest, ConvertFromUnicodePluginPath) {
   const std::string cmd = BuildCommandWithPaths(
       configFile.u8string(), inputFile.u8string(), outputFile.u8string(),
       DictionaryDirectory() + "/", tempPlugins.u8string());
-  ASSERT_EQ(0, system(("\"" + cmd + "\"").c_str()));
+  ASSERT_EQ(0, RunCommandUtf8("\"" + cmd + "\""));
 
   std::ifstream ifs(outputFile, std::ios::binary);
   ASSERT_TRUE(ifs.is_open());

--- a/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
+++ b/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
@@ -29,6 +29,53 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
+
+std::wstring WideFromUtf8(const std::string& text) {
+  if (text.empty()) {
+    return L"";
+  }
+  const int size =
+      MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+  if (size <= 1) {
+    return L"";
+  }
+  std::wstring wide(static_cast<size_t>(size), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, &wide[0], size);
+  wide.resize(static_cast<size_t>(size - 1));
+  return wide;
+}
+
+void CopyRegularFiles(const std::filesystem::path& sourceDir,
+                      const std::filesystem::path& targetDir) {
+  for (const auto& entry : std::filesystem::directory_iterator(sourceDir)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    std::filesystem::copy_file(entry.path(), targetDir / entry.path().filename(),
+                               std::filesystem::copy_options::overwrite_existing);
+  }
+}
+
+int RunProcessWide(const std::filesystem::path& application,
+                   const std::wstring& arguments,
+                   const std::filesystem::path& workingDirectory) {
+  STARTUPINFOW startupInfo = {};
+  startupInfo.cb = sizeof(startupInfo);
+  PROCESS_INFORMATION processInfo = {};
+  std::wstring commandLine = arguments;
+  if (!CreateProcessW(WideFromUtf8(application.u8string()).c_str(),
+                      commandLine.data(), nullptr, nullptr, FALSE, 0, nullptr,
+                      WideFromUtf8(workingDirectory.u8string()).c_str(),
+                      &startupInfo, &processInfo)) {
+    return -1;
+  }
+  WaitForSingleObject(processInfo.hProcess, INFINITE);
+  DWORD exitCode = 1;
+  GetExitCodeProcess(processInfo.hProcess, &exitCode);
+  CloseHandle(processInfo.hThread);
+  CloseHandle(processInfo.hProcess);
+  return static_cast<int>(exitCode);
+}
 #endif
 
 #ifdef BAZEL
@@ -316,55 +363,57 @@ TEST_F(JiebaPluginIntegrationTest, ConvertFromUnicodePluginPath) {
       fs::temp_directory_path() /
       fs::u8path("opencc-jieba-中文路径-" +
                  std::to_string(GetCurrentProcessId()));
+  const fs::path tempBin = tempRoot / "bin";
   const fs::path tempShareOpencc = tempRoot / "share" / "opencc";
   const fs::path tempJiebaDict = tempShareOpencc / "jieba_dict";
-  const fs::path tempPlugins = tempRoot / "bin" / "plugins";
-  const fs::path inputFile = tempRoot / "input.txt";
-  const fs::path outputFile = tempRoot / "output.txt";
+  const fs::path tempPlugins = tempBin / "plugins";
+  const fs::path inputFile = tempBin / "input.txt";
+  const fs::path outputFile = tempBin / "output.txt";
   const fs::path configFile = tempShareOpencc / "s2twp_jieba.json";
   const fs::path sourceConfig = fs::u8path(ConfigPath("s2twp_jieba"));
-  const fs::path sourceJiebaDict = sourceConfig.parent_path().parent_path() /
-                                   "deps" / "cppjieba" / "dict";
+  const fs::path sourcePluginRoot =
+      sourceConfig.parent_path().parent_path().parent_path();
+  const fs::path sourceJiebaDict =
+      sourcePluginRoot / "deps" / "cppjieba" / "dict";
   const fs::path sourcePluginDir = fs::u8path(PluginDirectory());
+  const fs::path sourceOpenccExe = fs::u8path(OpenccCommand());
+  const fs::path sourceBinDir = sourceOpenccExe.parent_path();
 
   fs::remove_all(tempRoot);
+  fs::create_directories(tempBin);
   fs::create_directories(tempJiebaDict);
   fs::create_directories(tempPlugins);
+  CopyRegularFiles(sourceBinDir, tempBin);
+  CopyRegularFiles(fs::u8path(DictionaryDirectory()), tempShareOpencc);
   fs::copy_file(sourceConfig, configFile, fs::copy_options::overwrite_existing);
-  for (const auto& entry : fs::directory_iterator(sourceJiebaDict)) {
-    if (!entry.is_regular_file()) {
-      continue;
+  CopyRegularFiles(sourceJiebaDict, tempJiebaDict);
+  CopyRegularFiles(sourcePluginDir, tempPlugins);
+
+  try {
+    {
+      std::ofstream ofs(inputFile, std::ios::binary);
+      ASSERT_TRUE(ofs.is_open());
+      ofs << "生活着名为正敏的少女\n";
     }
-    fs::copy_file(entry.path(), tempJiebaDict / entry.path().filename(),
-                  fs::copy_options::overwrite_existing);
-  }
-  for (const auto& entry : fs::directory_iterator(sourcePluginDir)) {
-    if (!entry.is_regular_file()) {
-      continue;
+
+    const fs::path tempOpenccExe = tempBin / sourceOpenccExe.filename();
+    const std::wstring args =
+        WideFromUtf8(sourceOpenccExe.filename().u8string()) +
+        L" -i input.txt -o output.txt -c s2twp_jieba.json";
+    ASSERT_EQ(0, RunProcessWide(tempOpenccExe, args, tempBin));
+
+    std::ifstream ifs(outputFile, std::ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+    std::string line;
+    ASSERT_TRUE(std::getline(ifs, line));
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
     }
-    fs::copy_file(entry.path(), tempPlugins / entry.path().filename(),
-                  fs::copy_options::overwrite_existing);
+    EXPECT_EQ("生活著名為正敏的少女", line);
+  } catch (...) {
+    fs::remove_all(tempRoot);
+    throw;
   }
-
-  {
-    std::ofstream ofs(inputFile, std::ios::binary);
-    ASSERT_TRUE(ofs.is_open());
-    ofs << "生活着名为正敏的少女\n";
-  }
-
-  const std::string cmd = BuildCommandWithPaths(
-      configFile.u8string(), inputFile.u8string(), outputFile.u8string(),
-      DictionaryDirectory() + "/", tempPlugins.u8string());
-  ASSERT_EQ(0, RunCommandUtf8("\"" + cmd + "\""));
-
-  std::ifstream ifs(outputFile, std::ios::binary);
-  ASSERT_TRUE(ifs.is_open());
-  std::string line;
-  ASSERT_TRUE(std::getline(ifs, line));
-  if (!line.empty() && line.back() == '\r') {
-    line.pop_back();
-  }
-  EXPECT_EQ("生活著名為正敏的少女", line);
 
   fs::remove_all(tempRoot);
 }

--- a/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
+++ b/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
@@ -179,15 +179,31 @@ protected:
   std::string BuildCommand(const std::string& config,
                            const std::string& inputFile,
                            const std::string& outputFile) const {
-    std::string cmd = EnvPrefix() + QuotePath(OpenccCommand()) + " -i " +
-                      QuotePath(inputFile) + " -o " + QuotePath(outputFile) +
-                      " -c " + QuotePath(ConfigPath(config)) + " --path " +
-                      QuotePath(DictionaryDirectory() + "/");
+    std::string cmd =
+        BuildCommandWithPaths(ConfigPath(config), inputFile, outputFile,
+                              DictionaryDirectory() + "/", PluginDirectory());
 #ifdef _WIN32
     return "\"" + cmd + "\"";
 #else
     return cmd;
 #endif
+  }
+
+  std::string BuildCommandWithPaths(const std::string& configPath,
+                                    const std::string& inputFile,
+                                    const std::string& outputFile,
+                                    const std::string& dictionaryDir,
+                                    const std::string& pluginDir) const {
+#ifdef _WIN32
+    std::string envPrefix =
+        "set \"OPENCC_SEGMENTATION_PLUGIN_PATH=" + pluginDir + "\" && ";
+#else
+    std::string envPrefix =
+        "OPENCC_SEGMENTATION_PLUGIN_PATH=" + QuotePath(pluginDir) + " ";
+#endif
+    return envPrefix + QuotePath(OpenccCommand()) + " -i " + QuotePath(inputFile) +
+           " -o " + QuotePath(outputFile) + " -c " + QuotePath(configPath) +
+           " --path " + QuotePath(dictionaryDir);
   }
 
   static CasesByConfig LoadCases(const std::string& jsonPath) {
@@ -270,5 +286,67 @@ TEST_F(JiebaPluginIntegrationTest, ConvertFromJsonCases) {
     EXPECT_EQ(idx, entry.second.size()) << "config=" << config;
   }
 }
+
+#if defined(_WIN32) || defined(_WIN64)
+TEST_F(JiebaPluginIntegrationTest, ConvertFromUnicodePluginPath) {
+  namespace fs = std::filesystem;
+
+  const fs::path tempRoot =
+      fs::temp_directory_path() /
+      fs::u8path("opencc-jieba-中文路径-" +
+                 std::to_string(GetCurrentProcessId()));
+  const fs::path tempShareOpencc = tempRoot / "share" / "opencc";
+  const fs::path tempJiebaDict = tempShareOpencc / "jieba_dict";
+  const fs::path tempPlugins = tempRoot / "bin" / "plugins";
+  const fs::path inputFile = tempRoot / "input.txt";
+  const fs::path outputFile = tempRoot / "output.txt";
+  const fs::path configFile = tempShareOpencc / "s2twp_jieba.json";
+  const fs::path sourceConfig = fs::u8path(ConfigPath("s2twp_jieba"));
+  const fs::path sourceJiebaDict = sourceConfig.parent_path().parent_path() /
+                                   "deps" / "cppjieba" / "dict";
+  const fs::path sourcePluginDir = fs::u8path(PluginDirectory());
+
+  fs::remove_all(tempRoot);
+  fs::create_directories(tempJiebaDict);
+  fs::create_directories(tempPlugins);
+  fs::copy_file(sourceConfig, configFile, fs::copy_options::overwrite_existing);
+  for (const auto& entry : fs::directory_iterator(sourceJiebaDict)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    fs::copy_file(entry.path(), tempJiebaDict / entry.path().filename(),
+                  fs::copy_options::overwrite_existing);
+  }
+  for (const auto& entry : fs::directory_iterator(sourcePluginDir)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    fs::copy_file(entry.path(), tempPlugins / entry.path().filename(),
+                  fs::copy_options::overwrite_existing);
+  }
+
+  {
+    std::ofstream ofs(inputFile, std::ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    ofs << "生活着名为正敏的少女\n";
+  }
+
+  const std::string cmd = BuildCommandWithPaths(
+      configFile.u8string(), inputFile.u8string(), outputFile.u8string(),
+      DictionaryDirectory() + "/", tempPlugins.u8string());
+  ASSERT_EQ(0, system(("\"" + cmd + "\"").c_str()));
+
+  std::ifstream ifs(outputFile, std::ios::binary);
+  ASSERT_TRUE(ifs.is_open());
+  std::string line;
+  ASSERT_TRUE(std::getline(ifs, line));
+  if (!line.empty() && line.back() == '\r') {
+    line.pop_back();
+  }
+  EXPECT_EQ("生活著名為正敏的少女", line);
+
+  fs::remove_all(tempRoot);
+}
+#endif
 
 } // namespace opencc

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -76,7 +76,11 @@ TEST_F(ConfigTest, NewFromStringWitoutTrailingSlash) {
   const ConverterPtr _ = config.NewFromString(content, CONFIG_TEST_DIR_PATH);
 }
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_MSC_VER)
+// This case exists only to verify Windows Unicode path handling in OpenCC
+// itself. Other platforms do not have this specific regression, and MinGW-like
+// Windows environments do not provide a stable enough std::filesystem Unicode
+// behavior for this check to be reliable.
 TEST_F(ConfigTest, LoadConfigFromUnicodePath) {
   namespace fs = std::filesystem;
 
@@ -96,7 +100,6 @@ TEST_F(ConfigTest, LoadConfigFromUnicodePath) {
   fs::copy_file(sourceDir / "config_test_characters.txt",
                 tempDir / "config_test_characters.txt",
                 fs::copy_options::overwrite_existing);
-
   try {
     const ConverterPtr unicodeConverter =
         config.NewFromFile(tempDir.u8string() + "/config_test.json");

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -17,6 +17,11 @@
  */
 
 #include <fstream>
+#include <filesystem>
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#endif
 
 #include "Config.hpp"
 #include "ConfigTestBase.hpp"
@@ -70,5 +75,39 @@ TEST_F(ConfigTest, NewFromStringWitoutTrailingSlash) {
 
   const ConverterPtr _ = config.NewFromString(content, CONFIG_TEST_DIR_PATH);
 }
+
+#if defined(_WIN32) || defined(_WIN64)
+TEST_F(ConfigTest, LoadConfigFromUnicodePath) {
+  namespace fs = std::filesystem;
+
+  const fs::path sourceDir = fs::u8path(CONFIG_TEST_DIR_PATH);
+  const fs::path tempDir =
+      fs::temp_directory_path() /
+      fs::u8path("opencc-中文路径-config-test-" +
+                 std::to_string(GetCurrentProcessId()));
+
+  fs::remove_all(tempDir);
+  fs::create_directories(tempDir);
+  fs::copy_file(sourceDir / "config_test.json", tempDir / "config_test.json",
+                fs::copy_options::overwrite_existing);
+  fs::copy_file(sourceDir / "config_test_phrases.txt",
+                tempDir / "config_test_phrases.txt",
+                fs::copy_options::overwrite_existing);
+  fs::copy_file(sourceDir / "config_test_characters.txt",
+                tempDir / "config_test_characters.txt",
+                fs::copy_options::overwrite_existing);
+
+  try {
+    const ConverterPtr unicodeConverter =
+        config.NewFromFile(tempDir.u8string() + "/config_test.json");
+    EXPECT_EQ(expected, unicodeConverter->Convert(input));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+
+  fs::remove_all(tempDir);
+}
+#endif
 
 } // namespace opencc


### PR DESCRIPTION
Also add tests to cover:
* Windows unicode config path loading
* Windows jieba unicode paths

This continues the fix of the first problem in https://github.com/BYVoid/OpenCC/issues/1101 for jieba plugin.