### PR TITLE
Switch segmentation plugin ABI to codepoint lengths

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -74,6 +74,24 @@ resolving them at runtime. Relative resource paths are expected to resolve
 within the existing OpenCC data layout rather than a plugin-specific ad hoc
 directory tree.
 
+## Segmentation ABI
+
+The current segmentation plugin ABI entry point is:
+
+- `opencc_get_segmentation_plugin_v2()`
+
+Segmentation results are returned as a sequence of segment lengths measured in
+Unicode code points, not as copied token strings. The ABI contract is:
+
+- input text is passed to the plugin as null-terminated UTF-8
+- the plugin returns `segment_count` plus `codepoint_lengths`
+- each element is the number of Unicode code points in the next segment
+- lengths must be positive and must cover the full input, in order
+- the host reconstructs segment boundaries from the original UTF-8 input
+
+This keeps the ABI simpler and avoids allocating one string per token across
+the plugin boundary.
+
 ### Customizing Jieba Dictionaries
 
 When using the `jieba` plugin, you can add custom terminology to the segmenter by defining a custom `user.dict.utf8` or editing the installed one. 
@@ -106,7 +124,7 @@ Current `jieba` targets:
 ## Adding A New Plugin
 
 1. Create `plugins/<name>/src`, `include`, `data`, and `tests`.
-2. Export `opencc_get_segmentation_plugin_v1()`.
+2. Export `opencc_get_segmentation_plugin_v2()`.
 3. Name the output binary using the `opencc-<type>` convention.
 4. Keep JSON configs platform-neutral and resource-oriented.
 5. Add both CMake and Bazel build rules.

--- a/plugins/jieba/BUILD.bazel
+++ b/plugins/jieba/BUILD.bazel
@@ -38,6 +38,7 @@ cc_binary(
         "//src:plugin_api",
         "//src:segmentation",
         "//src:segments",
+        "//src:utf8_util",
     ],
 )
 

--- a/plugins/jieba/CMakeLists.txt
+++ b/plugins/jieba/CMakeLists.txt
@@ -80,6 +80,21 @@ else()
   target_link_libraries(opencc_jieba PRIVATE libopencc)
 endif()
 target_compile_definitions(opencc_jieba PRIVATE OPENCC_PLUGIN_BUILD)
+
+# On Windows, OpenCC headers must not use dllimport when the plugin links
+# against a static OpenCC library. This affects both integrated builds and
+# standalone plugin builds via find_package(OpenCC).
+if (WIN32)
+  if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    get_target_property(_opencc_target_type OpenCC::OpenCC TYPE)
+  else()
+    get_target_property(_opencc_target_type libopencc TYPE)
+  endif()
+  if (_opencc_target_type STREQUAL "STATIC_LIBRARY")
+    target_compile_definitions(opencc_jieba PRIVATE Opencc_BUILT_AS_STATIC)
+  endif()
+endif()
+
 set_target_properties(opencc_jieba PROPERTIES
   OUTPUT_NAME opencc-jieba
   POSITION_INDEPENDENT_CODE ON

--- a/plugins/jieba/src/JiebaSegmentationPlugin.cpp
+++ b/plugins/jieba/src/JiebaSegmentationPlugin.cpp
@@ -19,6 +19,7 @@
 #include "Exception.hpp"
 #include "JiebaSegmentation.hpp"
 #include "Segments.hpp"
+#include "UTF8Util.hpp"
 #include "plugin/OpenCCPlugin.h"
 
 #include <cstdlib>
@@ -131,6 +132,10 @@ bool ReadConfigValue(const opencc_kv_pair_t* config,
     }
   }
   return false;
