### PR TITLE
feat(node): make jieba plugin a standalone and deterministic NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /.mypy_cache
 /bazel-*
 /build
-/plugins/*/build
 /other
 /doc/html
 /dist
@@ -16,6 +15,6 @@
 /test/dict.bin
 /xcode
 /node_modules
-/prebuilds
+prebuilds/
 /*.egg-info
 /.venv/

--- a/node/opencc.cc
+++ b/node/opencc.cc
@@ -55,6 +55,21 @@ public:
   explicit OpenccBinding(const Napi::CallbackInfo& info)
       : Napi::ObjectWrap<OpenccBinding>(info), config_(), converter_() {
     Napi::Env env = info.Env();
+
+    if (info.Length() >= 2 && info[0].IsString() && info[1].IsString()) {
+      // Two-argument mode: NewFromString(jsonString, configDirectory)
+      // Used by the JS layer to pass patched JSON with absolute paths.
+      const std::string json = ToUtf8String(info[0]);
+      const std::string configDir = ToUtf8String(info[1]);
+      try {
+        converter_ = config_.NewFromString(json, configDir);
+      } catch (opencc::Exception& e) {
+        Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+      }
+      return;
+    }
+
+    // Single-argument mode: NewFromFile(configFilePath)
     std::string configFile = "s2t.json";
     if (info.Length() >= 1) {
       if (!info[0].IsString()) {

--- a/node/opencc.js
+++ b/node/opencc.js
@@ -44,6 +44,15 @@ const getAssetsPath = function (bindingPath) {
   return bindingDir;
 };
 
+// Detect optional opencc-jieba plugin package.
+// When installed, jieba-based configs (e.g. s2twp_jieba.json) become available.
+let jiebaInfo = null;
+try {
+  jiebaInfo = require('opencc-jieba');
+} catch (e) {
+  // opencc-jieba not installed — jieba configs won't be available.
+}
+
 const assetsPath = getAssetsPath(bindingPath);
 const getConfigPath = function (config) {
   let configPath = config;
@@ -53,6 +62,55 @@ const getConfigPath = function (config) {
   }
   return configPath;
 };
+
+/**
+ * Recursively resolve all dict "file" paths in a config object to absolute
+ * paths under the given base directory.
+ * @param {Object} dict - A dict node from the config JSON.
+ * @param {string} baseDir - Directory to resolve relative paths against.
+ */
+function patchDictPaths(dict, baseDir) {
+  if (!dict) return;
+  if (dict.type === 'group' && Array.isArray(dict.dicts)) {
+    for (const d of dict.dicts) {
+      patchDictPaths(d, baseDir);
+    }
+  } else if (dict.file && !path.isAbsolute(dict.file)) {
+    dict.file = path.join(baseDir, dict.file);
+  }
+}
+
+/**
+ * Patch all relative paths in a config JSON object to absolute paths.
+ *
+ * - segmentation resources + __plugin_library → jieba package
+ * - conversion_chain dict files → main opencc package assets
+ *
+ * @param {Object} config - Parsed config JSON object (modified in-place).
+ * @param {Object} jieba - Info from the opencc-jieba package.
+ * @param {string} mainAssetsDir - Main opencc package assets directory.
+ */
+function patchConfigPaths(config, jieba, mainAssetsDir) {
+  // Inject explicit plugin library path (skips dlopen search in C++)
+  if (config.segmentation) {
+    config.segmentation.__plugin_library = jieba.pluginLibrary;
+    // Absolutify segmentation resource paths (dict_path, model_path, etc.)
+    if (config.segmentation.resources) {
+      const res = config.segmentation.resources;
+      for (const key of Object.keys(res)) {
+        if (!path.isAbsolute(res[key])) {
+          res[key] = path.join(jieba.dataDir, res[key]);
+        }
+      }
+    }
+  }
+  // Absolutify conversion_chain dict file paths
+  if (Array.isArray(config.conversion_chain)) {
+    for (const step of config.conversion_chain) {
+      patchDictPaths(step.dict, mainAssetsDir);
+    }
+  }
+}
 
 /**
  * OpenCC Node.js API
@@ -65,6 +123,23 @@ const OpenCC = module.exports = function (config) {
   if (!config) {
     config = 's2t.json';
   }
+
+  // When opencc-jieba is installed, check if the requested config is a jieba
+  // config. If so, load its JSON, patch all paths to absolute, and pass the
+  // patched JSON string directly to the C++ layer via NewFromString.
+  if (jiebaInfo && config[0] !== '/' && config[1] !== ':') {
+    const jiebaConfigPath = path.join(jiebaInfo.dataDir, config);
+    if (fs.existsSync(jiebaConfigPath)) {
+      const raw = JSON.parse(fs.readFileSync(jiebaConfigPath, 'utf-8'));
+      patchConfigPaths(raw, jiebaInfo, assetsPath);
+      this.handler = new binding.Opencc(
+        JSON.stringify(raw),
+        jiebaInfo.dataDir + '/'
+      );
+      return;
+    }
+  }
+
   config = getConfigPath(config);
   this.handler = new binding.Opencc(config);
 };

--- a/plugins/jieba/BUILD.bazel
+++ b/plugins/jieba/BUILD.bazel
@@ -33,6 +33,10 @@ cc_binary(
     ],
     defines = ["OPENCC_PLUGIN_BUILD"],
     includes = ["include"],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-S"],
+        "//conditions:default": ["-Wl,-s"],
+    }),
     linkshared = True,
     deps = [
         "//plugins/jieba/deps/cppjieba:cppjieba",

--- a/plugins/jieba/BUILD.bazel
+++ b/plugins/jieba/BUILD.bazel
@@ -35,6 +35,7 @@ cc_binary(
     includes = ["include"],
     linkopts = select({
         "@platforms//os:macos": ["-Wl,-S"],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-Wl,-s"],
     }),
     linkshared = True,

--- a/plugins/jieba/node/.gitignore
+++ b/plugins/jieba/node/.gitignore
@@ -1,0 +1,2 @@
+prebuilds/
+data/

--- a/plugins/jieba/node/.npmignore
+++ b/plugins/jieba/node/.npmignore
@@ -1,0 +1,2 @@
+NPM_PACKAGE_DESIGN.md
+build.js

--- a/plugins/jieba/node/NPM_PACKAGE_DESIGN.md
+++ b/plugins/jieba/node/NPM_PACKAGE_DESIGN.md
@@ -1,0 +1,60 @@
+# opencc-jieba Node.js Architecture & Engineering Design
+
+> This document details the architectural improvements and engineering updates for the `opencc-jieba` Node.js package.
+
+## 1. Background and Objectives
+
+Integrating the Jieba segmentation plugin into Node.js previously faced two major pain points:
+1. **Environment Variable Dependency**: The C++ core library relied on environment variables (like `OPENCC_SEGMENTATION_PLUGIN_PATH` and `OPENCC_DATA_DIR`) to locate dynamic libraries and dictionary files. This approach is prone to global pollution and is unsuitable for an independent NPM module.
+2. **Binary Artifact Management**: Committing large cross-platform build artifacts (`.dylib`, `.so`, `.dll`) and dictionary data directly into the Git repository causes uncontrollable repository bloat and severe merge conflicts during CI workflows and collaborative development.
+
+To resolve these issues, we refactored `opencc-jieba` into a **fully self-contained, deterministic, and artifact-free** modern NPM package.
+
+---
+
+## 2. Core Architectural Changes
+
+### 2.1 Deterministic Plugin Loading via Absolute Paths
+
+**[C++ Core Updates: `src/PluginSegmentation.cpp`]**
+To eliminate reliance on environment variables, we introduced a precise loading entry point in the C++ `PluginManager`: `LoadByPath(const std::string& path, ...)`.
+Simultaneously, when parsing segmentation configurations, the core library now checks for a special parameter named `__plugin_library` within the config pairs:
+```cpp
+// If __plugin_library is specified, bypass the traditional directory search strategy
+std::shared_ptr<PluginLibrary> plugin =
+    pluginLibraryPath.empty()
+        ? GetPluginManager().LoadByType(type)
+        : GetPluginManager().LoadByPath(pluginLibraryPath, type);
+```
+
+**[Node.js Integration]**
+On the Node.js side, `plugins/jieba/node/index.js` now exports the exact absolute paths to the platform-specific dynamic library (`pluginLibrary`) and the data directory (`dataDir`).
+When the upper-level Node.js wrapper (e.g., the `opencc` npm package) parses user-specified JSON configurations, it dynamically injects these **absolute paths** into the `__plugin_library` field. This guarantees 100% stable plugin discovery, completely unaffected by environment variables.
+
+### 2.2 Separation of Artifacts and Source Code
+
+**[Cleaning up Git Tracking: `.gitignore`]**
+By adding `prebuilds/` and `data/` to `plugins/jieba/node/.gitignore`, we completely stopped tracking external dictionary copies and compiled dynamic libraries in the code repository.
+
+**[Automated Directory Tree Restoration: `build.js`]**
+To ensure a seamless NPM publishing experience, we introduced `plugins/jieba/node/build.js`. Before packaging, this script automates the following pipeline:
+1. **Triggering the Build System**: Executes `bazel build //plugins/jieba:opencc-jieba //plugins/jieba:jieba_merged_dict` to compile the native addon and convert dictionaries.
+2. **Collecting Artifacts**:
+   - Extracts the generated dynamic libraries (`.dylib` / `.so` / `.dll`) into `prebuilds/<platform>-<arch>/`.
+   - Copies the upstream raw dictionaries and the compiled `.ocd2` binary dictionary into `data/jieba_dict/`.
+   - Copies segmentation-specific JSON configurations into `data/`.
+
+**[Automated NPM Hooks: `package.json`]**
+We configured `"prepack": "npm run build"` in the `scripts` section of `package.json`. This ensures that whether running `npm pack` locally or `npm publish` in CI, NPM will automatically invoke `build.js` to populate the latest artifact directories. End users running `npm install` simply download the prebuilt package without needing to compile from source or install Bazel.
+
+### 2.3 Highly Optimized Cross-Platform Compilation
+
+Building upon this engineering foundation, we optimized the package size and distribution efficiency:
+1. **Symbol Stripping**: Modified `plugins/jieba/BUILD.bazel` to explicitly add `-Wl,-S` (macOS) and `-Wl,-s` (Linux) linkopts. This ensures that C++ dynamic libraries in Release mode are stripped of redundant debugging symbols.
+2. **Remote Cross-Compilation**: The `build.js` script now accepts CLI arguments to trigger remote compilation (e.g., `--config=linux-arm64-remote`). Coupled with the `--remote_download_toplevel` Bazel flag, developers can seamlessly trigger cross-platform builds via a remote execution cluster and accurately download the artifacts directly into the local packaging directory tree.
+
+---
+
+## 3. Conclusion
+
+Through these refactoring efforts, the development and publishing workflow for `opencc-jieba` is now highly standardized. For contributors, the repository remains clean, and updating code or dictionaries requires only a single command to rebuild and repackage. For end users, the plugin provides a true "plug-and-play" experience, eliminating all elusive bugs caused by environment variable misconfigurations.

--- a/plugins/jieba/node/README.md
+++ b/plugins/jieba/node/README.md
@@ -1,0 +1,43 @@
+# opencc-jieba
+
+Jieba segmentation plugin for OpenCC (Node.js).
+
+This package provides pre-compiled native dynamic libraries (`.dylib`, `.so`, `.dll`) and Jieba dictionary data (`.ocd2`, `.utf8`) to allow [OpenCC](https://github.com/BYVoid/OpenCC) to use the Jieba algorithm for Chinese text segmentation.
+
+By leveraging this standalone NPM package, users do not need to manually install C++ toolchains or configure complex environment variables (such as `OPENCC_SEGMENTATION_PLUGIN_PATH` or `OPENCC_DATA_DIR`). The prebuilt libraries are deterministic and fully self-contained.
+
+## Installation
+
+```sh
+npm install opencc-jieba
+```
+
+> **Note**: This package is intended to be used alongside the `opencc` npm package (`>= 1.3.1`).
+
+## Usage
+
+This package acts as an underlying plugin provider. It exports absolute paths to the cross-platform native binaries and dictionary files, which can then be dynamically injected into the OpenCC configuration.
+
+```javascript
+const openccJieba = require('opencc-jieba');
+
+// Absolute path to the directory containing the dynamic library
+console.log(openccJieba.pluginDir);
+// e.g. ".../node_modules/opencc-jieba/prebuilds/darwin-arm64"
+
+// Absolute path to the specific dynamic library file
+console.log(openccJieba.pluginLibrary);
+// e.g. ".../node_modules/opencc-jieba/prebuilds/darwin-arm64/libopencc-jieba.dylib"
+
+// Absolute path to the data directory containing config JSONs and dictionaries
+console.log(openccJieba.dataDir);
+// e.g. ".../node_modules/opencc-jieba/data"
+```
+
+### Integration with OpenCC
+
+When initializing OpenCC in Node.js, you can supply these paths to override the default search directories, ensuring that the plugin is reliably discovered regardless of the runtime environment.
+
+## License
+
+Apache License 2.0

--- a/plugins/jieba/node/build.js
+++ b/plugins/jieba/node/build.js
@@ -1,0 +1,99 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Go to the repository root
+const rootDir = path.resolve(__dirname, '../../..');
+process.chdir(rootDir);
+
+let platform = os.platform();
+let arch = os.arch();
+let bazelFlags = '-c opt';
+
+// E.g., node build.js linux-arm64
+if (process.argv[2]) {
+  const parts = process.argv[2].split('-');
+  if (parts.length === 2) {
+    platform = parts[0];
+    arch = parts[1];
+    if (platform === 'linux') {
+      const configArch = arch === 'x64' ? 'x86_64' : arch;
+      bazelFlags += ` --config=linux-${configArch}-remote`;
+    }
+  }
+}
+
+// Ensure outputs are downloaded even if config sets minimal
+bazelFlags += ' --remote_download_toplevel';
+
+console.log(`Building native addon and dictionary via Bazel for ${platform}-${arch}...`);
+try {
+  execSync(`bazel build ${bazelFlags} //plugins/jieba:opencc-jieba //plugins/jieba:jieba_merged_dict`, { stdio: 'inherit' });
+} catch (err) {
+  console.error('Bazel build failed.', err);
+  process.exit(1);
+}
+
+// Dynamically resolve exact output paths using cquery
+const libPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:opencc-jieba 2>/dev/null`;
+const libSrcRaw = execSync(libPathCmd, { encoding: 'utf8' }).trim().split('\n').pop();
+const libSrc = path.join(rootDir, libSrcRaw);
+
+const dictPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:jieba_merged_dict 2>/dev/null`;
+const dictSrcRaw = execSync(dictPathCmd, { encoding: 'utf8' }).trim().split('\n').pop();
+const mergedOcd2 = path.join(rootDir, dictSrcRaw);
+
+const prebuildDir = path.join(__dirname, 'prebuilds', `${platform}-${arch}`);
+const dataDir = path.join(__dirname, 'data');
+const jiebaDictDir = path.join(dataDir, 'jieba_dict');
+
+// Create directories
+fs.mkdirSync(prebuildDir, { recursive: true });
+fs.mkdirSync(jiebaDictDir, { recursive: true });
+
+// Determine library name
+const libName = platform === 'win32' ? 'opencc-jieba.dll'
+  : platform === 'darwin' ? 'libopencc-jieba.dylib'
+  : 'libopencc-jieba.so';
+
+function copyForce(src, dest) {
+  if (fs.existsSync(dest)) fs.rmSync(dest, { force: true });
+  fs.copyFileSync(src, dest);
+}
+
+// Copy library
+if (fs.existsSync(libSrc)) {
+  copyForce(libSrc, path.join(prebuildDir, libName));
+  console.log(`Copied ${libName} to prebuilds/${platform}-${arch}/`);
+} else {
+  console.error(`Library not found: ${libSrc}`);
+  process.exit(1);
+}
+
+// Copy config JSON files
+const configSrcDir = path.join(rootDir, 'plugins/jieba/data/config');
+const configs = ['s2twp_jieba.json', 'tw2sp_jieba.json'];
+configs.forEach(config => {
+  copyForce(path.join(configSrcDir, config), path.join(dataDir, config));
+  console.log(`Copied ${config} to data/`);
+});
+
+// Copy generated dictionary file
+if (fs.existsSync(mergedOcd2)) {
+  copyForce(mergedOcd2, path.join(jiebaDictDir, 'jieba_merged.ocd2'));
+  console.log(`Copied jieba_merged.ocd2 to data/jieba_dict/`);
+} else {
+  console.error(`Dictionary not found: ${mergedOcd2}`);
+  process.exit(1);
+}
+
+// Copy cppjieba static dictionary files
+const dictSrcDir = path.join(rootDir, 'plugins/jieba/deps/cppjieba/dict');
+const dictFiles = ['hmm_model.utf8', 'idf.utf8', 'stop_words.utf8'];
+dictFiles.forEach(file => {
+  copyForce(path.join(dictSrcDir, file), path.join(jiebaDictDir, file));
+  console.log(`Copied ${file} to data/jieba_dict/`);
+});
+
+console.log('\nPackage directory tree restored successfully!');

--- a/plugins/jieba/node/build.js
+++ b/plugins/jieba/node/build.js
@@ -36,12 +36,12 @@ try {
 }
 
 // Dynamically resolve exact output paths using cquery
-const libPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:opencc-jieba 2>/dev/null`;
-const libSrcRaw = execSync(libPathCmd, { encoding: 'utf8' }).trim().split('\n').pop();
+const libPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:opencc-jieba`;
+const libSrcRaw = execSync(libPathCmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim().split('\n').pop();
 const libSrc = path.join(rootDir, libSrcRaw);
 
-const dictPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:jieba_merged_dict 2>/dev/null`;
-const dictSrcRaw = execSync(dictPathCmd, { encoding: 'utf8' }).trim().split('\n').pop();
+const dictPathCmd = `bazel cquery ${bazelFlags} --output=files //plugins/jieba:jieba_merged_dict`;
+const dictSrcRaw = execSync(dictPathCmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim().split('\n').pop();
 const mergedOcd2 = path.join(rootDir, dictSrcRaw);
 
 const prebuildDir = path.join(__dirname, 'prebuilds', `${platform}-${arch}`);

--- a/plugins/jieba/node/index.js
+++ b/plugins/jieba/node/index.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const os = require('os');
+
+const platform = os.platform();
+const arch = os.arch();
+const prebuildDir = path.join(__dirname, 'prebuilds', `${platform}-${arch}`);
+
+// Platform-specific plugin library filename
+const libName = platform === 'win32' ? 'opencc-jieba.dll'
+  : platform === 'darwin' ? 'libopencc-jieba.dylib'
+  : 'libopencc-jieba.so';
+
+module.exports = {
+  /** Directory containing the prebuilt libopencc-jieba shared library. */
+  pluginDir: prebuildDir,
+  /** Absolute path to the platform-specific plugin shared library. */
+  pluginLibrary: path.join(prebuildDir, libName),
+  /** Root data directory (config files and jieba_dict/ live here). */
+  dataDir: path.join(__dirname, 'data'),
+};

