### PR TITLE
Declare Node.js package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "license": "Apache-2.0",
   "main": "node/opencc.js",
   "types": "node/opencc.d.ts",
+  "exports": {
+    ".": {
+      "types": "./node/opencc.d.ts",
+      "require": "./node/opencc.js",
+      "default": "./node/opencc.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha -R spec node/test.js",
     "deploy": "node-pre-gyp package && (node-pre-gyp-github publish --release || exit 0)",


### PR DESCRIPTION
Add an explicit exports map for the package root and package metadata so modern Node.js resolution has a stable public surface.

Scope this to the existing CommonJS entry point and TypeScript declarations. This does not add an ESM wrapper, change the runtime API, or expose any WASM entry point.

Verified require('opencc'), require('opencc/package.json'), Node ESM default import, and npm test.