+}
+
+uint32_t CodePointLength(const std::string& text) {
+  return static_cast<uint32_t>(opencc::UTF8Util::Length(text.c_str()));
 }
 
 std::string ResolveResourcePath(const std::string& rawPath,
@@ -294,22 +299,19 @@ opencc::Segmentation* GetSegmentation(opencc_segmentation_handle_t* handle) {
   return handle->segmentation.get();
 }
 
-void FreeTokens(opencc_token_array_t* tokenArray) {
-  if (tokenArray == nullptr || tokenArray->tokens == nullptr) {
+void FreeSegmentLengths(opencc_segment_length_array_t* segmentLengths) {
+  if (segmentLengths == nullptr || segmentLengths->codepoint_lengths == nullptr) {
     return;
   }
-  for (size_t i = 0; i < tokenArray->token_count; i++) {
-    delete[] tokenArray->tokens[i];
-  }
-  delete[] tokenArray->tokens;
-  tokenArray->tokens = nullptr;
-  tokenArray->token_count = 0;
+  delete[] segmentLengths->codepoint_lengths;
+  segmentLengths->codepoint_lengths = nullptr;
+  segmentLengths->segment_count = 0;
 }
 
 int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
   if (args == nullptr || args->struct_size < sizeof(*args) ||
-      args->handle == nullptr || args->token_array == nullptr ||
-      args->token_array->struct_size < sizeof(*args->token_array) ||
+      args->handle == nullptr || args->segment_lengths == nullptr ||
+      args->segment_lengths->struct_size < sizeof(*args->segment_lengths) ||
       args->utf8_text == nullptr) {
     SetError(args == nullptr ? nullptr : args->error,
              OPENCC_ERROR_INVALID_ARGUMENT,
@@ -319,22 +321,41 @@ int SegmentWithJieba(opencc_segmentation_segment_args_t* args) {
   try {
     opencc::SegmentsPtr segments =
         GetSegmentation(args->handle)->Segment(args->utf8_text);
-    args->token_array->tokens = nullptr;
-    args->token_array->token_count = segments->Length();
-    args->token_array->tokens = new char*[args->token_array->token_count]();
-    for (size_t i = 0; i < args->token_array->token_count; i++) {
-      const char* token = segments->At(i);
-      const size_t length = std::strlen(token);
-      args->token_array->tokens[i] = new char[length + 1];
-      std::memcpy(args->token_array->tokens[i], token, length + 1);
+    const std::string text(args->utf8_text);
+    std::vector<uint32_t> lengths;
+    lengths.reserve(segments->Length() + 1);
+    size_t byteOffset = 0;
+
+    for (size_t i = 0; i < segments->Length(); i++) {
+      const std::string token = segments->At(i);
+      const size_t tokenPos = text.find(token, byteOffset);
+      if (tokenPos == std::string::npos) {
+        throw opencc::Exception("Jieba token sequence could not be aligned to input text.");
+      }
+      if (tokenPos > byteOffset) {
+        lengths.push_back(CodePointLength(text.substr(byteOffset, tokenPos - byteOffset)));
+      }
+      lengths.push_back(CodePointLength(token));
+      byteOffset = tokenPos + token.size();
+    }
+    if (byteOffset < text.size()) {
+      lengths.push_back(CodePointLength(text.substr(byteOffset)));
+    }
+
+    args->segment_lengths->codepoint_lengths = nullptr;
+    args->segment_lengths->segment_count = lengths.size();
+    args->segment_lengths->codepoint_lengths =
+        new uint32_t[args->segment_lengths->segment_count]();
+    for (size_t i = 0; i < args->segment_lengths->segment_count; i++) {
+      args->segment_lengths->codepoint_lengths[i] = lengths[i];
     }
     return 0;
   } catch (const std::exception& ex) {
-    FreeTokens(args->token_array);
+    FreeSegmentLengths(args->segment_lengths);
     SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE, ex.what());
     return -1;
   } catch (...) {
-    FreeTokens(args->token_array);
+    FreeSegmentLengths(args->segment_lengths);
     SetError(args->error, OPENCC_ERROR_PLUGIN_RUNTIME_FAILURE,
              "Unknown error while segmenting text.");
     return -1;
@@ -353,22 +374,22 @@ void FreeError(opencc_error_t* error) {
   error->message = nullptr;
 }
 
-const opencc_segmentation_plugin_v1 kJiebaPlugin = {
-    sizeof(opencc_segmentation_plugin_v1),
+const opencc_segmentation_plugin_v2 kJiebaPlugin = {
+    sizeof(opencc_segmentation_plugin_v2),
     OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR,
     OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR,
     "opencc-jieba",
     "jieba",
     &CreateJiebaSegmentation,
     &SegmentWithJieba,
-    &FreeTokens,
+    &FreeSegmentLengths,
     &DestroyJiebaSegmentation,
     &FreeError,
 };
 
 } // namespace
 
-extern "C" OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v1*
-opencc_get_segmentation_plugin_v1(void) {
+extern "C" OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v2*
+opencc_get_segmentation_plugin_v2(void) {
   return &kJiebaPlugin;
 }

--- a/plugins/jieba/tests/data/jieba_comparison_testcases.json
+++ b/plugins/jieba/tests/data/jieba_comparison_testcases.json
@@ -3,12 +3,12 @@
   "cases": [
     {
       "id": "jieba_s2t_001",
-      "description": "Ambiguous case: 着名 (wearing+name) vs 著名 (famous)",
-      "input": "生活着名为正敏的少女",
-      "expected_segmentation": "生活/着/名为/正敏/的/少女",
+      "description": "Ambiguous case: 的/士兵 vs 的士/兵",
+      "input": "勇敢的士兵",
+      "expected_segmentation": "勇敢/的/士兵",
       "expected": {
-        "s2twp": "生活著名為正敏的少女",
-        "s2twp_jieba": "生活著名為正敏的少女"
+        "s2twp": "勇敢計程車兵",
+        "s2twp_jieba": "勇敢的士兵"
       }
     },
     {

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -369,6 +369,7 @@ cc_library(
         ":plugin_api",
         ":segmentation",
         ":segments",
+        ":utf8_util",
     ],
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,9 @@ add_library(OpenCC::OpenCC ALIAS libopencc)
 set_target_properties(libopencc PROPERTIES POSITION_INDEPENDENT_CODE ON)
 source_group(libopencc FILES ${LIBOPENCC_SOURCES} ${LIBOPENCC_HEADERS})
 target_link_libraries(libopencc marisa)
+if (NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(libopencc PUBLIC Opencc_BUILT_AS_STATIC)
+endif()
 # PluginSegmentation.cpp uses LoadLibrary on _WIN32 (MSVC and MinGW).
 # Only non-Windows targets may need libdl for dlopen.
 if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -21,6 +21,7 @@
 #include "Exception.hpp"
 #include "Segmentation.hpp"
 #include "Segments.hpp"
+#include "UTF8Util.hpp"
 #include "plugin/OpenCCPlugin.h"
 
 #include <cstddef>
@@ -214,15 +215,15 @@ private:
 
 struct PluginLibrary {
   std::shared_ptr<SharedLibrary> library;
-  const opencc_segmentation_plugin_v1* descriptor = nullptr;
+  const opencc_segmentation_plugin_v2* descriptor = nullptr;
 };
 
 size_t RequiredDescriptorSize() {
-  return offsetof(opencc_segmentation_plugin_v1, free_error) +
-         sizeof(((opencc_segmentation_plugin_v1*)nullptr)->free_error);
+  return offsetof(opencc_segmentation_plugin_v2, free_error) +
+         sizeof(((opencc_segmentation_plugin_v2*)nullptr)->free_error);
 }
 
-std::string TakeErrorMessage(const opencc_segmentation_plugin_v1* descriptor,
+std::string TakeErrorMessage(const opencc_segmentation_plugin_v2* descriptor,
                              opencc_error_t* error,
                              const std::string& fallback) {
   if (error == nullptr) {
@@ -236,7 +237,7 @@ std::string TakeErrorMessage(const opencc_segmentation_plugin_v1* descriptor,
   return message;
 }
 
-[[noreturn]] void ThrowPluginError(const opencc_segmentation_plugin_v1* descriptor,
+[[noreturn]] void ThrowPluginError(const opencc_segmentation_plugin_v2* descriptor,
                                    opencc_error_t* error,
                                    const std::string& pluginType,
                                    const std::string& fallbackPrefix,
@@ -244,6 +245,43 @@ std::string TakeErrorMessage(const opencc_segmentation_plugin_v1* descriptor,
   const std::string message =
       TakeErrorMessage(descriptor, error, fallbackMessage);
   throw Exception(fallbackPrefix + " '" + pluginType + "': " + message);
+}
+
+SegmentsPtr BuildSegmentsFromLengths(const std::string& text,
+                                     const opencc_segment_length_array_t& lengths) {
+  SegmentsPtr segments(new Segments);
+  const char* bytes = text.c_str();
+  const size_t inputSize = std::strlen(bytes);
+  size_t byteOffset = 0;
+
+  for (size_t i = 0; i < lengths.segment_count; i++) {
+    const uint32_t codepointLength = lengths.codepoint_lengths[i];
+    if (codepointLength == 0) {
+      throw Exception("Segmentation plugin returned a zero-length segment.");
+    }
+
+    const size_t segmentStart = byteOffset;
+    for (uint32_t j = 0; j < codepointLength; j++) {
+      if (byteOffset >= inputSize) {
+        throw Exception("Segmentation plugin returned lengths past end of input.");
+      }
+      const size_t charLength = UTF8Util::NextCharLengthNoException(bytes + byteOffset);
+      if (charLength == 0 || byteOffset + charLength > inputSize) {
+        throw Exception("Input text is not valid UTF-8.");
+      }
+      byteOffset += charLength;
+    }
+
+    segments->AddSegment(text.substr(segmentStart, byteOffset - segmentStart));
+  }
+
+  if (byteOffset != inputSize) {
+    throw Exception("Segmentation plugin lengths do not cover the full input. "
+                    "Consumed bytes: " + std::to_string(byteOffset) +
+                    ", total bytes: " + std::to_string(inputSize) +
+                    ", segments: " + std::to_string(lengths.segment_count) + ".");
+  }
+  return segments;
 }
 
 class PluginSegmentationAdapter : public Segmentation {
@@ -260,35 +298,30 @@ public:
   }
 
   SegmentsPtr Segment(const std::string& text) const override {
-    opencc_token_array_t tokenArray = {};
-    tokenArray.struct_size = sizeof(tokenArray);
+    opencc_segment_length_array_t segmentLengths = {};
+    segmentLengths.struct_size = sizeof(segmentLengths);
     opencc_error_t error = {};
     error.struct_size = sizeof(error);
     opencc_segmentation_segment_args_t args = {};
     args.struct_size = sizeof(args);
     args.handle = handle_;
     args.utf8_text = text.c_str();
-    args.token_array = &tokenArray;
+    args.segment_lengths = &segmentLengths;
     args.error = &error;
     const int status = plugin_->descriptor->segment(&args);
 
-    struct TokenGuard {
-      const opencc_segmentation_plugin_v1* desc;
-      opencc_token_array_t* arr;
-      ~TokenGuard() { desc->free_tokens(arr); }
-    } guard{plugin_->descriptor, &tokenArray};
+    struct SegmentLengthGuard {
+      const opencc_segmentation_plugin_v2* desc;
+      opencc_segment_length_array_t* arr;
+      ~SegmentLengthGuard() { desc->free_segment_lengths(arr); }
+    } guard{plugin_->descriptor, &segmentLengths};
 
     if (status != 0) {
       ThrowPluginError(plugin_->descriptor, &error,
                        plugin_->descriptor->segmentation_type,
                        "Segmentation plugin failed", "unknown error");
     }
-
-    SegmentsPtr segments(new Segments);
-    for (size_t i = 0; i < tokenArray.token_count; i++) {
-      segments->AddSegment(std::string(tokenArray.tokens[i]));
-    }
-    return segments;
+    return BuildSegmentsFromLengths(text, segmentLengths);
   }
 
 private:
@@ -382,10 +415,10 @@ private:
   static std::shared_ptr<PluginLibrary> LoadFromPath(const std::string& path,
                                                      const std::string& type) {
     std::shared_ptr<SharedLibrary> library(new SharedLibrary(path));
-    typedef const opencc_segmentation_plugin_v1* (*EntryPoint)(void);
+    typedef const opencc_segmentation_plugin_v2* (*EntryPoint)(void);
     EntryPoint entryPoint = reinterpret_cast<EntryPoint>(
-        library->FindSymbol("opencc_get_segmentation_plugin_v1"));
-    const opencc_segmentation_plugin_v1* descriptor = entryPoint();
+        library->FindSymbol("opencc_get_segmentation_plugin_v2"));
+    const opencc_segmentation_plugin_v2* descriptor = entryPoint();
     if (descriptor == nullptr) {
       throw Exception("Plugin returned null descriptor.");
     }

--- a/src/plugin/OpenCCPlugin.h
+++ b/src/plugin/OpenCCPlugin.h
@@ -27,7 +27,7 @@ extern "C" {
  *   Implementations must ignore unknown trailing fields.
  */
 
-#define OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR 1
+#define OPENCC_SEGMENTATION_PLUGIN_ABI_MAJOR 2
 #define OPENCC_SEGMENTATION_PLUGIN_ABI_MINOR 0
 
 enum {
@@ -66,9 +66,13 @@ typedef struct {
 
 typedef struct {
   size_t struct_size;
-  char** tokens;
-  size_t token_count;
-} opencc_token_array_t;
+  /*
+   * One positive length per segment, measured in Unicode code points.
+   * The sequence must cover the full input text in order.
+   */
+  uint32_t* codepoint_lengths;
+  size_t segment_count;
+} opencc_segment_length_array_t;
 
 typedef struct {
   size_t struct_size;
@@ -82,7 +86,7 @@ typedef struct {
   size_t struct_size;
   opencc_segmentation_handle_t* handle;
   const char* utf8_text;
-  opencc_token_array_t* token_array;
+  opencc_segment_length_array_t* segment_lengths;
   opencc_error_t* error;
 } opencc_segmentation_segment_args_t;
 
@@ -138,28 +142,35 @@ typedef struct {
    * segment(args):
    * On success:
    * - returns 0
-   * - token_array contains plugin-owned token storage until free_tokens() is called.
+   * - args->utf8_text is interpreted as null-terminated UTF-8 input
+   * - segment_lengths contains plugin-owned segment length storage until
+   *   free_segment_lengths() is called.
+   * - each returned length must be > 0 and measured in Unicode code points
+   * - the returned length sequence must cover the full input in order
    *
    * On failure:
    * - returns non-zero
-   * - token_array may be partially populated, but must remain safe for free_tokens().
+   * - segment_lengths may be partially populated, but must remain safe for
+   *   free_segment_lengths().
    */
   int (*segment)(opencc_segmentation_segment_args_t* args);
 
   /*
    * Cleanup Functions:
-   * 1. Must gracefully handle null pointers (count = 0, tokens = null).
+   * 1. Must gracefully handle null pointers
+   *    (segment_count = 0, codepoint_lengths = null).
    * 2. Host promises to call these at most once per returned object.
-   * 3. free_tokens() must also accept token_array structures that were
+   * 3. free_segment_lengths() must also accept segment length array
+   *    structures that were
    *    partially initialized by segment() on failure.
    */
-  void (*free_tokens)(opencc_token_array_t* token_array);
+  void (*free_segment_lengths)(opencc_segment_length_array_t* segment_lengths);
   void (*destroy)(opencc_segmentation_handle_t* handle);
   void (*free_error)(opencc_error_t* error);
-} opencc_segmentation_plugin_v1;
+} opencc_segmentation_plugin_v2;
 
-OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v1*
-opencc_get_segmentation_plugin_v1(void);
+OPENCC_PLUGIN_EXPORT const opencc_segmentation_plugin_v2*
+opencc_get_segmentation_plugin_v2(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Update the segmentation plugin ABI entry point to:

- `opencc_get_segmentation_plugin_v2()`

Segmentation results are returned as a sequence of segment lengths measured in
Unicode code points, not as copied token strings. The ABI contract is:

- input text is passed to the plugin as null-terminated UTF-8
- the plugin returns `segment_count` plus `codepoint_lengths`
- each element is the number of Unicode code points in the next segment
- lengths must be positive and must cover the full input, in order
- the host reconstructs segment boundaries from the original UTF-8 input

This keeps the ABI simpler and avoids allocating one string per token across
the plugin boundary.