### PR TITLE
Add npm CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ The npm package supports Node.js `>=20.17 <26`. It uses bundled Node-API
 prebuilds when available and falls back to a local `node-gyp` build when the
 current platform does not have a matching prebuild.
 
+To install the npm CLI:
+
+```sh
+npm install -g opencc
+opencc -c s2t.json -i input.txt -o output.txt
+```
+
+The npm CLI supports basic text conversion. Plugins, `--inspect`, and
+`--segmentation` require the native OpenCC CLI.
+
 ```ts
 import { OpenCC } from 'opencc';
 async function main() {

--- a/node/cli.js
+++ b/node/cli.js
@@ -20,6 +20,7 @@ const BUILT_IN_CONFIGS = [
   ['t2jp.json', 'Traditional Chinese Characters (Kyujitai) to New Japanese Kanji (Shinjitai)'],
   ['jp2t.json', 'New Japanese Kanji (Shinjitai) to Traditional Chinese Characters (Kyujitai) (OpenCC Standard)'],
 ];
+const BUILT_IN_CONFIG_NAMES = new Set(BUILT_IN_CONFIGS.map(([name]) => name));
 
 function printHelp() {
   console.log(`Open Chinese Convert (OpenCC) npm Command Line Tool
@@ -57,6 +58,14 @@ function readOptionValue(args, index, option) {
   return value;
 }
 