--- a/plugins/jieba/node/package.json
+++ b/plugins/jieba/node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "opencc-jieba",
+  "version": "1.3.1-beta.0",
+  "description": "Jieba segmentation plugin for OpenCC",
+  "author": "Carbo Kuo and OpenCC contributors",
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "peerDependencies": {
+    "opencc": ">=1.3.1"
+  },
+  "files": [
+    "index.js",
+    "prebuilds",
+    "data"
+  ],
+  "scripts": {
+    "build": "node build.js",
+    "build:all": "npm run build && npm run build linux-x64 && npm run build linux-arm64",
+    "prepack": "npm run build:all"
+  }
+}

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -380,6 +380,24 @@ public:
                     "' not found. Searched: " + attempted.str());
   }
 
+  std::shared_ptr<PluginLibrary> LoadByPath(const std::string& path,
+                                            const std::string& type) {
+    if (IsTruthy(std::getenv("OPENCC_DISABLE_PLUGINS"))) {
+      throw Exception("Segmentation plugin loading is disabled.");
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Use the explicit path as cache key (not type) to avoid collisions
+    // when the same plugin type is loaded from different library paths.
+    auto it = cache_.find(path);
+    if (it != cache_.end()) {
+      return it->second;
+    }
+    std::shared_ptr<PluginLibrary> plugin = LoadFromPath(path, type);
+    cache_[path] = plugin;
+    return plugin;
+  }
+
 private:
   static std::vector<std::string> GetPluginFileNames(const std::string& type) {
 #if defined(_WIN32) || defined(_WIN64)
@@ -454,7 +472,20 @@ PluginManager& GetPluginManager() {
 
 SegmentationPtr CreatePluginSegmentation(const std::string& type,
                                          const PluginConfigPairs& configPairs) {
-  std::shared_ptr<PluginLibrary> plugin = GetPluginManager().LoadByType(type);
+  // Allow explicit plugin library path via __plugin_library config pair,
+  // bypassing search-based discovery (used by language bindings to bundle
+  // plugins as optional packages with deterministic paths).
+  std::string pluginLibraryPath;
+  for (const auto& pair : configPairs) {
+    if (pair.first == "__plugin_library") {
+      pluginLibraryPath = pair.second;
+      break;
+    }
+  }
+  std::shared_ptr<PluginLibrary> plugin =
+      pluginLibraryPath.empty()
+          ? GetPluginManager().LoadByType(type)
+          : GetPluginManager().LoadByPath(pluginLibraryPath, type);
   std::vector<opencc_kv_pair_t> rawConfig;
   rawConfig.reserve(configPairs.size());
   for (const auto& pair : configPairs) {


### PR DESCRIPTION
This commit introduces a major architectural shift to allow the Jieba segmentation plugin to be distributed as an optional, standalone NPM package (`opencc-jieba`) without relying on global environment variables or requiring local C++ compilation.

Key changes:
- Core C++: Support `__plugin_library` key in JSON configuration to load a plugin directly from an absolute path, bypassing traditional directory searches.
- Node Addon (`node/opencc.cc`): Add an overloaded constructor to `Opencc` accepting a raw JSON string and a base config directory.
- Node API (`node/opencc.js`): Optionally load `opencc-jieba`. If available, dynamically patch the Jieba configuration JSON by replacing relative dict paths and the segmentation plugin path with absolute paths from the standalone package.
- Packaging (`plugins/jieba/node`): Introduce `build.js` to cross-compile the Jieba plugin via Bazel and pack prebuilt binaries (`prebuilds/`) and dictionaries (`data/`) into the `opencc-jieba` NPM package for deterministic, zero-configuration installation.
- Build system: Update `plugins/jieba/BUILD.bazel` to correctly strip debugging symbols from the plugin dynamic libraries in release mode to reduce package size.