### PR TITLE
Remove `apt upgrade` from Linux PyPI build

### DIFF
--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -12,7 +12,6 @@ set -e
 # Download dependenciess
 export DEBIAN_FRONTEND=noninteractive
 apt update
-apt upgrade -y
 apt install -y g++ make curl
 
 cd /opt/OpenCC


### PR DESCRIPTION
The Docker-based Linux packaging job already starts from a fresh Ubuntu image and only needs apt update plus installation of the specific build tools it uses. Running a full system upgrade adds extra network and package-management work, increases CI time, and introduces avoidable variability without improving the wheel build itself. This change keeps the environment setup leaner and should reduce the runtime of the Build package and upload from docker step in the Python workflow.