+function readInlineOptionValue(arg, option) {
+  const value = arg.slice((option + '=').length);
+  if (!value) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
 function parseArgs(args) {
   const options = {
     config: 's2t.json',
@@ -76,17 +85,17 @@ function parseArgs(args) {
       options.config = readOptionValue(args, i, arg);
       i += 1;
     } else if (arg.startsWith('--config=')) {
-      options.config = arg.slice('--config='.length);
+      options.config = readInlineOptionValue(arg, '--config');
     } else if (arg === '-i' || arg === '--input') {
       options.input = readOptionValue(args, i, arg);
       i += 1;
     } else if (arg.startsWith('--input=')) {
-      options.input = arg.slice('--input='.length);
+      options.input = readInlineOptionValue(arg, '--input');
     } else if (arg === '-o' || arg === '--output') {
       options.output = readOptionValue(args, i, arg);
       i += 1;
     } else if (arg.startsWith('--output=')) {
-      options.output = arg.slice('--output='.length);
+      options.output = readInlineOptionValue(arg, '--output');
     } else if (arg === '--inspect' || arg === '--segmentation') {
       throw new Error(`${arg} is not supported by the npm CLI. Use the native OpenCC CLI instead.`);
     } else if (arg === '--path' || arg.startsWith('--path=')) {
@@ -116,6 +125,13 @@ function writeOutput(outputFileName, text) {
   }
 }
 
+function resolveConfigPath(config) {
+  if (BUILT_IN_CONFIG_NAMES.has(config) || path.isAbsolute(config)) {
+    return config;
+  }
+  return path.resolve(process.cwd(), config);
+}
+
 function main() {
   let options;
   try {
@@ -136,7 +152,7 @@ function main() {
   }
 
   try {
-    const converter = new OpenCC(options.config);
+    const converter = new OpenCC(resolveConfigPath(options.config));
     const input = readInput(options.input);
     const output = converter.convertSync(input);
     writeOutput(options.output, output);

--- a/node/cli.js
+++ b/node/cli.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const OpenCC = require('./opencc');
+
+const BUILT_IN_CONFIGS = [
+  ['s2t.json', 'Simplified Chinese to Traditional Chinese'],
+  ['t2s.json', 'Traditional Chinese to Simplified Chinese'],
+  ['s2tw.json', 'Simplified Chinese to Traditional Chinese (Taiwan Standard)'],
+  ['tw2s.json', 'Traditional Chinese (Taiwan Standard) to Simplified Chinese'],
+  ['s2hk.json', 'Simplified Chinese to Traditional Chinese (Hong Kong variant)'],
+  ['hk2s.json', 'Traditional Chinese (Hong Kong variant) to Simplified Chinese'],
+  ['s2twp.json', 'Simplified Chinese to Traditional Chinese (Taiwan Standard) with Taiwanese idiom'],
+  ['tw2sp.json', 'Traditional Chinese (Taiwan Standard) to Simplified Chinese with Mainland Chinese idiom'],
+  ['tw2t.json', 'Traditional Chinese (Taiwan Standard) to Traditional Chinese (OpenCC Standard)'],
+  ['t2tw.json', 'Traditional Chinese (OpenCC Standard) to Taiwan Standard'],
+  ['hk2t.json', 'Traditional Chinese (Hong Kong variant) to Traditional Chinese (OpenCC Standard)'],
+  ['t2hk.json', 'Traditional Chinese (OpenCC Standard) to Hong Kong variant'],
+  ['t2jp.json', 'Traditional Chinese Characters (Kyujitai) to New Japanese Kanji (Shinjitai)'],
+  ['jp2t.json', 'New Japanese Kanji (Shinjitai) to Traditional Chinese Characters (Kyujitai) (OpenCC Standard)'],
+];
+
+function printHelp() {
+  console.log(`Open Chinese Convert (OpenCC) npm Command Line Tool
+
+Usage:
+  opencc [options]
+
+Options:
+  -c, --config <file>  Configuration file. Defaults to s2t.json.
+  -i, --input <file>   Read original text from <file>. Defaults to stdin.
+  -o, --output <file>  Write converted text to <file>. Defaults to stdout.
+  -v, --version        Print OpenCC version.
+  -h, --help           Print this help.
+
+Unsupported in the npm CLI:
+  --inspect            Use the native OpenCC CLI for inspection output.
+  --segmentation       Use the native OpenCC CLI for segmentation output.
+  plugins              Plugin-backed segmentation is not supported by this npm CLI.
+
+Built-in Configurations:
+${BUILT_IN_CONFIGS.map(([name, description]) => `  ${name.padEnd(11)} ${description}`).join('\n')}
+`);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function readOptionValue(args, index, option) {
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function parseArgs(args) {
+  const options = {
+    config: 's2t.json',
+    input: null,
+    output: null,
+    help: false,
+    version: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-h' || arg === '--help') {
+      options.help = true;
+    } else if (arg === '-v' || arg === '--version') {
+      options.version = true;
+    } else if (arg === '-c' || arg === '--config') {
+      options.config = readOptionValue(args, i, arg);
+      i += 1;
+    } else if (arg.startsWith('--config=')) {
+      options.config = arg.slice('--config='.length);
+    } else if (arg === '-i' || arg === '--input') {
+      options.input = readOptionValue(args, i, arg);
+      i += 1;
+    } else if (arg.startsWith('--input=')) {
+      options.input = arg.slice('--input='.length);
+    } else if (arg === '-o' || arg === '--output') {
+      options.output = readOptionValue(args, i, arg);
+      i += 1;
+    } else if (arg.startsWith('--output=')) {
+      options.output = arg.slice('--output='.length);
+    } else if (arg === '--inspect' || arg === '--segmentation') {
+      throw new Error(`${arg} is not supported by the npm CLI. Use the native OpenCC CLI instead.`);
+    } else if (arg === '--path' || arg.startsWith('--path=')) {
+      throw new Error('--path is not supported by the npm CLI. Pass an explicit config file path instead.');
+    } else if (arg === '--noflush' || arg === '--measured_result' || arg.startsWith('--measured_result=')) {
+      throw new Error(`${arg.split('=')[0]} is not supported by the npm CLI.`);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readInput(inputFileName) {
+  if (inputFileName) {
+    return fs.readFileSync(inputFileName, 'utf8');
+  }
+  return fs.readFileSync(0, 'utf8');
+}
+
+function writeOutput(outputFileName, text) {
+  if (outputFileName) {
+    fs.writeFileSync(outputFileName, text, 'utf8');
+  } else {
+    process.stdout.write(text);
+  }
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    fail(error.message);
+    return;
+  }
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  if (options.version) {
+    console.log(OpenCC.version);
+    return;
+  }
+
+  try {
+    const converter = new OpenCC(options.config);
+    const input = readInput(options.input);
+    const output = converter.convertSync(input);
+    writeOutput(options.output, output);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    fail(path.basename(process.argv[1]) + ': ' + message);
+  }
+}
+
+main();

--- a/node/test.js
+++ b/node/test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
+const childProcess = require('child_process');
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const util = require('util');
 
 const OpenCC = require('./opencc');
@@ -55,5 +58,71 @@ describe('Async Promise API', function () {
         testAsyncPromise(tc, cfg, expected).then(() => done(), done);
       });
     });
+  });
+});
+
+describe('npm CLI', function () {
+  const cli = path.join(__dirname, 'cli.js');
+
+  it('converts stdin to stdout', function () {
+    const result = childProcess.spawnSync(process.execPath, [cli, '-c', 's2t.json'], {
+      input: '汉字',
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, '漢字');
+  });
+
+  it('converts input file to output file', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-'));
+    const input = path.join(dir, 'input.txt');
+    const output = path.join(dir, 'output.txt');
+    fs.writeFileSync(input, '汉字', 'utf8');
+    const result = childProcess.spawnSync(process.execPath, [
+      cli,
+      '--config=s2t.json',
+      '--input',
+      input,
+      '--output',
+      output,
+    ], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(output, 'utf8'), '漢字');
+  });
+
+  it('prints help', function () {
+    const result = childProcess.spawnSync(process.execPath, [cli, '--help'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /Unsupported in the npm CLI:/);
+    assert.match(result.stdout, /--inspect/);
+    assert.match(result.stdout, /--segmentation/);
+    assert.match(result.stdout, /plugins/);
+  });
+
+  it('prints version', function () {
+    const result = childProcess.spawnSync(process.execPath, [cli, '--version'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), OpenCC.version);
+  });
+
+  it('rejects unsupported diagnostic modes', function () {
+    const inspect = childProcess.spawnSync(process.execPath, [cli, '--inspect'], {
+      encoding: 'utf8',
+    });
+    assert.notEqual(inspect.status, 0);
+    assert.match(inspect.stderr, /not supported/);
+
+    const segmentation = childProcess.spawnSync(process.execPath, [cli, '--segmentation'], {
+      encoding: 'utf8',
+    });
+    assert.notEqual(segmentation.status, 0);
+    assert.match(segmentation.stderr, /not supported/);
   });
 });

--- a/node/test.js
+++ b/node/test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const childProcess = require('child_process');
 const fs = require('fs');
+const nodeGypBuild = require('node-gyp-build');
 const os = require('os');
 const path = require('path');
 const util = require('util');
@@ -64,6 +65,19 @@ describe('Async Promise API', function () {
 describe('npm CLI', function () {
   const cli = path.join(__dirname, 'cli.js');
 
+  function getAssetsPath() {
+    const bindingPath = nodeGypBuild.path(path.join(__dirname, '..'));
+    const bindingDir = path.dirname(bindingPath);
+    const prebuildsDir = path.dirname(bindingDir);
+    if (path.basename(prebuildsDir) === 'prebuilds') {
+      const sharedAssetsPath = path.join(prebuildsDir, 'assets');
+      if (fs.existsSync(sharedAssetsPath)) {
+        return sharedAssetsPath;
+      }
+    }
+    return bindingDir;
+  }
+
   it('converts stdin to stdout', function () {
     const result = childProcess.spawnSync(process.execPath, [cli, '-c', 's2t.json'], {
       input: '汉字',
@@ -90,6 +104,22 @@ describe('npm CLI', function () {
     });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(fs.readFileSync(output, 'utf8'), '漢字');
+  });
+
+  it('resolves custom relative config paths from cwd', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-config-'));
+    const assetsPath = getAssetsPath();
+    fs.copyFileSync(path.join(assetsPath, 's2t.json'), path.join(dir, 'custom-s2t.json'));
+    fs.copyFileSync(path.join(assetsPath, 'STPhrases.ocd2'), path.join(dir, 'STPhrases.ocd2'));
+    fs.copyFileSync(path.join(assetsPath, 'STCharacters.ocd2'), path.join(dir, 'STCharacters.ocd2'));
+
+    const result = childProcess.spawnSync(process.execPath, [cli, '-c', './custom-s2t.json'], {
+      cwd: dir,
+      input: '汉字',
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, '漢字');
   });
 
   it('prints help', function () {
@@ -124,5 +154,16 @@ describe('npm CLI', function () {
     });
     assert.notEqual(segmentation.status, 0);
     assert.match(segmentation.stderr, /not supported/);
+  });
+
+  it('rejects empty inline option values', function () {
+    for (const option of ['--config=', '--input=', '--output=']) {
+      const result = childProcess.spawnSync(process.execPath, [cli, option], {
+        input: '汉字',
+        encoding: 'utf8',
+      });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /Missing value/);
+    }
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "node-gyp": "^12.3.0",
         "node-gyp-build": "^4.8.4"
       },
+      "bin": {
+        "opencc": "node/cli.js"
+      },
       "devDependencies": {
         "mocha": "^11.7.5",
         "prebuildify": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "Apache-2.0",
   "main": "node/opencc.js",
   "types": "node/opencc.d.ts",
+  "bin": {
+    "opencc": "./node/cli.js"
+  },
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Expose a package bin named opencc that provides basic text conversion through the existing Node.js binding without changing the native addon API.

Support stdin/stdout, input and output files, config selection, help, and version output. Explicitly reject unsupported diagnostic/plugin features such as --inspect, --segmentation, --path, and measured results.

Document the global npm CLI usage and add smoke tests for conversion, help, version, and unsupported modes.