### PR TITLE
Enable BuildBuddy integration in CI with API key injection

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,9 @@ build:macos --cxxopt=-std=c++17
 build:macos --host_cxxopt=-std=c++17
 
 # BuildBuddy.io: BES + remote cache (safe to use on any platform).
-# Pass the API key with: --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+# Pass the API key with both:
+#   --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY  (remote cache/exec)
+#   --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY     (build event stream)
 build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
 build:buildbuddy --remote_timeout=10m
+build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
 
 build:linux-x86_64-remote --config=buildbuddy
 build:linux-x86_64-remote --remote_executor=grpcs://remote.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,15 +11,16 @@ build:linux --host_cxxopt=-std=c++17
 build:macos --cxxopt=-std=c++17
 build:macos --host_cxxopt=-std=c++17
 
-# BuildBuddy.io
+# BuildBuddy.io: BES + remote cache (safe to use on any platform).
+# Pass the API key with: --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
 build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
 build:buildbuddy --remote_timeout=10m
-build:buildbuddy --remote_executor=grpcs://remote.buildbuddy.io
 
 build:linux-x86_64-remote --config=buildbuddy
+build:linux-x86_64-remote --remote_executor=grpcs://remote.buildbuddy.io
 build:linux-x86_64-remote --host_platform=@toolchains_buildbuddy//platforms:linux_x86_64
 build:linux-x86_64-remote --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 build:linux-x86_64-remote --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
@@ -27,6 +28,7 @@ build:linux-x86_64-remote --remote_download_minimal
 build:linux-x86_64-remote --define=EXECUTOR=remote
 
 build:linux-arm64-remote --config=buildbuddy
+build:linux-arm64-remote --remote_executor=grpcs://remote.buildbuddy.io
 build:linux-arm64-remote --host_platform=@toolchains_buildbuddy//platforms:linux_arm64
 build:linux-arm64-remote --platforms=@toolchains_buildbuddy//platforms:linux_arm64
 build:linux-arm64-remote --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_arm64
@@ -41,3 +43,6 @@ build:node-linux-x64 --config=linux-x86_64-remote
 # Build opencc.node for Linux arm64 using BuildBuddy remote execution.
 # Usage: bazel build --config=node-linux-arm64 //node:opencc_node
 build:node-linux-arm64 --config=linux-arm64-remote
+
+# Optional user/CI overrides (e.g. injecting BuildBuddy API key in CI).
+try-import %workspace%/.bazelrc.user

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -43,7 +43,11 @@ jobs:
         shell: bash
         run: |
           if [ -n "${BUILDBUDDY_API_KEY}" ]; then
-            echo "build --config=buildbuddy --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc.user
+            {
+              echo "build --config=buildbuddy"
+              echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+              echo "build --bes_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+            } >> .bazelrc.user
             echo "BuildBuddy enabled."
           else
             echo "BUILDBUDDY_API_KEY not set; skipping BuildBuddy config (fork PR or missing secret)."

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,6 +39,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Configure BuildBuddy
+        shell: bash
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            echo "build --config=buildbuddy --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc.user
+            echo "BuildBuddy enabled."
+          else
+            echo "BUILDBUDDY_API_KEY not set; skipping BuildBuddy config (fork PR or missing secret)."
+          fi
       - name: Build
         if: runner.os == 'Linux'
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.vscode
 /.mypy_cache
 /bazel-*
+/.bazelrc.user
 /build
 /other
 /doc/html


### PR DESCRIPTION
## Summary
This PR integrates BuildBuddy remote caching and build event streaming into the CI/CD pipeline by securely injecting the API key at runtime, while maintaining flexibility for local development and fork PRs.

## Key Changes
- **GitHub Actions Workflow**: Added a new step that conditionally configures BuildBuddy by writing the API key to `.bazelrc.user` when the `BUILDBUDDY_API_KEY` secret is available. The step gracefully handles missing secrets (e.g., in fork PRs) with an informative message.
- **Bazel Configuration**:
  - Refactored the `buildbuddy` config to be platform-agnostic by removing the remote executor setting
  - Moved remote executor configuration to platform-specific configs (`linux-x86_64-remote` and `linux-arm64-remote`)
  - Added `--build_metadata=VISIBILITY=PUBLIC` so invocation result pages are viewable without a BuildBuddy account
  - Updated comments to clarify that the API key should be passed via `--remote_header=x-buildbuddy-api-key`
- **User Config Support**: Added `.bazelrc.user` to `.gitignore` and configured `.bazelrc` to import it with `try-import`, allowing CI and local development to inject environment-specific settings without version control

## Local Development Is Unaffected
BuildBuddy is **opt-in** — it is *only* activated in CI, not during local development:

- All BuildBuddy flags live under the `build:buildbuddy` config namespace, so they only apply when `--config=buildbuddy` is explicitly passed.
- CI activates the config by writing `build --config=buildbuddy --remote_header=x-buildbuddy-api-key=…` into `.bazelrc.user` at job start. That file is gitignored and never exists locally.
- `.bazelrc` loads it via `try-import %workspace%/.bazelrc.user`, which silently no-ops when the file is absent.

Net effect:
- **Local** `bazel build //...` → no `.bazelrc.user`, no `--config=buildbuddy` → zero traffic to BuildBuddy.
- **CI** → workflow generates `.bazelrc.user` → BES upload + remote cache enabled automatically.

A developer who *wants* BuildBuddy locally can either create their own `.bazelrc.user` with their personal API key, or pass `--config=buildbuddy --remote_header=x-buildbuddy-api-key=$KEY` ad hoc.

## Implementation Details
- The BuildBuddy configuration is now split: the base `buildbuddy` config handles BES and remote caching (safe for all platforms), while platform-specific configs add remote execution capabilities
- The CI workflow uses bash to conditionally enable BuildBuddy only when the API key secret is present, preventing failures in fork PRs
- The `.bazelrc.user` file is generated at runtime and ignored by git, enabling secure credential injection without exposing secrets in the repository

https://claude.ai/code/session_01KVRC2eMbe6ShHJqaTLPxPj