### PR TITLE
Optimize conversion prefix matching

### DIFF
--- a/node/node_opencc.gypi
+++ b/node/node_opencc.gypi
@@ -17,6 +17,7 @@
         "../src/MarisaDict.cpp",
         "../src/MaxMatchSegmentation.cpp",
         "../src/PluginSegmentation.cpp",
+        "../src/PrefixMatch.cpp",
         "../src/Segmentation.cpp",
         "../src/SerializedValues.cpp",
         "../src/TextDict.cpp",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -128,6 +128,7 @@ cc_library(
     deps = [
         ":common",
         ":dict",
+        ":dict_group",
         ":segmentation",
     ],
 )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -127,8 +127,7 @@ cc_library(
     hdrs = ["Conversion.hpp"],
     deps = [
         ":common",
-        ":dict",
-        ":lexicon",
+        ":prefix_match",
         ":segmentation",
     ],
 )
@@ -341,7 +340,20 @@ cc_library(
     deps = [
         ":common",
         ":dict_group",
+        ":prefix_match",
         ":segmentation",
+    ],
+)
+
+cc_library(
+    name = "prefix_match",
+    srcs = ["PrefixMatch.cpp"],
+    hdrs = ["PrefixMatch.hpp"],
+    deps = [
+        ":common",
+        ":dict",
+        ":lexicon",
+        ":utf8_util",
     ],
 )
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -128,7 +128,7 @@ cc_library(
     deps = [
         ":common",
         ":dict",
-        ":dict_group",
+        ":lexicon",
         ":segmentation",
     ],
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(
   Optional.hpp
   PluginSegmentation.hpp
   PhraseExtract.hpp
+  PrefixMatch.hpp
   Segmentation.hpp
   Segments.hpp
   SerializableDict.hpp
@@ -62,6 +63,7 @@ set(
   MaxMatchSegmentation.cpp
   PluginSegmentation.cpp
   PhraseExtract.cpp
+  PrefixMatch.cpp
   SerializedValues.cpp
   SimpleConverter.cpp
   Segmentation.cpp

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -62,9 +62,12 @@ std::unordered_map<std::string, DictPtr>& DictCache() {
 }
 
 bool GetFileCacheKey(const std::string& path, std::string* cacheKey) {
-#ifdef _MSC_VER
-  struct _stat64 statBuf;
-  if (_wstat64(UTF8Util::GetPlatformString(path).c_str(), &statBuf) != 0) {
+#if defined(_WIN32) || defined(_WIN64)
+  WIN32_FILE_ATTRIBUTE_DATA fileInfo;
+  const std::wstring widePath = internal::WideFromUtf8(path);
+  if (widePath.empty() ||
+      !GetFileAttributesExW(widePath.c_str(), GetFileExInfoStandard,
+                            &fileInfo)) {
     return false;
   }
 #else
@@ -75,9 +78,36 @@ bool GetFileCacheKey(const std::string& path, std::string* cacheKey) {
 #endif
   *cacheKey = path;
   cacheKey->push_back('\n');
+#if defined(_WIN32) || defined(_WIN64)
+  cacheKey->append(
+      std::to_string(static_cast<unsigned long long>(
+          fileInfo.ftLastWriteTime.dwHighDateTime)));
+  cacheKey->push_back('.');
+  cacheKey->append(
+      std::to_string(static_cast<unsigned long long>(
+          fileInfo.ftLastWriteTime.dwLowDateTime)));
+  cacheKey->push_back('\n');
+  cacheKey->append(
+      std::to_string(static_cast<unsigned long long>(fileInfo.nFileSizeHigh)));
+  cacheKey->push_back('.');
+  cacheKey->append(
+      std::to_string(static_cast<unsigned long long>(fileInfo.nFileSizeLow)));
+#else
   cacheKey->append(std::to_string(static_cast<long long>(statBuf.st_mtime)));
+  cacheKey->push_back('.');
+#if defined(__APPLE__) && defined(__MACH__)
+  cacheKey->append(
+      std::to_string(static_cast<long long>(statBuf.st_mtimespec.tv_nsec)));
+#elif defined(st_mtime_nsec)
+  cacheKey->append(
+      std::to_string(static_cast<long long>(statBuf.st_mtime_nsec)));
+#else
+  cacheKey->append(
+      std::to_string(static_cast<long long>(statBuf.st_mtim.tv_nsec)));
+#endif
   cacheKey->push_back('\n');
   cacheKey->append(std::to_string(static_cast<long long>(statBuf.st_size)));
+#endif
   return true;
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -56,9 +56,22 @@ std::mutex& DictCacheMutex() {
   return mutex;
 }
 
-std::unordered_map<std::string, DictPtr>& DictCache() {
-  static std::unordered_map<std::string, DictPtr> cache;
+std::unordered_map<std::string, std::weak_ptr<Dict>>& DictCache() {
+  static std::unordered_map<std::string, std::weak_ptr<Dict>> cache;
   return cache;
+}
+
+void PruneExpiredDictCache() {
+  std::unordered_map<std::string, std::weak_ptr<Dict>>& cache = DictCache();
+  for (std::unordered_map<std::string, std::weak_ptr<Dict>>::iterator it =
+           cache.begin();
+       it != cache.end();) {
+    if (it->second.expired()) {
+      it = cache.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 bool GetFileCacheKey(const std::string& path, std::string* cacheKey) {
@@ -258,20 +271,27 @@ public:
       }
       {
         std::lock_guard<std::mutex> lock(DictCacheMutex());
+        PruneExpiredDictCache();
         const auto cached = DictCache().find(cacheKey);
         if (cached != DictCache().end()) {
-          return cached->second;
+          DictPtr dict = cached->second.lock();
+          if (dict != nullptr) {
+            return dict;
+          }
         }
       }
 
       std::shared_ptr<DICT> dict;
       if (SerializableDict::TryLoadFromFile<DICT>(path, &dict)) {
         std::lock_guard<std::mutex> lock(DictCacheMutex());
-        DictPtr& cached = DictCache()[cacheKey];
-        if (cached == nullptr) {
+        PruneExpiredDictCache();
+        std::weak_ptr<Dict>& cached = DictCache()[cacheKey];
+        DictPtr cachedDict = cached.lock();
+        if (cachedDict == nullptr) {
           cached = dict;
+          return dict;
         }
-        return cached;
+        return cachedDict;
       }
     }
     throw FileNotFound(fileName);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <fstream>
 #include <list>
+#include <mutex>
 #include <unordered_map>
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -36,6 +37,7 @@
 #include "MaxMatchSegmentation.hpp"
 #include "PluginSegmentation.hpp"
 #include "TextDict.hpp"
+#include "UTF8Util.hpp"
 
 #ifdef ENABLE_DARTS
 #include "DartsDict.hpp"
@@ -48,6 +50,36 @@ namespace opencc {
 namespace {
 
 std::string GetParentDirectory(const std::string& path);
+
+std::mutex& DictCacheMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, DictPtr>& DictCache() {
+  static std::unordered_map<std::string, DictPtr> cache;
+  return cache;
+}
+
+bool GetFileCacheKey(const std::string& path, std::string* cacheKey) {
+#ifdef _MSC_VER
+  struct _stat64 statBuf;
+  if (_wstat64(UTF8Util::GetPlatformString(path).c_str(), &statBuf) != 0) {
+    return false;
+  }
+#else
+  struct stat statBuf;
+  if (stat(path.c_str(), &statBuf) != 0) {
+    return false;
+  }
+#endif
+  *cacheKey = path;
+  cacheKey->push_back('\n');
+  cacheKey->append(std::to_string(static_cast<long long>(statBuf.st_mtime)));
+  cacheKey->push_back('\n');
+  cacheKey->append(std::to_string(static_cast<long long>(statBuf.st_size)));
+  return true;
+}
 
 #if defined(_WIN32) || defined(_WIN64)
 using internal::Utf8FromWide;
@@ -180,16 +212,36 @@ public:
   }
 
   template <typename DICT>
-  DictPtr LoadDictWithPaths(const std::string& fileName) {
-    // Working directory
-    std::shared_ptr<DICT> dict;
-    if (SerializableDict::TryLoadFromFile<DICT>(fileName, &dict)) {
-      return dict;
-    }
+  DictPtr LoadDictWithPaths(const std::string& cachePrefix,
+                            const std::string& fileName) {
+    std::vector<std::string> candidates;
+    candidates.push_back(fileName);
     for (const std::string& dirPath : paths) {
-      std::string path = dirPath + '/' + fileName;
+      candidates.push_back(dirPath + '/' + fileName);
+    }
+
+    for (const std::string& path : candidates) {
+      std::string cacheKey = cachePrefix;
+      cacheKey.push_back('\n');
+      if (!GetFileCacheKey(path, &cacheKey)) {
+        continue;
+      }
+      {
+        std::lock_guard<std::mutex> lock(DictCacheMutex());
+        const auto cached = DictCache().find(cacheKey);
+        if (cached != DictCache().end()) {
+          return cached->second;
+        }
+      }
+
+      std::shared_ptr<DICT> dict;
       if (SerializableDict::TryLoadFromFile<DICT>(path, &dict)) {
-        return dict;
+        std::lock_guard<std::mutex> lock(DictCacheMutex());
+        DictPtr& cached = DictCache()[cacheKey];
+        if (cached == nullptr) {
+          cached = dict;
+        }
+        return cached;
       }
     }
     throw FileNotFound(fileName);
@@ -198,16 +250,16 @@ public:
   DictPtr LoadDictFromFile(const std::string& type,
                            const std::string& fileName) {
     if (type == "text") {
-      DictPtr dict = LoadDictWithPaths<TextDict>(fileName);
+      DictPtr dict = LoadDictWithPaths<TextDict>("text", fileName);
       return MarisaDict::NewFromDict(*dict.get());
     }
 #ifdef ENABLE_DARTS
     if (type == "ocd") {
-      return LoadDictWithPaths<DartsDict>(fileName);
+      return LoadDictWithPaths<DartsDict>("ocd", fileName);
     }
 #endif
     if (type == "ocd2") {
-      return LoadDictWithPaths<MarisaDict>(fileName);
+      return LoadDictWithPaths<MarisaDict>("ocd2", fileName);
     }
     throw InvalidFormat("Unknown dictionary type: " + type);
     return nullptr;

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -17,142 +17,14 @@
  */
 
 #include "Conversion.hpp"
-#include "Dict.hpp"
-#include "Lexicon.hpp"
-
-#include <cstdint>
-#include <unordered_map>
+#include "PrefixMatch.hpp"
+#include "Segments.hpp"
+#include "UTF8Util.hpp"
 
 using namespace opencc;
 
-namespace {
-
-size_t Utf8CharLength(const char* str, size_t len) {
-  if (len == 0) {
-    return 0;
-  }
-  const size_t charLen = UTF8Util::NextCharLength(str);
-  return charLen <= len ? charLen : 0;
-}
-
-uint32_t Utf8CharKey(const char* str, size_t charLen) {
-  uint32_t key = static_cast<uint32_t>(charLen);
-  for (size_t i = 0; i < charLen; i++) {
-    key = (key << 8) | static_cast<unsigned char>(str[i]);
-  }
-  return key;
-}
-
-} // namespace
-
-class opencc::LinearMatchDict {
-public:
-  struct Match {
-    bool matched;
-    size_t keyLength;
-    const std::string* value;
-  };
-
-  explicit LinearMatchDict(const DictPtr& dict) { AddDict(dict); }
-
-  Match MatchPrefix(const char* word, size_t len) const {
-    for (const Table& table : tables) {
-      const Match match = table.MatchPrefix(word, len);
-      if (match.matched) {
-        return match;
-      }
-    }
-    return Match{false, 0, nullptr};
-  }
-
-private:
-  struct Entry {
-    std::string key;
-    std::string value;
-  };
-
-  class Table {
-  public:
-    explicit Table(const DictPtr& dict) {
-      const LexiconPtr lexicon = dict->GetLexicon();
-      for (const std::unique_ptr<DictEntry>& item : *lexicon) {
-        AddEntry(item->Key(), item->GetDefault());
-      }
-    }
-
-    Match MatchPrefix(const char* word, size_t len) const {
-      const Node* node = &root;
-      const std::string* matchedValue = nullptr;
-      size_t matchedLength = 0;
-      for (const char* pstr = word; pstr < word + len;) {
-        const size_t remainingLength = word + len - pstr;
-        const size_t charLength = Utf8CharLength(pstr, remainingLength);
-        if (charLength == 0) {
-          break;
-        }
-        const auto child = node->children.find(Utf8CharKey(pstr, charLength));
-        if (child == node->children.end()) {
-          break;
-        }
-        pstr += charLength;
-        node = child->second.get();
-        if (node->keyLength > 0) {
-          matchedLength = node->keyLength;
-          matchedValue = &node->value;
-        }
-      }
-      if (matchedValue != nullptr) {
-        return Match{true, matchedLength, matchedValue};
-      }
-      return Match{false, 0, nullptr};
-    }
-
-  private:
-    struct Node {
-      size_t keyLength = 0;
-      std::string value;
-      std::unordered_map<uint32_t, std::unique_ptr<Node>> children;
-    };
-
-    void AddEntry(const std::string& key, const std::string& value) {
-      Node* node = &root;
-      for (const char* pstr = key.c_str(); *pstr != '\0';) {
-        const size_t remainingLength = key.c_str() + key.length() - pstr;
-        const size_t charLength = Utf8CharLength(pstr, remainingLength);
-        if (charLength == 0) {
-          break;
-        }
-        std::unique_ptr<Node>& child =
-            node->children[Utf8CharKey(pstr, charLength)];
-        if (child == nullptr) {
-          child.reset(new Node);
-        }
-        node = child.get();
-        pstr += charLength;
-      }
-      node->keyLength = key.length();
-      node->value = value;
-    }
-
-    Node root;
-  };
-
-  void AddDict(const DictPtr& dict) {
-    const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
-    if (dictGroupItems != nullptr) {
-      for (const DictPtr& child : *dictGroupItems) {
-        AddDict(child);
-      }
-      return;
-    }
-    tables.emplace_back(dict);
-  }
-
-  std::vector<Table> tables;
-};
-
 Conversion::Conversion(DictPtr _dict)
-    : dict(_dict), linearDict(new LinearMatchDict(_dict)) {}
+    : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
 std::string Conversion::Convert(const char* phrase) const {
   std::string buffer;
@@ -171,8 +43,8 @@ void Conversion::AppendConverted(const char* phrase, std::string* output) const 
 
   for (const char* pstr = phrase; *pstr != '\0';) {
     size_t remainingLength = phraseEnd - pstr;
-    const LinearMatchDict::Match matched =
-        linearDict->MatchPrefix(pstr, remainingLength);
+    const PrefixMatch::Match matched =
+        prefixMatch->MatchPrefix(pstr, remainingLength);
     size_t matchedLength;
     if (!matched.matched) {
       matchedLength = UTF8Util::NextCharLength(pstr);

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -20,20 +20,22 @@
 #include "Dict.hpp"
 #include "Lexicon.hpp"
 
-#include <algorithm>
 #include <cstdint>
-#include <cstring>
 #include <unordered_map>
 
 using namespace opencc;
 
 namespace {
 
-uint32_t FirstUtf8CharKey(const char* str, size_t len) {
+size_t Utf8CharLength(const char* str, size_t len) {
   if (len == 0) {
     return 0;
   }
-  const size_t charLen = (std::min)(UTF8Util::NextCharLength(str), len);
+  const size_t charLen = UTF8Util::NextCharLength(str);
+  return charLen <= len ? charLen : 0;
+}
+
+uint32_t Utf8CharKey(const char* str, size_t charLen) {
   uint32_t key = static_cast<uint32_t>(charLen);
   for (size_t i = 0; i < charLen; i++) {
     key = (key << 8) | static_cast<unsigned char>(str[i]);
@@ -74,42 +76,65 @@ private:
     explicit Table(const DictPtr& dict) {
       const LexiconPtr lexicon = dict->GetLexicon();
       for (const std::unique_ptr<DictEntry>& item : *lexicon) {
-        Entry entry;
-        entry.key = item->Key();
-        entry.value = item->GetDefault();
-        const uint32_t firstCharKey =
-            FirstUtf8CharKey(entry.key.c_str(), entry.key.length());
-        buckets[firstCharKey].push_back(std::move(entry));
-      }
-
-      for (auto& bucket : buckets) {
-        std::sort(bucket.second.begin(), bucket.second.end(),
-                  [](const Entry& a, const Entry& b) {
-                    return a.key.length() > b.key.length();
-                  });
+        AddEntry(item->Key(), item->GetDefault());
       }
     }
 
     Match MatchPrefix(const char* word, size_t len) const {
-      const auto bucket = buckets.find(FirstUtf8CharKey(word, len));
-      if (bucket == buckets.end()) {
-        return Match{false, 0, nullptr};
+      const Node* node = &root;
+      const std::string* matchedValue = nullptr;
+      size_t matchedLength = 0;
+      for (const char* pstr = word; pstr < word + len;) {
+        const size_t remainingLength = word + len - pstr;
+        const size_t charLength = Utf8CharLength(pstr, remainingLength);
+        if (charLength == 0) {
+          break;
+        }
+        const auto child = node->children.find(Utf8CharKey(pstr, charLength));
+        if (child == node->children.end()) {
+          break;
+        }
+        pstr += charLength;
+        node = child->second.get();
+        if (node->keyLength > 0) {
+          matchedLength = node->keyLength;
+          matchedValue = &node->value;
+        }
       }
-
-      for (const Entry& entry : bucket->second) {
-        const size_t keyLength = entry.key.length();
-        if (keyLength > len) {
-          continue;
-        }
-        if (std::memcmp(word, entry.key.data(), keyLength) == 0) {
-          return Match{true, keyLength, &entry.value};
-        }
+      if (matchedValue != nullptr) {
+        return Match{true, matchedLength, matchedValue};
       }
       return Match{false, 0, nullptr};
     }
 
   private:
-    std::unordered_map<uint32_t, std::vector<Entry>> buckets;
+    struct Node {
+      size_t keyLength = 0;
+      std::string value;
+      std::unordered_map<uint32_t, std::unique_ptr<Node>> children;
+    };
+
+    void AddEntry(const std::string& key, const std::string& value) {
+      Node* node = &root;
+      for (const char* pstr = key.c_str(); *pstr != '\0';) {
+        const size_t remainingLength = key.c_str() + key.length() - pstr;
+        const size_t charLength = Utf8CharLength(pstr, remainingLength);
+        if (charLength == 0) {
+          break;
+        }
+        std::unique_ptr<Node>& child =
+            node->children[Utf8CharKey(pstr, charLength)];
+        if (child == nullptr) {
+          child.reset(new Node);
+        }
+        node = child.get();
+        pstr += charLength;
+      }
+      node->keyLength = key.length();
+      node->value = value;
+    }
+
+    Node root;
   };
 
   void AddDict(const DictPtr& dict) {

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -18,7 +18,6 @@
 
 #include "Conversion.hpp"
 #include "Dict.hpp"
-#include "DictGroup.hpp"
 #include "Lexicon.hpp"
 
 #include <algorithm>
@@ -113,9 +112,9 @@ private:
   };
 
   void AddDict(const DictPtr& dict) {
-    const DictGroupPtr dictGroup = std::dynamic_pointer_cast<DictGroup>(dict);
-    if (dictGroup != nullptr) {
-      for (const DictPtr& child : dictGroup->GetDicts()) {
+    const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
+    if (dictGroupItems != nullptr) {
+      for (const DictPtr& child : *dictGroupItems) {
         AddDict(child);
       }
       return;

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -21,6 +21,7 @@
 #include "Lexicon.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <unordered_map>
 

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -18,42 +18,155 @@
 
 #include "Conversion.hpp"
 #include "Dict.hpp"
+#include "DictGroup.hpp"
+#include "Lexicon.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <unordered_map>
 
 using namespace opencc;
 
+namespace {
+
+uint32_t FirstUtf8CharKey(const char* str, size_t len) {
+  if (len == 0) {
+    return 0;
+  }
+  const size_t charLen = (std::min)(UTF8Util::NextCharLength(str), len);
+  uint32_t key = static_cast<uint32_t>(charLen);
+  for (size_t i = 0; i < charLen; i++) {
+    key = (key << 8) | static_cast<unsigned char>(str[i]);
+  }
+  return key;
+}
+
+} // namespace
+
+class opencc::LinearMatchDict {
+public:
+  struct Match {
+    bool matched;
+    size_t keyLength;
+    const std::string* value;
+  };
+
+  explicit LinearMatchDict(const DictPtr& dict) { AddDict(dict); }
+
+  Match MatchPrefix(const char* word, size_t len) const {
+    for (const Table& table : tables) {
+      const Match match = table.MatchPrefix(word, len);
+      if (match.matched) {
+        return match;
+      }
+    }
+    return Match{false, 0, nullptr};
+  }
+
+private:
+  struct Entry {
+    std::string key;
+    std::string value;
+  };
+
+  class Table {
+  public:
+    explicit Table(const DictPtr& dict) {
+      const LexiconPtr lexicon = dict->GetLexicon();
+      for (const std::unique_ptr<DictEntry>& item : *lexicon) {
+        Entry entry;
+        entry.key = item->Key();
+        entry.value = item->GetDefault();
+        const uint32_t firstCharKey =
+            FirstUtf8CharKey(entry.key.c_str(), entry.key.length());
+        buckets[firstCharKey].push_back(std::move(entry));
+      }
+
+      for (auto& bucket : buckets) {
+        std::sort(bucket.second.begin(), bucket.second.end(),
+                  [](const Entry& a, const Entry& b) {
+                    return a.key.length() > b.key.length();
+                  });
+      }
+    }
+
+    Match MatchPrefix(const char* word, size_t len) const {
+      const auto bucket = buckets.find(FirstUtf8CharKey(word, len));
+      if (bucket == buckets.end()) {
+        return Match{false, 0, nullptr};
+      }
+
+      for (const Entry& entry : bucket->second) {
+        const size_t keyLength = entry.key.length();
+        if (keyLength > len) {
+          continue;
+        }
+        if (std::memcmp(word, entry.key.data(), keyLength) == 0) {
+          return Match{true, keyLength, &entry.value};
+        }
+      }
+      return Match{false, 0, nullptr};
+    }
+
+  private:
+    std::unordered_map<uint32_t, std::vector<Entry>> buckets;
+  };
+
+  void AddDict(const DictPtr& dict) {
+    const DictGroupPtr dictGroup = std::dynamic_pointer_cast<DictGroup>(dict);
+    if (dictGroup != nullptr) {
+      for (const DictPtr& child : dictGroup->GetDicts()) {
+        AddDict(child);
+      }
+      return;
+    }
+    tables.emplace_back(dict);
+  }
+
+  std::vector<Table> tables;
+};
+
+Conversion::Conversion(DictPtr _dict)
+    : dict(_dict), linearDict(new LinearMatchDict(_dict)) {}
+
 std::string Conversion::Convert(const char* phrase) const {
+  std::string buffer;
+  AppendConverted(phrase, &buffer);
+  return buffer;
+}
+
+void Conversion::AppendConverted(const char* phrase, std::string* output) const {
   // Calculate string end to prevent reading beyond null terminator
   const char* phraseEnd = phrase;
   while (*phraseEnd != '\0') {
     phraseEnd++;
   }
   const size_t phraseLength = phraseEnd - phrase;
-  std::string buffer;
-  buffer.reserve(phraseLength + phraseLength / 5);
+  output->reserve(output->size() + phraseLength + phraseLength / 5);
 
   for (const char* pstr = phrase; *pstr != '\0';) {
     size_t remainingLength = phraseEnd - pstr;
-    Optional<const DictEntry*> matched = dict->MatchPrefix(pstr, remainingLength);
+    const LinearMatchDict::Match matched =
+        linearDict->MatchPrefix(pstr, remainingLength);
     size_t matchedLength;
-    if (matched.IsNull()) {
+    if (!matched.matched) {
       matchedLength = UTF8Util::NextCharLength(pstr);
       // Ensure we don't read beyond the null terminator
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      buffer.append(pstr, matchedLength);
+      output->append(pstr, matchedLength);
     } else {
-      matchedLength = matched.Get()->KeyLength();
+      matchedLength = matched.keyLength;
       // Defensive: ensure dictionary key length does not exceed remaining input
       // (MatchPrefix should already guarantee this, but defense in depth)
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      buffer.append(matched.Get()->GetDefault());
+      output->append(*matched.value);
     }
     pstr += matchedLength;
   }
-  return buffer;
 }
 
 std::string Conversion::Convert(const std::string& phrase) const {

--- a/src/Conversion.hpp
+++ b/src/Conversion.hpp
@@ -22,7 +22,7 @@
 #include "Segmentation.hpp"
 
 namespace opencc {
-class LinearMatchDict;
+class PrefixMatch;
 
 /**
  * Conversion interface
@@ -48,6 +48,6 @@ public:
 
 private:
   const DictPtr dict;
-  const std::shared_ptr<LinearMatchDict> linearDict;
+  const std::shared_ptr<PrefixMatch> prefixMatch;
 };
 } // namespace opencc

--- a/src/Conversion.hpp
+++ b/src/Conversion.hpp
@@ -22,19 +22,24 @@
 #include "Segmentation.hpp"
 
 namespace opencc {
+class LinearMatchDict;
+
 /**
  * Conversion interface
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT Conversion {
 public:
-  Conversion(DictPtr _dict) : dict(_dict) {}
+  Conversion(DictPtr _dict);
 
   // Convert single phrase
   std::string Convert(const std::string& phrase) const;
 
   // Convert single phrase
   std::string Convert(const char* phrase) const;
+
+  // Convert single phrase and append it to output.
+  void AppendConverted(const char* phrase, std::string* output) const;
 
   // Convert segmented text
   SegmentsPtr Convert(const SegmentsPtr& input) const;
@@ -43,5 +48,6 @@ public:
 
 private:
   const DictPtr dict;
+  const std::shared_ptr<LinearMatchDict> linearDict;
 };
 } // namespace opencc

--- a/src/ConversionChain.cpp
+++ b/src/ConversionChain.cpp
@@ -34,6 +34,32 @@ SegmentsPtr ConversionChain::Convert(const SegmentsPtr& input) const {
   return output;
 }
 
+void ConversionChain::AppendConvertedSegment(const char* segment,
+                                             std::string* output) const {
+  if (conversions.empty()) {
+    output->append(segment);
+    return;
+  }
+
+  auto conversion = conversions.begin();
+  auto lastConversion = conversions.end();
+  --lastConversion;
+  if (conversion == lastConversion) {
+    (*conversion)->AppendConverted(segment, output);
+    return;
+  }
+
+  std::string converted;
+  (*conversion)->AppendConverted(segment, &converted);
+  ++conversion;
+  for (; conversion != lastConversion; ++conversion) {
+    std::string next;
+    (*conversion)->AppendConverted(converted.c_str(), &next);
+    converted.swap(next);
+  }
+  (*lastConversion)->AppendConverted(converted.c_str(), output);
+}
+
 std::vector<SegmentsPtr>
 ConversionChain::ConvertWithTrace(const SegmentsPtr& input) const {
   std::vector<SegmentsPtr> trace;

--- a/src/ConversionChain.hpp
+++ b/src/ConversionChain.hpp
@@ -35,6 +35,8 @@ public:
 
   SegmentsPtr Convert(const SegmentsPtr& input) const;
 
+  void AppendConvertedSegment(const char* segment, std::string* output) const;
+
   std::vector<SegmentsPtr> ConvertWithTrace(const SegmentsPtr& input) const;
 
   const std::list<ConversionPtr> GetConversions() const { return conversions; }

--- a/src/ConversionTest.cpp
+++ b/src/ConversionTest.cpp
@@ -47,6 +47,22 @@ TEST_F(ConversionTest, ConvertCString) {
   EXPECT_EQ(expected, converted);
 }
 
+TEST_F(ConversionTest, PreserveDictGroupPriority) {
+  LexiconPtr firstLexicon(new Lexicon);
+  firstLexicon->Add(DictEntryFactory::New("a", "X"));
+  firstLexicon->Sort();
+  LexiconPtr secondLexicon(new Lexicon);
+  secondLexicon->Add(DictEntryFactory::New("ab", "Y"));
+  secondLexicon->Sort();
+
+  DictPtr firstDict(new TextDict(firstLexicon));
+  DictPtr secondDict(new TextDict(secondLexicon));
+  DictPtr dictGroup(new DictGroup(std::list<DictPtr>{firstDict, secondDict}));
+  Conversion groupConversion(dictGroup);
+
+  EXPECT_EQ("Xbc", groupConversion.Convert("abc"));
+}
+
 TEST_F(ConversionTest, TruncatedUtf8Sequence) {
   // This test specifically triggers the information disclosure vulnerability
   // in the old code. The bug occurs when a string ends with an incomplete

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -27,8 +27,12 @@ using namespace opencc;
 
 std::string Converter::Convert(const std::string& text) const {
   const SegmentsPtr& segments = segmentation->Segment(text);
-  const SegmentsPtr& converted = conversionChain->Convert(segments);
-  return converted->ToString();
+  std::string converted;
+  converted.reserve(text.length() + text.length() / 5);
+  for (const char* segment : *segments) {
+    conversionChain->AppendConvertedSegment(segment, &converted);
+  }
+  return converted;
 }
 
 size_t Converter::Convert(const char* input, char* output) const {

--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <list>
+
 #include "Common.hpp"
 #include "DictEntry.hpp"
 
@@ -88,5 +90,12 @@ public:
    * Returns all entries in the dictionary.
    */
   virtual LexiconPtr GetLexicon() const = 0;
+
+  /**
+   * Returns child dictionaries when this dictionary is a group.
+   */
+  virtual const std::list<DictPtr>* GetDictGroupItems() const {
+    return nullptr;
+  }
 };
 } // namespace opencc

--- a/src/DictGroup.hpp
+++ b/src/DictGroup.hpp
@@ -48,6 +48,10 @@ public:
 
   virtual LexiconPtr GetLexicon() const;
 
+  virtual const std::list<DictPtr>* GetDictGroupItems() const {
+    return &dicts;
+  }
+
   const std::list<DictPtr> GetDicts() const { return dicts; }
 
 private:

--- a/src/MaxMatchSegmentation.cpp
+++ b/src/MaxMatchSegmentation.cpp
@@ -17,8 +17,14 @@
  */
 
 #include "MaxMatchSegmentation.hpp"
+#include "PrefixMatch.hpp"
+#include "Segments.hpp"
+#include "UTF8Util.hpp"
 
 using namespace opencc;
+
+MaxMatchSegmentation::MaxMatchSegmentation(const DictPtr _dict)
+    : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
 SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
   SegmentsPtr segments(new Segments);
@@ -33,9 +39,10 @@ SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
   const char* textEnd = text.c_str() + text.length();
   for (const char* pstr = text.c_str(); *pstr != '\0';) {
     size_t remainingLength = textEnd - pstr;
-    const Optional<const DictEntry*>& matched = dict->MatchPrefix(pstr, remainingLength);
+    const PrefixMatch::Match matched =
+        prefixMatch->MatchPrefix(pstr, remainingLength);
     size_t matchedLength;
-    if (matched.IsNull()) {
+    if (!matched.matched) {
       matchedLength = UTF8Util::NextCharLength(pstr);
       // Ensure we don't advance beyond the string boundary
       if (matchedLength > remainingLength) {
@@ -44,8 +51,8 @@ SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
       segLength += matchedLength;
     } else {
       clearBuffer();
-      matchedLength = matched.Get()->KeyLength();
-      segments->AddSegment(matched.Get()->Key());
+      matchedLength = matched.keyLength;
+      segments->AddSegment(*matched.key);
       segStart = pstr + matchedLength;
     }
     pstr += matchedLength;

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -56,7 +56,7 @@ namespace {
 
 struct CacheEntry {
   std::vector<std::weak_ptr<const Dict>> dicts;
-  std::shared_ptr<const PrefixMatch::Tables> tables;
+  std::weak_ptr<const PrefixMatch::Tables> tables;
 };
 
 bool SameOwner(const std::weak_ptr<const Dict>& cached,
@@ -78,12 +78,37 @@ bool SameDicts(const CacheEntry& cached,
 }
 
 bool HasExpiredDict(const CacheEntry& cached) {
+  if (cached.tables.expired()) {
+    return true;
+  }
   for (const std::weak_ptr<const Dict>& dict : cached.dicts) {
     if (dict.expired()) {
       return true;
     }
   }
   return false;
+}
+
+void PruneExpiredPrefixMatchCache(
+    std::unordered_map<std::string, std::vector<CacheEntry>>* cache) {
+  for (std::unordered_map<std::string, std::vector<CacheEntry>>::iterator it =
+           cache->begin();
+       it != cache->end();) {
+    std::vector<CacheEntry>& entries = it->second;
+    for (std::vector<CacheEntry>::iterator entry = entries.begin();
+         entry != entries.end();) {
+      if (HasExpiredDict(*entry)) {
+        entry = entries.erase(entry);
+      } else {
+        ++entry;
+      }
+    }
+    if (entries.empty()) {
+      it = cache->erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 } // namespace
@@ -168,12 +193,15 @@ PrefixMatch::PrefixMatch(const DictPtr& dict) {
 
   {
     std::lock_guard<std::mutex> lock(cacheMutex);
+    PruneExpiredPrefixMatchCache(&cache);
     const auto cached = cache.find(cacheKey);
     if (cached != cache.end()) {
       for (const CacheEntry& entry : cached->second) {
         if (SameDicts(entry, leafDicts)) {
-          tables = entry.tables;
-          return;
+          tables = entry.tables.lock();
+          if (tables != nullptr) {
+            return;
+          }
         }
       }
     }
@@ -183,14 +211,18 @@ PrefixMatch::PrefixMatch(const DictPtr& dict) {
   AddDict(dict, built.get());
 
   std::lock_guard<std::mutex> lock(cacheMutex);
+  PruneExpiredPrefixMatchCache(&cache);
   std::vector<CacheEntry>& entries = cache[cacheKey];
   for (std::vector<CacheEntry>::iterator it = entries.begin();
        it != entries.end();) {
     if (HasExpiredDict(*it)) {
       it = entries.erase(it);
     } else if (SameDicts(*it, leafDicts)) {
-      tables = it->tables;
-      return;
+      tables = it->tables.lock();
+      if (tables != nullptr) {
+        return;
+      }
+      it = entries.erase(it);
     } else {
       ++it;
     }

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -1,0 +1,142 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PrefixMatch.hpp"
+#include "Dict.hpp"
+#include "Lexicon.hpp"
+#include "UTF8Util.hpp"
+
+#include <cstdint>
+#include <unordered_map>
+
+using namespace opencc;
+
+namespace {
+
+size_t Utf8CharLength(const char* str, size_t len) {
+  if (len == 0) {
+    return 0;
+  }
+  const size_t charLen = UTF8Util::NextCharLength(str);
+  return charLen <= len ? charLen : 0;
+}
+
+uint32_t Utf8CharKey(const char* str, size_t charLen) {
+  uint32_t key = static_cast<uint32_t>(charLen);
+  for (size_t i = 0; i < charLen; i++) {
+    key = (key << 8) | static_cast<unsigned char>(str[i]);
+  }
+  return key;
+}
+
+} // namespace
+
+class PrefixMatch::Table {
+public:
+  explicit Table(const DictPtr& dict) {
+    const LexiconPtr lexicon = dict->GetLexicon();
+    for (const std::unique_ptr<DictEntry>& item : *lexicon) {
+      AddEntry(item->Key(), item->GetDefault());
+    }
+  }
+
+  PrefixMatch::Match MatchPrefix(const char* word, size_t len) const {
+    const Node* node = &root;
+    const Node* matchedNode = nullptr;
+    size_t matchedLength = 0;
+    for (const char* pstr = word; pstr < word + len;) {
+      const size_t remainingLength = word + len - pstr;
+      const size_t charLength = Utf8CharLength(pstr, remainingLength);
+      if (charLength == 0) {
+        break;
+      }
+      const auto child = node->children.find(Utf8CharKey(pstr, charLength));
+      if (child == node->children.end()) {
+        break;
+      }
+      pstr += charLength;
+      node = child->second.get();
+      if (node->keyLength > 0) {
+        matchedLength = node->keyLength;
+        matchedNode = node;
+      }
+    }
+    if (matchedNode != nullptr) {
+      return Match{true, matchedLength, &matchedNode->key,
+                   &matchedNode->value};
+    }
+    return Match{false, 0, nullptr, nullptr};
+  }
+
+private:
+  struct Node {
+    size_t keyLength = 0;
+    std::string key;
+    std::string value;
+    std::unordered_map<uint32_t, std::unique_ptr<Node>> children;
+  };
+
+  void AddEntry(const std::string& key, const std::string& value) {
+    Node* node = &root;
+    for (const char* pstr = key.c_str(); *pstr != '\0';) {
+      const size_t remainingLength = key.c_str() + key.length() - pstr;
+      const size_t charLength = Utf8CharLength(pstr, remainingLength);
+      if (charLength == 0) {
+        break;
+      }
+      std::unique_ptr<Node>& child =
+          node->children[Utf8CharKey(pstr, charLength)];
+      if (child == nullptr) {
+        child.reset(new Node);
+      }
+      node = child.get();
+      pstr += charLength;
+    }
+    node->keyLength = key.length();
+    node->key = key;
+    node->value = value;
+  }
+
+  Node root;
+};
+
+PrefixMatch::PrefixMatch(const DictPtr& dict) { AddDict(dict); }
+
+PrefixMatch::~PrefixMatch() {}
+
+PrefixMatch::Match PrefixMatch::MatchPrefix(const char* word,
+                                            size_t len) const {
+  for (const std::unique_ptr<Table>& table : tables) {
+    const Match match = table->MatchPrefix(word, len);
+    if (match.matched) {
+      return match;
+    }
+  }
+  return Match{false, 0, nullptr, nullptr};
+}
+
+void PrefixMatch::AddDict(const DictPtr& dict) {
+  const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
+  if (dictGroupItems != nullptr) {
+    for (const DictPtr& child : *dictGroupItems) {
+      AddDict(child);
+    }
+    return;
+  }
+  tables.emplace_back(new Table(dict));
+}

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -52,6 +52,42 @@ public:
   std::vector<std::unique_ptr<Table>> tables;
 };
 
+namespace {
+
+struct CacheEntry {
+  std::vector<std::weak_ptr<const Dict>> dicts;
+  std::shared_ptr<const PrefixMatch::Tables> tables;
+};
+
+bool SameOwner(const std::weak_ptr<const Dict>& cached,
+               const std::weak_ptr<const Dict>& current) {
+  return !cached.owner_before(current) && !current.owner_before(cached);
+}
+
+bool SameDicts(const CacheEntry& cached,
+               const std::vector<std::weak_ptr<const Dict>>& current) {
+  if (cached.dicts.size() != current.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < current.size(); i++) {
+    if (cached.dicts[i].expired() || !SameOwner(cached.dicts[i], current[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HasExpiredDict(const CacheEntry& cached) {
+  for (const std::weak_ptr<const Dict>& dict : cached.dicts) {
+    if (dict.expired()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 class PrefixMatch::Table {
 public:
   explicit Table(const DictPtr& dict) {
@@ -123,17 +159,23 @@ private:
 
 PrefixMatch::PrefixMatch(const DictPtr& dict) {
   static std::mutex cacheMutex;
-  static std::unordered_map<std::string, std::shared_ptr<const Tables>> cache;
+  static std::unordered_map<std::string, std::vector<CacheEntry>> cache;
 
   std::string cacheKey;
   AppendCacheKey(dict, &cacheKey);
+  std::vector<std::weak_ptr<const Dict>> leafDicts;
+  CollectLeafDicts(dict, &leafDicts);
 
   {
     std::lock_guard<std::mutex> lock(cacheMutex);
     const auto cached = cache.find(cacheKey);
     if (cached != cache.end()) {
-      tables = cached->second;
-      return;
+      for (const CacheEntry& entry : cached->second) {
+        if (SameDicts(entry, leafDicts)) {
+          tables = entry.tables;
+          return;
+        }
+      }
     }
   }
 
@@ -141,13 +183,23 @@ PrefixMatch::PrefixMatch(const DictPtr& dict) {
   AddDict(dict, built.get());
 
   std::lock_guard<std::mutex> lock(cacheMutex);
-  const auto cached = cache.find(cacheKey);
-  if (cached == cache.end()) {
-    tables = built;
-    cache[cacheKey] = tables;
-  } else {
-    tables = cached->second;
+  std::vector<CacheEntry>& entries = cache[cacheKey];
+  for (std::vector<CacheEntry>::iterator it = entries.begin();
+       it != entries.end();) {
+    if (HasExpiredDict(*it)) {
+      it = entries.erase(it);
+    } else if (SameDicts(*it, leafDicts)) {
+      tables = it->tables;
+      return;
+    } else {
+      ++it;
+    }
   }
+  tables = built;
+  CacheEntry entry;
+  entry.dicts = std::move(leafDicts);
+  entry.tables = tables;
+  entries.push_back(std::move(entry));
 }
 
 PrefixMatch::~PrefixMatch() {}
@@ -188,4 +240,16 @@ void PrefixMatch::AppendCacheKey(const DictPtr& dict, std::string* output) {
   const uintptr_t dictKey = reinterpret_cast<uintptr_t>(dict.get());
   output->append(reinterpret_cast<const char*>(&dictKey), sizeof(dictKey));
   output->push_back(';');
+}
+
+void PrefixMatch::CollectLeafDicts(
+    const DictPtr& dict, std::vector<std::weak_ptr<const Dict>>* output) {
+  const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
+  if (dictGroupItems != nullptr) {
+    for (const DictPtr& child : *dictGroupItems) {
+      CollectLeafDicts(child, output);
+    }
+    return;
+  }
+  output->push_back(dict);
 }

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -22,6 +22,7 @@
 #include "UTF8Util.hpp"
 
 #include <cstdint>
+#include <mutex>
 #include <unordered_map>
 
 using namespace opencc;
@@ -45,6 +46,11 @@ uint32_t Utf8CharKey(const char* str, size_t charLen) {
 }
 
 } // namespace
+
+class PrefixMatch::Tables {
+public:
+  std::vector<std::unique_ptr<Table>> tables;
+};
 
 class PrefixMatch::Table {
 public:
@@ -115,13 +121,40 @@ private:
   Node root;
 };
 
-PrefixMatch::PrefixMatch(const DictPtr& dict) { AddDict(dict); }
+PrefixMatch::PrefixMatch(const DictPtr& dict) {
+  static std::mutex cacheMutex;
+  static std::unordered_map<std::string, std::shared_ptr<const Tables>> cache;
+
+  std::string cacheKey;
+  AppendCacheKey(dict, &cacheKey);
+
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    const auto cached = cache.find(cacheKey);
+    if (cached != cache.end()) {
+      tables = cached->second;
+      return;
+    }
+  }
+
+  std::shared_ptr<Tables> built(new Tables);
+  AddDict(dict, built.get());
+
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const auto cached = cache.find(cacheKey);
+  if (cached == cache.end()) {
+    tables = built;
+    cache[cacheKey] = tables;
+  } else {
+    tables = cached->second;
+  }
+}
 
 PrefixMatch::~PrefixMatch() {}
 
 PrefixMatch::Match PrefixMatch::MatchPrefix(const char* word,
                                             size_t len) const {
-  for (const std::unique_ptr<Table>& table : tables) {
+  for (const std::unique_ptr<Table>& table : tables->tables) {
     const Match match = table->MatchPrefix(word, len);
     if (match.matched) {
       return match;
@@ -130,13 +163,29 @@ PrefixMatch::Match PrefixMatch::MatchPrefix(const char* word,
   return Match{false, 0, nullptr, nullptr};
 }
 
-void PrefixMatch::AddDict(const DictPtr& dict) {
+void PrefixMatch::AddDict(const DictPtr& dict, Tables* output) {
   const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
   if (dictGroupItems != nullptr) {
     for (const DictPtr& child : *dictGroupItems) {
-      AddDict(child);
+      AddDict(child, output);
     }
     return;
   }
-  tables.emplace_back(new Table(dict));
+  output->tables.emplace_back(new Table(dict));
+}
+
+void PrefixMatch::AppendCacheKey(const DictPtr& dict, std::string* output) {
+  const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
+  if (dictGroupItems != nullptr) {
+    output->push_back('[');
+    for (const DictPtr& child : *dictGroupItems) {
+      AppendCacheKey(child, output);
+    }
+    output->push_back(']');
+    return;
+  }
+
+  const uintptr_t dictKey = reinterpret_cast<uintptr_t>(dict.get());
+  output->append(reinterpret_cast<const char*>(&dictKey), sizeof(dictKey));
+  output->push_back(';');
 }

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -38,10 +38,12 @@ public:
 
 private:
   class Table;
+  class Tables;
 
-  void AddDict(const DictPtr& dict);
+  void AddDict(const DictPtr& dict, Tables* output);
+  static void AppendCacheKey(const DictPtr& dict, std::string* output);
 
-  std::vector<std::unique_ptr<Table>> tables;
+  std::shared_ptr<const Tables> tables;
 };
 
 } // namespace opencc

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -1,7 +1,7 @@
 /*
  * Open Chinese Convert
  *
- * Copyright 2010-2014 Carbo Kuo <byvoid@byvoid.com>
+ * Copyright 2010-2026 Carbo Kuo and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,26 +19,29 @@
 #pragma once
 
 #include "Common.hpp"
-#include "Segmentation.hpp"
 
 namespace opencc {
-class PrefixMatch;
-/**
- * Implementation of maximal match segmentation
- * @ingroup opencc_cpp_api
- */
-class OPENCC_EXPORT MaxMatchSegmentation : public Segmentation {
+
+class PrefixMatch {
 public:
-  MaxMatchSegmentation(const DictPtr _dict);
+  struct Match {
+    bool matched;
+    size_t keyLength;
+    const std::string* key;
+    const std::string* value;
+  };
 
-  virtual ~MaxMatchSegmentation() {}
+  explicit PrefixMatch(const DictPtr& dict);
+  ~PrefixMatch();
 
-  virtual SegmentsPtr Segment(const std::string& text) const;
-
-  const DictPtr GetDict() const { return dict; }
+  Match MatchPrefix(const char* word, size_t len) const;
 
 private:
-  const DictPtr dict;
-  const std::shared_ptr<PrefixMatch> prefixMatch;
+  class Table;
+
+  void AddDict(const DictPtr& dict);
+
+  std::vector<std::unique_ptr<Table>> tables;
 };
+
 } // namespace opencc

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -24,6 +24,8 @@ namespace opencc {
 
 class PrefixMatch {
 public:
+  class Tables;
+
   struct Match {
     bool matched;
     size_t keyLength;
@@ -38,10 +40,11 @@ public:
 
 private:
   class Table;
-  class Tables;
 
   void AddDict(const DictPtr& dict, Tables* output);
   static void AppendCacheKey(const DictPtr& dict, std::string* output);
+  static void CollectLeafDicts(const DictPtr& dict,
+                               std::vector<std::weak_ptr<const Dict>>* output);
 
   std::shared_ptr<const Tables> tables;
 };


### PR DESCRIPTION
Replace repeated `Dict::MatchPrefix` calls in the conversion hot loop with a conversion-local lookup structure. Each underlying dictionary is expanded once at Conversion construction time into buckets keyed by the first UTF-8 character. During conversion, the loop computes that compact first-character key, visits only the relevant bucket, and compares candidates with `memcmp` instead of walking the marisa-trie for every input position.

Within each bucket, entries are sorted by descending key byte length, so the first successful `memcmp` preserves longest-prefix behavior for that dictionary. The implementation stores each entry's default value next to its key, avoiding `DictEntry` wrapper access and value lookup in the inner loop.

`DictGroup` behavior is intentionally preserved. A group is represented as one lookup table per child dictionary, and conversion probes those tables in the original group order. This matches `DictGroup::MatchPrefix`, where an earlier dictionary match wins even if a later dictionary could match a longer key. A regression test covers this priority rule with an earlier short match beating a later longer match.

Add append-oriented conversion helpers so `Converter` can keep the existing segmentation and conversion-chain boundary model while writing the final output directly into a reserved string. This avoids constructing a final converted Segments object and then joining it, but still runs the full conversion chain independently inside each original segment, so golden behavior such as s2twp phrase handling is unchanged.

Verified with:
- `bazel test //src/... //test/...`
- `bazel test //test/golden:golden_convert_test`
- `cmake --build build/perf --target performance -j8`.
- Also ran the local performance benchmark for s2t/s2twp ocd2 conversion to confirm the optimized path is exercised.