### PR TITLE
ci: refresh Node.js versions (drop 20, add 25)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         # Current stable line on latest hosted runners
         os: [ubuntu-latest, macos-latest]
-        node-version: [24]
+        node-version: [24, 25]
         # LTS coverage on macOS 14 (ARM64)
         include:
           - os: macos-14

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,8 +25,6 @@ jobs:
         include:
           - os: macos-14
             node-version: 22
-          - os: macos-14
-            node-version: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "node-pre-gyp-github": "^2.0.0"
       },
       "engines": {
-        "node": ">=20 <25"
+        "node": ">=20 <=25"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "install": "node-pre-gyp install --fallback-to-build || node-pre-gyp rebuild"
   },
   "engines": {
-    "node": ">=20 <25"
+    "node": ">=20 <=25"
   },
   "binary": {
     "module_name": "opencc",


### PR DESCRIPTION
## Summary
- Drop Node.js 20 from the GitHub Actions matrix as it approaches end-of-life.
- Add Node.js 25 (current stable line) to the primary runners alongside the Node.js 24 LTS.
- Widen `engines.node` in `package.json` (and the matching `package-lock.json` entry) from `>=20 <25` to `>=20 <=25` so Node.js 25 is permitted.

## Changes
- `.github/workflows/nodejs.yml`:
  - Primary matrix now tests Node.js **24** and **25** on `ubuntu-latest` / `macos-latest`.
  - macOS 14 (ARM64) still runs Node.js **22** for older-LTS coverage; the redundant Node.js 20 entry is removed.
- `package.json` / `package-lock.json`: `"node": ">=20 <=25"`.

## Rationale
Node.js 20 moves to EOL soon, so keeping it in the CI matrix adds noise without real coverage. Node.js 25 is the current stable release per nodejs.org; exercising it on the primary runners catches regressions against the newest line while Node.js 24 LTS remains the production recommendation.

https://claude.ai/code/session_017xps8CYCFXzRKeTUsKm1Ca