### PR TITLE
Add conditional ESM entrypoint for Node package

### DIFF
--- a/node/esm-test.mjs
+++ b/node/esm-test.mjs
@@ -1,0 +1,12 @@
+import OpenCCDefault, { OpenCC } from './opencc.mjs';
+
+if (OpenCCDefault !== OpenCC) {
+  throw new Error('ESM default export does not match named OpenCC export');
+}
+
+const converter = new OpenCC('s2t.json');
+const result = await converter.convertPromise('汉字');
+
+if (result !== '漢字') {
+  throw new Error(`Unexpected ESM conversion result: ${result}`);
+}

--- a/node/opencc.d.cts
+++ b/node/opencc.d.cts
@@ -1,0 +1,14 @@
+declare class OpenCC {
+  constructor(config?: string);
+  static readonly version: string;
+  static generateDict(inputFileName: string, outputFileName: string, formatFrom: string, formatTo: string): void;
+  convert(input: string, callback: (err: string | undefined, convertedText: string) => void): void;
+  convertSync(input: string): string;
+  convertPromise(input: string): Promise<string>;
+}
+
+declare namespace OpenCC {
+  export { OpenCC };
+}
+
+export = OpenCC;

--- a/node/opencc.d.mts
+++ b/node/opencc.d.mts
@@ -1,0 +1,10 @@
+declare class OpenCC {
+  constructor(config?: string);
+  static readonly version: string;
+  static generateDict(inputFileName: string, outputFileName: string, formatFrom: string, formatTo: string): void;
+  convert(input: string, callback: (err: string | undefined, convertedText: string) => void): void;
+  convertSync(input: string): string;
+  convertPromise(input: string): Promise<string>;
+}
+export { OpenCC };
+export default OpenCC;

--- a/node/opencc.mjs
+++ b/node/opencc.mjs
@@ -1,0 +1,4 @@
+import OpenCC from './opencc.js';
+
+export { OpenCC };
+export default OpenCC;

--- a/package.json
+++ b/package.json
@@ -8,14 +8,20 @@
   "types": "node/opencc.d.ts",
   "exports": {
     ".": {
-      "types": "./node/opencc.d.ts",
-      "require": "./node/opencc.js",
+      "import": {
+        "types": "./node/opencc.d.mts",
+        "default": "./node/opencc.mjs"
+      },
+      "require": {
+        "types": "./node/opencc.d.cts",
+        "default": "./node/opencc.js"
+      },
       "default": "./node/opencc.js"
     },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "test": "mocha -R spec node/test.js",
+    "test": "mocha -R spec node/test.js && node node/esm-test.mjs",
     "prebuild": "prebuildify --napi --strip --postinstall \"node scripts/prepare-node-prebuild-artifacts.js\"",
     "install": "node-gyp-build"
   },


### PR DESCRIPTION
Expose node/opencc.mjs through the package exports import condition so ESM consumers can use both default and named OpenCC imports without relying on CommonJS interop. Example:

```
import OpenCC from 'opencc';
```

Add separate .d.mts and .d.cts declarations for ESM and CommonJS consumers, while keeping the existing CommonJS require path backed by node/opencc.js.

Extend npm test with an ESM smoke test that verifies the default and named exports resolve to the same constructor and can run a conversion.