### PR TITLE
Fix Node.js TypeScript declaration exports

### DIFF
--- a/node/opencc.d.ts
+++ b/node/opencc.d.ts
@@ -1,9 +1,10 @@
 declare class OpenCC {
-  constructor(config: string);
-  version(): string;
-  generateDict(inputFileName: string, outputFileName: string, formatFrom: string, formatTo: string): void;
-  convert(input: string, callback: (err: string, convertedText: string) => void): string;
+  constructor(config?: string);
+  static readonly version: string;
+  static generateDict(inputFileName: string, outputFileName: string, formatFrom: string, formatTo: string): void;
+  convert(input: string, callback: (err: string | undefined, convertedText: string) => void): void;
   convertSync(input: string): string;
   convertPromise(input: string): Promise<string>;
 }
 export { OpenCC };
+export default OpenCC;

--- a/node/opencc.d.ts
+++ b/node/opencc.d.ts
@@ -7,4 +7,3 @@ declare class OpenCC {
   convertPromise(input: string): Promise<string>;
 }
 export { OpenCC };
-export default OpenCC;


### PR DESCRIPTION
- Update `node/opencc.d.ts` to accurately describe the CommonJS export shape.
- Mark `constructor(config?: string)`.
- Move `version` and `generateDict` to static members.
- Correct `callback` error typing and return type.