### PR TITLE
Make `opencc` Python package pure Python: rewrite core algorithm, drop third-party library

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,12 +61,7 @@ jobs:
   test-pypi:
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
-        python-build: ["cp312"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -87,19 +82,16 @@ jobs:
           python-version: "3.12"
 
       - name: Build and test wheel
-        uses: pypa/cibuildwheel@v3.2.1
-        env:
-          CIBW_BUILD: ${{ matrix.python-build }}-*
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
-          CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "pytest {project}/python/tests"
+        run: |
+          python -m pip install --upgrade pip build pytest
+          python -m build --wheel --outdir wheelhouse
+          python -m pip install wheelhouse/*.whl
+          pytest python/tests
 
       - name: upload artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: opencc-${{ env.VERSION }}-pypi-${{ matrix.os }}-${{ matrix.python-build }}
+          name: opencc-${{ env.VERSION }}-pypi
           path: |
             wheelhouse/*.whl

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -7,11 +7,7 @@ jobs:
   release-pypi:
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, ubuntu-22.04-arm, macos-15-intel, macos-15, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -31,23 +27,8 @@ jobs:
       with:
         python-version: "3.12"
 
-    - name: Build package and upload (Linux)
-      if: runner.os == 'Linux'
+    - name: Build package and upload
       run: bash release-pypi-linux.sh
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-
-    - name: Build package and upload (macOS)
-      if: runner.os == 'macOS'
-      run: bash release-pypi-macos.sh
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-
-    - name: Build package and upload (Windows)
-      if: runner.os == 'Windows'
-      run: ./release-pypi-windows.cmd
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ See [demo.js](https://github.com/BYVoid/OpenCC/blob/master/node/demo.js) and [ts
 
 `pip install opencc` (Windows, Linux, macOS)
 
+The Python package uses the pure Python implementation and supports the built-in
+mmseg-based configs. Jieba plugin configs are not supported by the Python
+package.
+
 ```python
 import opencc
 converter = opencc.OpenCC('s2t.json')

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ The Python package uses the pure Python implementation and supports the built-in
 mmseg-based configs. Jieba plugin configs are not supported by the Python
 package.
 
+The pure Python implementation loads text dictionaries. Built-in configs keep
+their standard `.ocd2` dictionary references, and the Python loader resolves
+those references to bundled same-stem `.txt` dictionaries when possible. Custom
+configs that reference `.ocd` or `.ocd2` dictionaries must also provide matching
+text dictionary files; binary dictionary files are not parsed by the Python
+package.
+
 ```python
 import opencc
 converter = opencc.OpenCC('s2t.json')

--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ See [demo.js](https://github.com/BYVoid/OpenCC/blob/master/node/demo.js) and [ts
 `pip install opencc` (Windows, Linux, macOS)
 
 The Python package uses the pure Python implementation and supports the built-in
-mmseg-based configs. Jieba plugin configs are not supported by the Python
-package.
+mmseg-based configs. Jieba configs are optional: install `jieba` manually with
+`pip install jieba` to use configs such as `s2t_jieba` or `s2twp_jieba`.
+Installing `opencc` does not install `jieba` automatically. The Python package
+does not load the C++ `opencc-jieba` plugin; it uses the optional Python
+`jieba` package with bundled Jieba text dictionaries.
 
 The pure Python implementation loads text dictionaries. Built-in configs keep
 their standard `.ocd2` dictionary references, and the Python loader resolves
@@ -229,6 +232,8 @@ OpenCC now supports external C++ segmentation plugins. The first plugin is
 - 該插件機制目前仍為試驗性功能。
 - `jieba` 插件是可選組件，預設 OpenCC 構建、Python 套件和 Node.js 套件都不要求它。
 - `opencc-jieba` 額外依賴 `cppjieba` 及其配套詞典資源，這些依賴僅在構建或分發該插件時需要。
+- Python 套件不載入此 C++ 插件；安裝 Python `jieba` 套件後，Python 版會使用純 Python
+  後端與打包的 Jieba 文字詞典支援 `*_jieba` 配置。
 - 在下一次正式發布版本之前，插件 ABI 仍可能發生變化，不應視為穩定介面。
 - 我們預計從下一次正式發布版本開始，將插件 ABI 視為穩定介面。
 - Windows 下插件必須與宿主 OpenCC 二進位使用 ABI 相容的工具鏈／執行時構建；MSVC 與 MinGW 產物不支援混用。
@@ -241,6 +246,9 @@ Notes:
 - `opencc-jieba` additionally depends on `cppjieba` and its dictionary
   resources. These dependencies are only needed when building or distributing
   the plugin itself.
+- The Python package does not load this C++ plugin. If the Python `jieba`
+  package is installed manually, the pure Python backend supports `*_jieba`
+  configs with packaged Jieba text dictionaries.
 - The plugin ABI may still change before the next formal OpenCC release and
   should not yet be treated as stable.
 - We expect to treat the plugin ABI as stable starting with the next formal
@@ -299,7 +307,8 @@ bazel test --test_output=all //src/... //data/... //python/... //test/...
 make benchmark
 ```
 
-Example results (from Github CI, commit ID 9e80d5d, 2026-04-16, CMake macos-latest):
+Example results (from Github CI, commit ID 9e80d5d, 2026-04-16, CMake macos-latest).
+These are C++ core/plugin benchmarks, not Python package benchmarks:
 
 ```
 -------------------------------------------------------------------------
@@ -364,6 +373,9 @@ Apache License 2.0
 * [cppjieba](https://github.com/yanyiwu/cppjieba) MIT License
   - Optional dependency used by the experimental `opencc-jieba` plugin.
   - 試驗性 `opencc-jieba` 插件使用的可選依賴。
+* [jieba](https://github.com/fxsjy/jieba) MIT License
+  - Optional runtime dependency for Python `*_jieba` configs; not installed by default.
+  - Python `*_jieba` 配置的可選執行時依賴；預設不安裝。
 
 ## Change History 版本歷史
 

--- a/python/benchmarks/benchmark_opencc.py
+++ b/python/benchmarks/benchmark_opencc.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Benchmark the pure Python OpenCC package with project data."""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import opencc
+from opencc import _opencc_pure
+
+_this_dir = Path(__file__).resolve().parent
+_opencc_rootdir = _this_dir.parents[1]
+_testcases_path = _opencc_rootdir / 'test' / 'testcases' / 'testcases.json'
+_golden_input_path = _opencc_rootdir / 'test' / 'golden' / 'input' / 'us_constitution_zhs.txt'
+_long_input_path = _opencc_rootdir / 'test' / 'benchmark' / 'zuozhuan.txt'
+
+
+def _config_name(config):
+    return config[:-5] if config.endswith('.json') else config
+
+
+def _default_configs():
+    preferred = ['s2t', 't2s', 's2tw', 's2twp', 's2hk', 'tw2s']
+    available = {
+        _config_name(config)
+        for config in opencc.CONFIGS
+        if 'jieba' not in config
+    }
+    return [config for config in preferred if config in available]
+
+
+def _load_texts(dataset):
+    if dataset == 'testcases':
+        with open(_testcases_path, encoding='utf-8') as f:
+            parsed = json.load(f)
+        return [
+            case['input']
+            for case in parsed.get('cases', [])
+            if case.get('input')
+        ]
+
+    if dataset == 'golden':
+        return [_golden_input_path.read_text(encoding='utf-8')]
+
+    if dataset == 'long':
+        return [_long_input_path.read_text(encoding='utf-8')]
+
+    raise ValueError(f'Unknown dataset: {dataset}')
+
+
+def _time_call(fn):
+    start = time.perf_counter()
+    result = fn()
+    return time.perf_counter() - start, result
+
+
+def _median(values):
+    return statistics.median(values) if values else 0.0
+
+
+def _benchmark_init(configs, iterations):
+    rows = []
+    for config in configs:
+        samples = []
+        for _ in range(iterations):
+            _opencc_pure._trie_cache.clear()
+            elapsed, _ = _time_call(lambda: opencc.OpenCC(config))
+            samples.append(elapsed)
+        rows.append({
+            'name': f'init/{config}',
+            'iterations': iterations,
+            'seconds_median': _median(samples),
+            'seconds_min': min(samples),
+            'seconds_max': max(samples),
+            'chars_per_second': None,
+        })
+    return rows
+
+
+def _benchmark_convert(configs, texts, warmups, iterations):
+    total_chars = sum(len(text) for text in texts)
+    rows = []
+    for config in configs:
+        converter = opencc.OpenCC(config)
+        for _ in range(warmups):
+            for text in texts:
+                converter.convert(text)
+
+        samples = []
+        for _ in range(iterations):
+            elapsed, _ = _time_call(
+                lambda: [converter.convert(text) for text in texts]
+            )
+            samples.append(elapsed)
+
+        median = _median(samples)
+        rows.append({
+            'name': f'convert/{config}',
+            'iterations': iterations,
+            'seconds_median': median,
+            'seconds_min': min(samples),
+            'seconds_max': max(samples),
+            'chars_per_second': total_chars / median if median > 0 else 0.0,
+        })
+    return rows
+
+
+def _print_table(rows):
+    print('| benchmark | iterations | median ms | min ms | max ms | chars/s |')
+    print('|---|---:|---:|---:|---:|---:|')
+    for row in rows:
+        chars_per_second = row['chars_per_second']
+        if chars_per_second is None:
+            throughput = ''
+        else:
+            throughput = f'{chars_per_second:,.0f}'
+        print(
+            '| {name} | {iterations} | {median:.3f} | {min:.3f} | {max:.3f} | {throughput} |'.format(
+                name=row['name'],
+                iterations=row['iterations'],
+                median=row['seconds_median'] * 1000,
+                min=row['seconds_min'] * 1000,
+                max=row['seconds_max'] * 1000,
+                throughput=throughput,
+            )
+        )
+
+
+def _print_json(rows):
+    print(json.dumps(rows, ensure_ascii=False, indent=2))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--dataset',
+        choices=['testcases', 'golden', 'long'],
+        default='golden',
+        help='Project dataset to use for conversion benchmarks.',
+    )
+    parser.add_argument(
+        '--configs',
+        nargs='+',
+        default=None,
+        help='Config names to benchmark. Defaults to common non-jieba configs.',
+    )
+    parser.add_argument(
+        '--warmups',
+        type=int,
+        default=1,
+        help='Warmup conversion runs before timing.',
+    )
+    parser.add_argument(
+        '--iterations',
+        type=int,
+        default=5,
+        help='Timed iterations per benchmark.',
+    )
+    parser.add_argument(
+        '--include-init',
+        action='store_true',
+        help='Also benchmark converter construction time.',
+    )
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Emit machine-readable JSON instead of a Markdown table.',
+    )
+    args = parser.parse_args(argv)
+
+    configs = [_config_name(config) for config in (args.configs or _default_configs())]
+    texts = _load_texts(args.dataset)
+
+    rows = []
+    if args.include_init:
+        rows.extend(_benchmark_init(configs, args.iterations))
+    rows.extend(_benchmark_convert(configs, texts, args.warmups, args.iterations))
+
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_table(rows)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/python/opencc/BUILD.bazel
+++ b/python/opencc/BUILD.bazel
@@ -11,6 +11,9 @@ py_library(
     data = [
         "//data/config",
         "//data/dictionary:text_dictionaries",
+        "//plugins/jieba:config",
+        "//plugins/jieba/deps/cppjieba:dict/jieba.dict.utf8",
+        "//plugins/jieba/deps/cppjieba:dict/user.dict.utf8",
     ],
     imports = [".."],
 )

--- a/python/opencc/BUILD.bazel
+++ b/python/opencc/BUILD.bazel
@@ -4,12 +4,13 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "opencc",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "_opencc_pure.py",
+    ],
     data = [
         "//data/config",
-        "//data/dictionary:binary_dictionaries",
         "//data/dictionary:text_dictionaries",
     ],
     imports = [".."],
-    deps = ["//src:py_opencc"],
 )

--- a/python/opencc/__init__.py
+++ b/python/opencc/__init__.py
@@ -1,49 +1,13 @@
-import os
+from importlib import metadata
 
-try:
-    import opencc_clib
-except ImportError:
-    from opencc.clib import opencc_clib
+from opencc._opencc_pure import OpenCC
+from opencc._opencc_pure import list_configs
 
 __all__ = ['CONFIGS', 'OpenCC', '__version__']
 
-__version__ = opencc_clib.__version__
-_this_dir = os.path.dirname(os.path.abspath(__file__))
-_opencc_share_dir = os.path.join(_this_dir, 'clib', 'share', 'opencc')
-_opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
-_opencc_configdir = os.path.join(_opencc_rootdir, 'data', 'config')
+try:
+    __version__ = metadata.version('OpenCC')
+except metadata.PackageNotFoundError:
+    __version__ = 'dev'
 
-if os.path.isdir(_opencc_share_dir):
-    CONFIGS = [f for f in os.listdir(_opencc_share_dir) if f.endswith('.json')]
-elif os.path.isdir(_opencc_configdir):
-    CONFIGS = [f for f in os.listdir(_opencc_configdir) if f.endswith('.json')]
-else:
-    CONFIGS = []
-
-
-def _append_path_to_env(name: str, path: str) -> None:
-    value = os.environ.get(name, '')
-    if path in value:  # Path already exists
-        return
-    if value == '':
-        value = path
-    else:
-        value += f':{path}'
-    os.environ[name] = value
-
-
-class OpenCC(opencc_clib._OpenCC):
-
-    def __init__(self, config: str = 't2s') -> None:
-        if not config.endswith('.json'):
-            config += '.json'
-        if not os.path.isfile(config):
-            config_under_share_dir = os.path.join(_opencc_share_dir, config)
-            if os.path.isfile(config_under_share_dir):
-                config = config_under_share_dir
-        super().__init__(config)
-        self.config = config
-
-    def convert(self, text: str):
-        byte_text = text.encode('utf-8')
-        return super().convert(byte_text, len(byte_text))
+CONFIGS = list_configs()

--- a/python/opencc/_opencc_pure.py
+++ b/python/opencc/_opencc_pure.py
@@ -210,8 +210,10 @@ def _find_dict_txt(filename: str, config_dir: str = ''):
             stem = stem[: -len(ext)]
             break
 
-    if os.path.isabs(filename) and os.path.isfile(filename):
-        return filename, False
+    if os.path.isabs(filename):
+        path = stem + '.txt'
+        if os.path.isfile(path):
+            return path, False
 
     search_dirs = (
         config_dir,
@@ -247,7 +249,7 @@ def _parse_dict_lines(path: str):
     Comment lines (starting with ``#``) and blank lines are skipped.
     ``candidates`` is a list of one or more whitespace-separated values.
     """
-    with open(path, encoding='utf-8') as f:
+    with open(path, encoding='utf-8-sig') as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith('#') or '\t' not in line:

--- a/python/opencc/_opencc_pure.py
+++ b/python/opencc/_opencc_pure.py
@@ -1,0 +1,459 @@
+"""
+Pure Python implementation of the OpenCC Chinese conversion algorithm.
+
+Algorithm overview (mirrors the C++ reference implementation):
+
+  Dictionary (.txt)
+    Each line: ``key<TAB>value1 value2 ...``
+    The first listed candidate is used as the conversion target.
+
+  Trie
+    Character-by-character prefix tree.  Built per dictionary file.
+    ``prefix_match(text, pos)`` returns ``(matched_length, value)``
+    for the *longest* match starting at ``text[pos]``.
+
+  DictGroup  (_GroupMatcher)
+    An ordered list of tries.  At each position the tries are tried in
+    declaration order; the **first** trie that has any match (not the
+    globally longest) wins.  This gives phrase dictionaries priority
+    over character dictionaries, mirroring the C++ PrefixMatch logic.
+
+  Conversion
+    Scans the text left-to-right.  At each position the active
+    group/dict matcher is consulted; the matched substring is replaced
+    with the dictionary value.  On no match, exactly one character is
+    passed through unchanged.
+
+  MaxMatch Segmentation
+    Same scan as Conversion, but instead of replacing tokens the
+    matched keys are emitted as segment boundaries.  Unmatched
+    characters accumulate in a buffer that is flushed as a single
+    segment when the next match is found or the string ends.
+
+  Conversion Chain
+    Multiple conversion steps applied sequentially to each segment
+    produced by the segmenter.  Each step uses an independent
+    group/dict matcher.
+"""
+
+import json
+import os
+
+__all__ = ['OpenCC']
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Bundled data directories (populated when the package is installed with
+# ``pip install .`` and the data files are included as package_data).
+_pkg_config_dir = os.path.join(_this_dir, 'config')
+_pkg_dict_dir = os.path.join(_this_dir, 'dictionary')
+
+
+_MAX_PARENT_TRAVERSAL_DEPTH = 8
+
+
+def _find_repo_root() -> str:
+    """
+    Walk up the directory tree to find the OpenCC repo root.
+
+    Detects the repo by the presence of ``data/config/`` and
+    ``data/dictionary/`` subdirectories.  Returns an empty string when the
+    repo root cannot be determined (e.g. in a standalone installed package
+    without bundled data files).
+    """
+    candidate = _this_dir
+    for _ in range(_MAX_PARENT_TRAVERSAL_DEPTH):
+        if (os.path.isdir(os.path.join(candidate, 'data', 'config')) and
+                os.path.isdir(os.path.join(candidate, 'data', 'dictionary'))):
+            return candidate
+        parent = os.path.dirname(candidate)
+        if parent == candidate:
+            break
+        candidate = parent
+    return ''
+
+
+_repo_root = _find_repo_root()
+_repo_config_dir = os.path.join(_repo_root, 'data', 'config') if _repo_root else ''
+_repo_dict_dir = os.path.join(_repo_root, 'data', 'dictionary') if _repo_root else ''
+
+
+# Trie
+
+class _TrieNode:
+    """Single node in the character trie."""
+
+    __slots__ = ('children', 'value')
+
+    def __init__(self):
+        self.children = {}  # char -> _TrieNode
+        self.value = None   # str or None; non-None marks a terminal node
+
+
+class _Trie:
+    """
+    Character-by-character trie for longest-prefix matching.
+
+    Mirrors the inner ``Table`` class in ``PrefixMatch.cpp``.
+    """
+
+    __slots__ = ('root',)
+
+    def __init__(self):
+        self.root = _TrieNode()
+
+    def add(self, key: str, value: str) -> None:
+        """Insert ``key -> value`` into the trie."""
+        node = self.root
+        for ch in key:
+            child = node.children.get(ch)
+            if child is None:
+                child = _TrieNode()
+                node.children[ch] = child
+            node = child
+        node.value = value
+
+    def prefix_match(self, text: str, pos: int):
+        """
+        Find the longest entry whose key is a prefix of ``text[pos:]``.
+
+        Returns ``(matched_length, value)``; ``matched_length`` is 0 when
+        no entry matches.
+        """
+        node = self.root
+        matched_len = 0
+        matched_value = None
+        i = pos
+        n = len(text)
+        while i < n:
+            child = node.children.get(text[i])
+            if child is None:
+                break
+            node = child
+            i += 1
+            if node.value is not None:
+                matched_len = i - pos
+                matched_value = node.value
+        return matched_len, matched_value
+
+
+# DictGroup
+
+class _GroupMatcher:
+    """
+    Ordered collection of tries.
+
+    Mirrors the multi-table behaviour of ``PrefixMatch::MatchPrefix`` in the
+    C++ implementation: tries are checked in declaration order; the **first**
+    trie that has any prefix match returns its longest match for that trie.
+    This gives phrase dictionaries priority over character dictionaries.
+    """
+
+    __slots__ = ('tries',)
+
+    def __init__(self, tries):
+        self.tries = list(tries)
+
+    def match(self, text: str, pos: int):
+        """
+        Return ``(matched_length, value)`` using priority-ordered trie lookup.
+        Returns ``(0, None)`` when no trie has a match.
+        """
+        for trie in self.tries:
+            length, value = trie.prefix_match(text, pos)
+            if length > 0:
+                return length, value
+        return 0, None
+
+
+# Dictionary loading
+
+_trie_cache: dict = {}  # (absolute_path, reversed: bool) -> _Trie
+
+
+def _find_dict_txt(filename: str):
+    """
+    Resolve a dictionary filename (typically ``Foo.ocd2``) to a
+    ``(txt_path, needs_reverse)`` tuple.
+
+    Resolution:
+    1. Strip the extension (``Foo.ocd2`` → ``Foo``).
+    2. Look for ``<stem>.txt`` in the bundled pkg dir, then the repo dir.
+    3. If the stem ends with ``Rev`` (e.g. ``HKVariantsRev``), look for
+       the forward dict (``HKVariants.txt``) and mark it for reversal.
+       These reversed dicts are generated on-the-fly from the forward file,
+       matching the behaviour of the ``reverse_items`` build script.
+
+    Raises ``FileNotFoundError`` if no suitable txt file is found.
+    """
+    stem = filename
+    for ext in ('.ocd2', '.ocd', '.txt'):
+        if stem.endswith(ext):
+            stem = stem[: -len(ext)]
+            break
+
+    for search_dir in (_pkg_dict_dir, _repo_dict_dir):
+        if not search_dir:
+            continue
+        path = os.path.join(search_dir, stem + '.txt')
+        if os.path.isfile(path):
+            return path, False
+
+    # Try reversed dict: strip the trailing "Rev" and reverse the forward file.
+    if stem.endswith('Rev'):
+        forward_stem = stem[:-3]
+        for search_dir in (_pkg_dict_dir, _repo_dict_dir):
+            if not search_dir:
+                continue
+            path = os.path.join(search_dir, forward_stem + '.txt')
+            if os.path.isfile(path):
+                return path, True
+
+    raise FileNotFoundError(f'Dictionary file not found for: {filename!r}')
+
+
+def _parse_dict_lines(path: str):
+    """
+    Yield ``(key, candidates)`` tuples for every data line in a txt dict file.
+
+    Comment lines (starting with ``#``) and blank lines are skipped.
+    ``candidates`` is a list of one or more whitespace-separated values.
+    """
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '\t' not in line:
+                continue
+            key, rest = line.split('\t', 1)
+            candidates = rest.split()
+            if candidates:
+                yield key, candidates
+
+
+def _load_trie(path: str, reverse: bool) -> _Trie:
+    """
+    Load a ``key<TAB>value1 value2 ...`` txt file into a :class:`_Trie`.
+
+    When ``reverse`` is ``True`` the mapping is inverted: each candidate
+    value becomes a key whose conversion target is the original key.  When
+    multiple original keys share the same candidate value the first
+    encountered (in file order) wins, matching the behaviour of the C++
+    dict-reversal script.
+    """
+    cache_key = (path, reverse)
+    cached = _trie_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    trie = _Trie()
+
+    if not reverse:
+        for key, candidates in _parse_dict_lines(path):
+            trie.add(key, candidates[0])
+    else:
+        # Reverse: each candidate value -> original key (first writer wins).
+        reversed_mapping: dict = {}
+        for key, candidates in _parse_dict_lines(path):
+            for candidate in candidates:
+                if candidate not in reversed_mapping:
+                    reversed_mapping[candidate] = key
+        for new_key, new_value in reversed_mapping.items():
+            trie.add(new_key, new_value)
+
+    _trie_cache[cache_key] = trie
+    return trie
+
+
+def _get_trie(filename: str) -> _Trie:
+    """Resolve ``filename`` to a txt path and return the loaded trie."""
+    path, needs_reverse = _find_dict_txt(filename)
+    return _load_trie(path, needs_reverse)
+
+
+# Config parsing
+
+def _parse_dict_node(d: dict) -> _GroupMatcher:
+    """
+    Recursively parse a JSON dict-config node and return a :class:`_GroupMatcher`.
+
+    Mirrors ``ConfigInternal::ParseDict`` in ``Config.cpp``.  Groups are
+    flattened into an ordered list of leaf tries, preserving the priority
+    order used by ``PrefixMatch::AddDict``.
+    """
+    dtype = d['type']
+
+    if dtype == 'group':
+        tries = []
+        for sub in d['dicts']:
+            sub_matcher = _parse_dict_node(sub)
+            # Flatten: extend with the sub-group's ordered tries list.
+            tries.extend(sub_matcher.tries)
+        return _GroupMatcher(tries)
+
+    if dtype in ('ocd2', 'ocd', 'txt', 'text'):
+        trie = _get_trie(d['file'])
+        return _GroupMatcher([trie])
+
+    raise ValueError(f'Unknown dict type: {dtype!r}')
+
+
+# Core conversion routines
+
+def _convert_phrase(text: str, matcher: _GroupMatcher) -> str:
+    """
+    Convert *text* using left-to-right longest-prefix matching.
+
+    At each position the group matcher is consulted (first-trie-wins
+    semantics).  On a match the matched substring is replaced by the
+    dictionary value.  On no match exactly one character is passed through
+    unchanged, mirroring ``Conversion::AppendConverted`` in the C++ code.
+    """
+    parts = []
+    i = 0
+    n = len(text)
+    while i < n:
+        length, value = matcher.match(text, i)
+        if length > 0:
+            parts.append(value)
+            i += length
+        else:
+            parts.append(text[i])
+            i += 1
+    return ''.join(parts)
+
+
+def _segment(text: str, matcher: _GroupMatcher) -> list:
+    """
+    Max-match segmentation of *text*.
+
+    Scans left-to-right using the segmentation dict.  On a match the
+    pending character buffer is flushed as one segment and the matched key
+    becomes the next segment.  Unmatched characters accumulate until the
+    next match or end of string.
+
+    Mirrors ``MaxMatchSegmentation::Segment`` in the C++ code.
+    """
+    segments = []
+    buf = []
+    i = 0
+    n = len(text)
+    while i < n:
+        length, _ = matcher.match(text, i)
+        if length > 0:
+            if buf:
+                segments.append(''.join(buf))
+                buf = []
+            segments.append(text[i: i + length])
+            i += length
+        else:
+            buf.append(text[i])
+            i += 1
+    if buf:
+        segments.append(''.join(buf))
+    return segments
+
+
+# Config location helpers
+
+def _find_config(config_name: str) -> str:
+    """
+    Locate a config JSON file by name (with or without ``.json`` suffix).
+
+    Searches the bundled package config directory first, then the source-tree
+    ``data/config`` directory as a fallback.
+    """
+    filename = config_name if config_name.endswith('.json') else config_name + '.json'
+    for search_dir in (_pkg_config_dir, _repo_config_dir):
+        if not search_dir:
+            continue
+        path = os.path.join(search_dir, filename)
+        if os.path.isfile(path):
+            return path
+    raise FileNotFoundError(f'Config not found: {config_name!r}')
+
+
+def _is_mmseg_config(config_path: str) -> bool:
+    """Return True if the config uses mmseg segmentation (pure-Python compatible)."""
+    try:
+        with open(config_path, encoding='utf-8') as f:
+            cfg = json.load(f)
+        return cfg.get('segmentation', {}).get('type') == 'mmseg'
+    except Exception:
+        return False
+
+
+def list_configs() -> list:
+    """
+    Return a sorted list of ``.json`` config filenames available to the
+    pure Python converter (mmseg-based configs only).
+    """
+    configs = []
+    seen = set()
+    for search_dir in (_pkg_config_dir, _repo_config_dir):
+        if not search_dir or not os.path.isdir(search_dir):
+            continue
+        for fname in os.listdir(search_dir):
+            if not fname.endswith('.json') or fname in seen:
+                continue
+            path = os.path.join(search_dir, fname)
+            if _is_mmseg_config(path):
+                configs.append(fname)
+                seen.add(fname)
+    return sorted(configs)
+
+
+# Public API
+
+class OpenCC:
+    """
+    Pure Python OpenCC converter.
+
+    Usage::
+
+        cc = OpenCC('s2t')          # or 's2t.json'
+        result = cc.convert('汉字')  # -> '漢字'
+
+    The ``config`` argument accepts a conversion name (e.g. ``'s2t'``) or
+    a bare filename (e.g. ``'s2t.json'``).  Custom absolute config paths
+    are also accepted.
+    """
+
+    def __init__(self, config: str = 't2s') -> None:
+        config_name = config[:-5] if config.endswith('.json') else config
+
+        # Allow custom config paths, matching the previous Python wrapper.
+        if os.path.isfile(config):
+            config_path = config
+        else:
+            config_path = _find_config(config_name)
+
+        with open(config_path, encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        self.config = config if config.endswith('.json') else f'{config}.json'
+
+        seg_type = cfg.get('segmentation', {}).get('type', '')
+        if seg_type != 'mmseg':
+            raise ValueError(
+                f"Config {config_name!r} uses segmentation type {seg_type!r} "
+                f"which is not supported by the pure Python backend."
+            )
+
+        self._segmenter: _GroupMatcher = _parse_dict_node(
+            cfg['segmentation']['dict']
+        )
+        self._chain: list = [
+            _parse_dict_node(step['dict'])
+            for step in cfg['conversion_chain']
+        ]
+
+    def convert(self, text: str) -> str:
+        """Convert *text* and return the result."""
+        segments = _segment(text, self._segmenter)
+        result = []
+        for seg in segments:
+            converted = seg
+            for matcher in self._chain:
+                converted = _convert_phrase(converted, matcher)
+            result.append(converted)
+        return ''.join(result)

--- a/python/opencc/_opencc_pure.py
+++ b/python/opencc/_opencc_pure.py
@@ -38,6 +38,7 @@ Algorithm overview (mirrors the C++ reference implementation):
 
 import json
 import os
+from pathlib import Path
 
 __all__ = ['OpenCC']
 
@@ -50,6 +51,20 @@ _pkg_dict_dir = os.path.join(_this_dir, 'dictionary')
 
 
 _MAX_PARENT_TRAVERSAL_DEPTH = 8
+
+
+def _runfile_dir(relative_path: str) -> str:
+    runfiles_root = os.environ.get('RUNFILES_DIR')
+    workspace = os.environ.get('TEST_WORKSPACE', '_main')
+    if not runfiles_root:
+        return ''
+
+    for candidate in (
+            Path(runfiles_root) / workspace / relative_path,
+            Path(runfiles_root) / relative_path):
+        if candidate.is_dir():
+            return str(candidate)
+    return ''
 
 
 def _find_repo_root() -> str:
@@ -76,6 +91,8 @@ def _find_repo_root() -> str:
 _repo_root = _find_repo_root()
 _repo_config_dir = os.path.join(_repo_root, 'data', 'config') if _repo_root else ''
 _repo_dict_dir = os.path.join(_repo_root, 'data', 'dictionary') if _repo_root else ''
+_runfiles_config_dir = _runfile_dir('data/config')
+_runfiles_dict_dir = _runfile_dir('data/dictionary')
 
 
 # Trie
@@ -171,14 +188,15 @@ class _GroupMatcher:
 _trie_cache: dict = {}  # (absolute_path, reversed: bool) -> _Trie
 
 
-def _find_dict_txt(filename: str):
+def _find_dict_txt(filename: str, config_dir: str = ''):
     """
     Resolve a dictionary filename (typically ``Foo.ocd2``) to a
     ``(txt_path, needs_reverse)`` tuple.
 
     Resolution:
     1. Strip the extension (``Foo.ocd2`` → ``Foo``).
-    2. Look for ``<stem>.txt`` in the bundled pkg dir, then the repo dir.
+    2. Look for ``<stem>.txt`` next to a custom config, in the bundled pkg
+       dir, then in Bazel runfiles and the repo dir.
     3. If the stem ends with ``Rev`` (e.g. ``HKVariantsRev``), look for
        the forward dict (``HKVariants.txt``) and mark it for reversal.
        These reversed dicts are generated on-the-fly from the forward file,
@@ -192,7 +210,17 @@ def _find_dict_txt(filename: str):
             stem = stem[: -len(ext)]
             break
 
-    for search_dir in (_pkg_dict_dir, _repo_dict_dir):
+    if os.path.isabs(filename) and os.path.isfile(filename):
+        return filename, False
+
+    search_dirs = (
+        config_dir,
+        _pkg_dict_dir,
+        _runfiles_dict_dir,
+        _repo_dict_dir,
+    )
+
+    for search_dir in search_dirs:
         if not search_dir:
             continue
         path = os.path.join(search_dir, stem + '.txt')
@@ -202,7 +230,7 @@ def _find_dict_txt(filename: str):
     # Try reversed dict: strip the trailing "Rev" and reverse the forward file.
     if stem.endswith('Rev'):
         forward_stem = stem[:-3]
-        for search_dir in (_pkg_dict_dir, _repo_dict_dir):
+        for search_dir in search_dirs:
             if not search_dir:
                 continue
             path = os.path.join(search_dir, forward_stem + '.txt')
@@ -264,15 +292,15 @@ def _load_trie(path: str, reverse: bool) -> _Trie:
     return trie
 
 
-def _get_trie(filename: str) -> _Trie:
+def _get_trie(filename: str, config_dir: str = '') -> _Trie:
     """Resolve ``filename`` to a txt path and return the loaded trie."""
-    path, needs_reverse = _find_dict_txt(filename)
+    path, needs_reverse = _find_dict_txt(filename, config_dir)
     return _load_trie(path, needs_reverse)
 
 
 # Config parsing
 
-def _parse_dict_node(d: dict) -> _GroupMatcher:
+def _parse_dict_node(d: dict, config_dir: str = '') -> _GroupMatcher:
     """
     Recursively parse a JSON dict-config node and return a :class:`_GroupMatcher`.
 
@@ -285,13 +313,13 @@ def _parse_dict_node(d: dict) -> _GroupMatcher:
     if dtype == 'group':
         tries = []
         for sub in d['dicts']:
-            sub_matcher = _parse_dict_node(sub)
+            sub_matcher = _parse_dict_node(sub, config_dir)
             # Flatten: extend with the sub-group's ordered tries list.
             tries.extend(sub_matcher.tries)
         return _GroupMatcher(tries)
 
     if dtype in ('ocd2', 'ocd', 'txt', 'text'):
-        trie = _get_trie(d['file'])
+        trie = _get_trie(d['file'], config_dir)
         return _GroupMatcher([trie])
 
     raise ValueError(f'Unknown dict type: {dtype!r}')
@@ -363,7 +391,7 @@ def _find_config(config_name: str) -> str:
     ``data/config`` directory as a fallback.
     """
     filename = config_name if config_name.endswith('.json') else config_name + '.json'
-    for search_dir in (_pkg_config_dir, _repo_config_dir):
+    for search_dir in (_pkg_config_dir, _runfiles_config_dir, _repo_config_dir):
         if not search_dir:
             continue
         path = os.path.join(search_dir, filename)
@@ -389,7 +417,7 @@ def list_configs() -> list:
     """
     configs = []
     seen = set()
-    for search_dir in (_pkg_config_dir, _repo_config_dir):
+    for search_dir in (_pkg_config_dir, _runfiles_config_dir, _repo_config_dir):
         if not search_dir or not os.path.isdir(search_dir):
             continue
         for fname in os.listdir(search_dir):
@@ -440,10 +468,11 @@ class OpenCC:
             )
 
         self._segmenter: _GroupMatcher = _parse_dict_node(
-            cfg['segmentation']['dict']
+            cfg['segmentation']['dict'],
+            os.path.dirname(config_path),
         )
         self._chain: list = [
-            _parse_dict_node(step['dict'])
+            _parse_dict_node(step['dict'], os.path.dirname(config_path))
             for step in cfg['conversion_chain']
         ]
 

--- a/python/opencc/_opencc_pure.py
+++ b/python/opencc/_opencc_pure.py
@@ -38,6 +38,7 @@ Algorithm overview (mirrors the C++ reference implementation):
 
 import json
 import os
+import importlib.util
 from pathlib import Path
 
 __all__ = ['OpenCC']
@@ -48,6 +49,7 @@ _this_dir = os.path.dirname(os.path.abspath(__file__))
 # ``pip install .`` and the data files are included as package_data).
 _pkg_config_dir = os.path.join(_this_dir, 'config')
 _pkg_dict_dir = os.path.join(_this_dir, 'dictionary')
+_pkg_jieba_dict_dir = os.path.join(_this_dir, 'jieba_dict')
 
 
 _MAX_PARENT_TRAVERSAL_DEPTH = 8
@@ -91,8 +93,12 @@ def _find_repo_root() -> str:
 _repo_root = _find_repo_root()
 _repo_config_dir = os.path.join(_repo_root, 'data', 'config') if _repo_root else ''
 _repo_dict_dir = os.path.join(_repo_root, 'data', 'dictionary') if _repo_root else ''
+_repo_jieba_config_dir = os.path.join(_repo_root, 'plugins', 'jieba', 'data', 'config') if _repo_root else ''
+_repo_jieba_dict_dir = os.path.join(_repo_root, 'plugins', 'jieba', 'deps', 'cppjieba', 'dict') if _repo_root else ''
 _runfiles_config_dir = _runfile_dir('data/config')
 _runfiles_dict_dir = _runfile_dir('data/dictionary')
+_runfiles_jieba_config_dir = _runfile_dir('plugins/jieba/data/config')
+_runfiles_jieba_dict_dir = _runfile_dir('plugins/jieba/deps/cppjieba/dict')
 
 
 # Trie
@@ -181,6 +187,111 @@ class _GroupMatcher:
             if length > 0:
                 return length, value
         return 0, None
+
+
+# Jieba segmentation
+
+_jieba_tokenizer_cache: dict = {}
+
+
+class _JiebaSegmenter:
+    """
+    Optional Jieba segmenter backed by the ``jieba`` Python package.
+
+    The dependency is intentionally lazy: importing ``opencc`` and using the
+    normal mmseg configs never imports or requires ``jieba``.
+    """
+
+    __slots__ = ('tokenizer',)
+
+    def __init__(self, resources: dict, config_dir: str = ''):
+        try:
+            import jieba
+        except ImportError as exc:
+            raise ImportError(
+                "Config uses Jieba segmentation. Install the optional "
+                "dependency with `pip install jieba` to use *_jieba configs."
+            ) from exc
+
+        dict_path = _find_jieba_resource(
+            resources.get('dict_path', ''),
+            config_dir,
+            'jieba.dict.utf8',
+        )
+        user_dict_path = _find_jieba_resource(
+            resources.get('user_dict_path', ''),
+            config_dir,
+            'user.dict.utf8',
+            required=False,
+        )
+
+        cache_key = (dict_path, user_dict_path)
+        tokenizer = _jieba_tokenizer_cache.get(cache_key)
+        if tokenizer is None:
+            tokenizer = jieba.Tokenizer(dictionary=dict_path)
+            tokenizer.initialize()
+            if user_dict_path:
+                tokenizer.load_userdict(user_dict_path)
+            _jieba_tokenizer_cache[cache_key] = tokenizer
+        self.tokenizer = tokenizer
+
+    def segment(self, text: str) -> list:
+        return list(self.tokenizer.cut(text, HMM=True))
+
+
+def _jieba_available() -> bool:
+    return importlib.util.find_spec('jieba') is not None
+
+
+def _find_jieba_resource(raw_path: str,
+                         config_dir: str,
+                         fallback_name: str,
+                         required: bool = True) -> str:
+    """
+    Resolve Jieba resources for the pure Python optional backend.
+
+    Plugin configs point at ``jieba_merged.ocd2`` for the C++ plugin.  Python
+    ``jieba`` consumes cppjieba's text dictionaries directly, so that request
+    is mapped to ``jieba.dict.utf8`` plus ``user.dict.utf8``.
+    """
+    candidates = []
+
+    if raw_path:
+        if raw_path.endswith('jieba_merged.ocd2'):
+            candidates.append(raw_path[:-len('jieba_merged.ocd2')] + fallback_name)
+            candidates.append(fallback_name)
+        else:
+            candidates.append(raw_path)
+            candidates.append(os.path.join(os.path.dirname(raw_path), fallback_name))
+            candidates.append(fallback_name)
+    else:
+        candidates.append(fallback_name)
+
+    search_dirs = (
+        '',
+        config_dir,
+        os.path.dirname(config_dir) if config_dir else '',
+        _pkg_jieba_dict_dir,
+        _runfiles_jieba_dict_dir,
+        _repo_jieba_dict_dir,
+    )
+
+    seen = set()
+    for candidate in candidates:
+        for search_dir in search_dirs:
+            if not candidate:
+                continue
+            path = candidate if os.path.isabs(candidate) or not search_dir else os.path.join(search_dir, candidate)
+            norm = os.path.abspath(path)
+            if norm in seen:
+                continue
+            seen.add(norm)
+            if os.path.isfile(path):
+                return path
+
+    if required:
+        raise FileNotFoundError(f'Jieba resource not found: {fallback_name!r}')
+    return ''
 
 
 # Dictionary loading
@@ -393,7 +504,12 @@ def _find_config(config_name: str) -> str:
     ``data/config`` directory as a fallback.
     """
     filename = config_name if config_name.endswith('.json') else config_name + '.json'
-    for search_dir in (_pkg_config_dir, _runfiles_config_dir, _repo_config_dir):
+    for search_dir in (
+            _pkg_config_dir,
+            _runfiles_config_dir,
+            _repo_config_dir,
+            _runfiles_jieba_config_dir,
+            _repo_jieba_config_dir):
         if not search_dir:
             continue
         path = os.path.join(search_dir, filename)
@@ -412,21 +528,47 @@ def _is_mmseg_config(config_path: str) -> bool:
         return False
 
 
+def _is_supported_config(config_path: str) -> bool:
+    """Return True if the pure Python backend can use this config now."""
+    try:
+        with open(config_path, encoding='utf-8') as f:
+            cfg = json.load(f)
+        seg_type = cfg.get('segmentation', {}).get('type')
+        if seg_type == 'mmseg':
+            return True
+        if seg_type == 'jieba':
+            if not _jieba_available():
+                return False
+            resources = cfg.get('segmentation', {}).get('resources', {})
+            config_dir = os.path.dirname(config_path)
+            _find_jieba_resource(resources.get('dict_path', ''), config_dir, 'jieba.dict.utf8')
+            return True
+        return False
+    except Exception:
+        return False
+
+
 def list_configs() -> list:
     """
     Return a sorted list of ``.json`` config filenames available to the
-    pure Python converter (mmseg-based configs only).
+    pure Python converter.  Jieba configs are listed only when the optional
+    ``jieba`` package and dictionary data are available.
     """
     configs = []
     seen = set()
-    for search_dir in (_pkg_config_dir, _runfiles_config_dir, _repo_config_dir):
+    for search_dir in (
+            _pkg_config_dir,
+            _runfiles_config_dir,
+            _repo_config_dir,
+            _runfiles_jieba_config_dir,
+            _repo_jieba_config_dir):
         if not search_dir or not os.path.isdir(search_dir):
             continue
         for fname in os.listdir(search_dir):
             if not fname.endswith('.json') or fname in seen:
                 continue
             path = os.path.join(search_dir, fname)
-            if _is_mmseg_config(path):
+            if _is_supported_config(path):
                 configs.append(fname)
                 seen.add(fname)
     return sorted(configs)
@@ -462,25 +604,33 @@ class OpenCC:
 
         self.config = config if config.endswith('.json') else f'{config}.json'
 
-        seg_type = cfg.get('segmentation', {}).get('type', '')
-        if seg_type != 'mmseg':
+        config_dir = os.path.dirname(config_path)
+        segmentation = cfg.get('segmentation', {})
+        seg_type = segmentation.get('type', '')
+        if seg_type == 'mmseg':
+            self._segmenter = _parse_dict_node(segmentation['dict'], config_dir)
+        elif seg_type == 'jieba':
+            self._segmenter = _JiebaSegmenter(
+                segmentation.get('resources', {}),
+                config_dir,
+            )
+        else:
             raise ValueError(
                 f"Config {config_name!r} uses segmentation type {seg_type!r} "
                 f"which is not supported by the pure Python backend."
             )
 
-        self._segmenter: _GroupMatcher = _parse_dict_node(
-            cfg['segmentation']['dict'],
-            os.path.dirname(config_path),
-        )
         self._chain: list = [
-            _parse_dict_node(step['dict'], os.path.dirname(config_path))
+            _parse_dict_node(step['dict'], config_dir)
             for step in cfg['conversion_chain']
         ]
 
     def convert(self, text: str) -> str:
         """Convert *text* and return the result."""
-        segments = _segment(text, self._segmenter)
+        if isinstance(self._segmenter, _JiebaSegmenter):
+            segments = self._segmenter.segment(text)
+        else:
+            segments = _segment(text, self._segmenter)
         result = []
         for seg in segments:
             converted = seg

--- a/python/opencc/_opencc_pure.py
+++ b/python/opencc/_opencc_pure.py
@@ -594,8 +594,11 @@ class OpenCC:
         config_name = config[:-5] if config.endswith('.json') else config
 
         # Allow custom config paths, matching the previous Python wrapper.
+        suffixed_config = config if config.endswith('.json') else f'{config}.json'
         if os.path.isfile(config):
             config_path = config
+        elif os.path.isfile(suffixed_config):
+            config_path = suffixed_config
         else:
             config_path = _find_config(config_name)
 

--- a/python/tests/BUILD.bazel
+++ b/python/tests/BUILD.bazel
@@ -6,7 +6,25 @@ py_test(
     size = "small",
     srcs = ["test_opencc.py"],
     data = [
+        "//test/config_test",
         "//test/testcases",
+    ],
+    imports = [".."],
+    deps = [
+        "//python/opencc",
+        requirement("pytest"),
+        requirement("pygments"),
+        requirement("exceptiongroup"),
+    ],
+)
+
+py_test(
+    name = "test_opencc_golden",
+    size = "medium",
+    srcs = ["test_opencc_golden.py"],
+    data = [
+        "//test/golden:golden_inputs",
+        "//test/golden:golden_outputs",
     ],
     imports = [".."],
     deps = [

--- a/python/tests/BUILD.bazel
+++ b/python/tests/BUILD.bazel
@@ -6,6 +6,7 @@ py_test(
     size = "small",
     srcs = ["test_opencc.py"],
     data = [
+        "//plugins/jieba:testcases",
         "//test/config_test",
         "//test/testcases",
     ],

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -20,6 +20,12 @@ def test_init_delete_converter():
         del converter
 
 
+def test_jieba_configs_are_not_exposed():
+    import opencc
+
+    assert all('jieba' not in config for config in opencc.CONFIGS)
+
+
 def test_conversion():
     import opencc
 

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -1,4 +1,5 @@
 import json
+import importlib.util
 import os
 import pytest
 import sys
@@ -7,6 +8,18 @@ _this_dir = os.path.dirname(os.path.abspath(__file__))
 _opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
 _testcases_path = os.path.join(_opencc_rootdir, 'test', 'testcases', 'testcases.json')
 _config_test_path = os.path.join(_opencc_rootdir, 'test', 'config_test', 'config_test.json')
+_jieba_testcases_path = os.path.join(
+    _opencc_rootdir,
+    'plugins',
+    'jieba',
+    'tests',
+    'data',
+    'jieba_comparison_testcases.json',
+)
+
+
+def _has_jieba():
+    return importlib.util.find_spec('jieba') is not None
 
 
 def test_import():
@@ -21,10 +34,39 @@ def test_init_delete_converter():
         del converter
 
 
-def test_jieba_configs_are_not_exposed():
+def test_jieba_configs_are_exposed_only_when_optional_dependency_is_available():
     import opencc
 
-    assert all('jieba' not in config for config in opencc.CONFIGS)
+    if _has_jieba():
+        assert any('jieba' in config for config in opencc.CONFIGS)
+    else:
+        assert all('jieba' not in config for config in opencc.CONFIGS)
+
+
+def test_jieba_config_requires_optional_dependency_when_missing():
+    if _has_jieba():
+        pytest.skip('jieba is installed')
+
+    import opencc
+
+    with pytest.raises(ImportError, match='pip install jieba'):
+        opencc.OpenCC('s2t_jieba')
+
+
+@pytest.mark.skipif(not _has_jieba(), reason='jieba optional dependency is not installed')
+def test_jieba_configs_match_plugin_comparison_cases():
+    import opencc
+
+    with open(_jieba_testcases_path, 'r', encoding='utf-8') as f:
+        parsed = json.load(f)
+
+    for case in parsed['cases']:
+        for cfg, ans in case.get('expected', {}).items():
+            if not cfg.endswith('_jieba'):
+                continue
+            converter = opencc.OpenCC(f'{cfg}.json')
+            assert converter.convert(case['input']) == ans, \
+                'Failed to convert {} for {} -> {}'.format(cfg, case['input'], ans)
 
 
 def test_custom_config_resolves_local_dictionaries():

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -36,6 +36,44 @@ def test_custom_config_resolves_local_dictionaries():
     assert converter.convert('远') == '遠'
 
 
+def test_custom_config_resolves_absolute_ocd2_path_to_text_dictionary(tmp_path):
+    import opencc
+
+    dict_txt = tmp_path / 'CustomPhrases.txt'
+    dict_txt.write_text('测试\t測試\n', encoding='utf-8')
+    config_path = tmp_path / 'custom.json'
+    config_path.write_text(json.dumps({
+        'name': 'Custom',
+        'segmentation': {
+            'type': 'mmseg',
+            'dict': {
+                'type': 'ocd2',
+                'file': str(tmp_path / 'CustomPhrases.ocd2'),
+            },
+        },
+        'conversion_chain': [{
+            'dict': {
+                'type': 'ocd2',
+                'file': str(tmp_path / 'CustomPhrases.ocd2'),
+            },
+        }],
+    }), encoding='utf-8')
+
+    converter = opencc.OpenCC(str(config_path))
+
+    assert converter.convert('测试') == '測試'
+
+
+def test_dictionary_parser_strips_utf8_bom(tmp_path):
+    from opencc import _opencc_pure
+
+    dict_txt = tmp_path / 'BomPhrases.txt'
+    dict_txt.write_text('\ufeff测试\t測試\n', encoding='utf-8')
+    trie = _opencc_pure._load_trie(str(dict_txt), reverse=False)
+
+    assert trie.prefix_match('测试', 0) == (2, '測試')
+
+
 def test_conversion():
     import opencc
 

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -6,6 +6,7 @@ import sys
 _this_dir = os.path.dirname(os.path.abspath(__file__))
 _opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
 _testcases_path = os.path.join(_opencc_rootdir, 'test', 'testcases', 'testcases.json')
+_config_test_path = os.path.join(_opencc_rootdir, 'test', 'config_test', 'config_test.json')
 
 
 def test_import():
@@ -24,6 +25,15 @@ def test_jieba_configs_are_not_exposed():
     import opencc
 
     assert all('jieba' not in config for config in opencc.CONFIGS)
+
+
+def test_custom_config_resolves_local_dictionaries():
+    import opencc
+
+    converter = opencc.OpenCC(_config_test_path)
+
+    assert converter.convert('燕燕于飞，之子于归。') == '燕燕于飛，之子于歸。'
+    assert converter.convert('远') == '遠'
 
 
 def test_conversion():

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -78,6 +78,14 @@ def test_custom_config_resolves_local_dictionaries():
     assert converter.convert('远') == '遠'
 
 
+def test_custom_config_path_accepts_suffixless_json_path():
+    import opencc
+
+    converter = opencc.OpenCC(_config_test_path[:-5])
+
+    assert converter.convert('燕燕于飞，之子于归。') == '燕燕于飛，之子于歸。'
+
+
 def test_custom_config_resolves_absolute_ocd2_path_to_text_dictionary(tmp_path):
     import opencc
 

--- a/python/tests/test_opencc_golden.py
+++ b/python/tests/test_opencc_golden.py
@@ -1,0 +1,59 @@
+import difflib
+from pathlib import Path
+
+import pytest
+
+import opencc
+
+_this_dir = Path(__file__).resolve().parent
+_opencc_rootdir = _this_dir.parents[1]
+_golden_input_dir = _opencc_rootdir / 'test' / 'golden' / 'input'
+_golden_output_dir = _opencc_rootdir / 'test' / 'golden' / 'output'
+
+_GOLDEN_INPUTS = [
+    'us_constitution_zhs.txt',
+]
+
+
+def _available_python_golden_cases():
+    configs = [
+        config[:-5] if config.endswith('.json') else config
+        for config in opencc.CONFIGS
+        if 'jieba' not in config
+    ]
+    cases = []
+    for input_name in _GOLDEN_INPUTS:
+        input_stem = Path(input_name).stem
+        for config in configs:
+            expected_path = _golden_output_dir / f'{input_stem}.{config}.txt'
+            if expected_path.is_file():
+                cases.append((input_name, config, expected_path))
+    return cases
+
+
+_GOLDEN_CASES = _available_python_golden_cases()
+
+
+def test_python_golden_cases_are_available():
+    assert _GOLDEN_CASES
+
+
+@pytest.mark.parametrize(
+    'input_name,config,expected_path',
+    _GOLDEN_CASES,
+)
+def test_python_matches_project_golden_output(input_name, config, expected_path):
+    input_path = _golden_input_dir / input_name
+    source_text = input_path.read_text(encoding='utf-8')
+    expected = expected_path.read_text(encoding='utf-8')
+
+    actual = opencc.OpenCC(config).convert(source_text)
+
+    assert actual == expected, ''.join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=str(expected_path),
+            tofile=f'opencc.OpenCC({config!r})',
+        )
+    )

--- a/release-pypi-linux.sh
+++ b/release-pypi-linux.sh
@@ -1,23 +1,11 @@
 #!/bin/sh
 set -e
 
-# Linux wheels are built inside manylinux2014 containers managed by cibuildwheel.
-python -m pip install --upgrade pip cibuildwheel twine build
+python -m pip install --upgrade pip build pytest twine
 
-export CIBW_BUILD="cp310-* cp311-* cp312-* cp313-* cp314-*"
-export CIBW_SKIP="*-musllinux_*"
-export CIBW_MANYLINUX_X86_64_IMAGE="manylinux2014"
-export CIBW_MANYLINUX_AARCH64_IMAGE="manylinux2014"
-export CIBW_ENVIRONMENT="VERSION=\"${VERSION}\""
-export CIBW_TEST_REQUIRES="pytest"
-export CIBW_TEST_COMMAND="pytest {project}/python/tests"
-
-python -m cibuildwheel --output-dir wheelhouse
-
-if [ "$(uname -m)" = "x86_64" ]; then
-    # Build sdist only once, to avoid duplicate uploads from matrix jobs.
-    python -m build --sdist --outdir wheelhouse
-fi
+python -m build --sdist --wheel --outdir wheelhouse
+python -m pip install wheelhouse/*.whl
+pytest python/tests
 
 if [ "$1" != "testonly" ]; then
     # Upload to PyPI

--- a/release-pypi-macos.sh
+++ b/release-pypi-macos.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
 set -e
 
-python -m pip install --upgrade pip cibuildwheel twine
+python -m pip install --upgrade pip build pytest twine
 
-export CIBW_BUILD="cp310-* cp311-* cp312-* cp313-* cp314-*"
-export CIBW_ENVIRONMENT="VERSION=\"${VERSION}\""
-export CIBW_TEST_REQUIRES="pytest"
-export CIBW_TEST_COMMAND="pytest {project}/python/tests"
-
-python -m cibuildwheel --output-dir wheelhouse
+python -m build --wheel --outdir wheelhouse
+python -m pip install wheelhouse/*.whl
+pytest python/tests
 
 if [ "$1" != "testonly" ]; then
     # Upload to PyPI

--- a/release-pypi-windows.cmd
+++ b/release-pypi-windows.cmd
@@ -1,16 +1,18 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-python -m pip install --upgrade pip cibuildwheel twine
+python -m pip install --upgrade pip build pytest twine
 if !ERRORLEVEL! NEQ 0 (EXIT !ERRORLEVEL!)
 
-SET CIBW_BUILD=cp310-* cp311-* cp312-* cp313-* cp314-*
-SET CIBW_ARCHS=AMD64
-SET CIBW_ENVIRONMENT=VERSION="%VERSION%"
-SET CIBW_TEST_REQUIRES=pytest
-SET CIBW_TEST_COMMAND=pytest {project}/python/tests
+python -m build --wheel --outdir wheelhouse
+if !ERRORLEVEL! NEQ 0 (EXIT !ERRORLEVEL!)
 
-python -m cibuildwheel --output-dir wheelhouse
+for %%f in (wheelhouse\*.whl) do (
+    python -m pip install "%%f"
+    if !ERRORLEVEL! NEQ 0 (EXIT !ERRORLEVEL!)
+)
+
+pytest python/tests
 if !ERRORLEVEL! NEQ 0 (EXIT !ERRORLEVEL!)
 
 if NOT "%~1"=="testonly" (

--- a/setup.py
+++ b/setup.py
@@ -103,9 +103,12 @@ class BuildPyCommand(setuptools.command.build_py.build_py, object):
     def _copy_opencc_data(self):
         src_config = os.path.join(_this_dir, 'data', 'config')
         src_dict = os.path.join(_this_dir, 'data', 'dictionary')
+        src_jieba_config = os.path.join(_this_dir, 'plugins', 'jieba', 'data', 'config')
+        src_jieba_dict = os.path.join(_this_dir, 'plugins', 'jieba', 'deps', 'cppjieba', 'dict')
         dst_base = os.path.join(self.build_lib, 'opencc')
         dst_config = os.path.join(dst_base, 'config')
         dst_dict = os.path.join(dst_base, 'dictionary')
+        dst_jieba_dict = os.path.join(dst_base, 'jieba_dict')
 
         os.makedirs(dst_config, exist_ok=True)
         for fname in os.listdir(src_config):
@@ -117,6 +120,13 @@ class BuildPyCommand(setuptools.command.build_py.build_py, object):
             if config.get('segmentation', {}).get('type') != 'mmseg':
                 continue
             shutil.copy2(src_config_path, os.path.join(dst_config, fname))
+        if os.path.isdir(src_jieba_config):
+            for fname in os.listdir(src_jieba_config):
+                if fname.endswith('.json'):
+                    shutil.copy2(
+                        os.path.join(src_jieba_config, fname),
+                        os.path.join(dst_config, fname),
+                    )
 
         os.makedirs(dst_dict, exist_ok=True)
         for fname in os.listdir(src_dict):
@@ -125,6 +135,11 @@ class BuildPyCommand(setuptools.command.build_py.build_py, object):
                     os.path.join(src_dict, fname),
                     os.path.join(dst_dict, fname),
                 )
+        os.makedirs(dst_jieba_dict, exist_ok=True)
+        for fname in ('jieba.dict.utf8', 'user.dict.utf8'):
+            src_path = os.path.join(src_jieba_dict, fname)
+            if os.path.isfile(src_path):
+                shutil.copy2(src_path, os.path.join(dst_jieba_dict, fname))
 
 
 packages = ['opencc']
@@ -145,7 +160,7 @@ setuptools.setup(
     packages=packages,
     package_dir={'opencc': 'python/opencc'},
     package_data={
-        'opencc': ['py.typed', 'config/*.json', 'dictionary/*.txt'],
+        'opencc': ['py.typed', 'config/*.json', 'dictionary/*.txt', 'jieba_dict/*.utf8'],
     },
     cmdclass={
         'build_py': BuildPyCommand,

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,14 @@
+import json
 import os
 import re
 import shutil
 import subprocess
-import sys
-import warnings
 
 import setuptools
-import setuptools.command.build_ext
-import wheel.bdist_wheel
+import setuptools.command.build_py
 
 _this_dir = os.path.dirname(os.path.abspath(__file__))
-_build_dir = os.path.join(_this_dir, 'build', 'python')
 
-_cmake_file = os.path.join(_this_dir, 'CMakeLists.txt')
 _author_file = os.path.join(_this_dir, 'AUTHORS')
 _readme_file = os.path.join(_this_dir, 'README.md')
 _fallback_version = '1.3.1'
@@ -97,109 +93,44 @@ def get_long_description():
         return f.read().decode('utf-8')
 
 
-def build_libopencc(output_path):
-    print('building libopencc into %s' % _build_dir)
+class BuildPyCommand(setuptools.command.build_py.build_py, object):
+    """Bundle OpenCC's JSON configs and text dictionaries into the package."""
 
-    is_windows = sys.platform == 'win32'
+    def run(self):
+        super(BuildPyCommand, self).run()
+        self._copy_opencc_data()
 
-    # Make build directories
-    os.makedirs(_build_dir, exist_ok=True)
+    def _copy_opencc_data(self):
+        src_config = os.path.join(_this_dir, 'data', 'config')
+        src_dict = os.path.join(_this_dir, 'data', 'dictionary')
+        dst_base = os.path.join(self.build_lib, 'opencc')
+        dst_config = os.path.join(dst_base, 'config')
+        dst_dict = os.path.join(dst_base, 'dictionary')
 
-    # Configure
-    cmake_args = [
-        '-DBUILD_DOCUMENTATION:BOOL=OFF',
-        '-DBUILD_SHARED_LIBS:BOOL=OFF',
-        '-DENABLE_GTEST:BOOL=OFF',
-        '-DENABLE_BENCHMARK:BOOL=OFF',
-        '-DBUILD_PYTHON:BOOL=ON',
-        '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_INSTALL_PREFIX={}'.format(output_path),
-        '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}'.format(output_path),
-        '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
-    ]
+        os.makedirs(dst_config, exist_ok=True)
+        for fname in os.listdir(src_config):
+            if not fname.endswith('.json'):
+                continue
+            src_config_path = os.path.join(src_config, fname)
+            with open(src_config_path, encoding='utf-8') as f:
+                config = json.load(f)
+            if config.get('segmentation', {}).get('type') != 'mmseg':
+                continue
+            shutil.copy2(src_config_path, os.path.join(dst_config, fname))
 
-    if is_windows:
-        cmake_args += \
-            ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE={}'.format(output_path)]
-        if sys.maxsize > 2**32:
-            cmake_args += ['-A', 'x64']
-
-    cmd = ['cmake', '-B', _build_dir] + cmake_args
-    errno = subprocess.call(cmd)
-    assert errno == 0, 'Configure failed'
-
-    # Build
-    cmd = [
-        'cmake', '--build', _build_dir,
-        '--config', 'Release',
-        '--target', 'install'
-    ]
-    errno = subprocess.call(cmd)
-    assert errno == 0, 'Build failed'
+        os.makedirs(dst_dict, exist_ok=True)
+        for fname in os.listdir(src_dict):
+            if fname.endswith('.txt'):
+                shutil.copy2(
+                    os.path.join(src_dict, fname),
+                    os.path.join(dst_dict, fname),
+                )
 
 
-class OpenCCExtension(setuptools.Extension, object):
-    def __init__(self, name, sourcedir=''):
-        setuptools.Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
-
-
-class BuildExtCommand(setuptools.command.build_ext.build_ext, object):
-    def build_extension(self, ext):
-        if self.inplace:
-            output_path = os.path.join(_this_dir, 'python', 'opencc', 'clib')
-        else:
-            output_path = os.path.abspath(os.path.join(self.build_lib, 'opencc', 'clib'))
-        if isinstance(ext, OpenCCExtension):
-            build_libopencc(output_path)
-        else:
-            super(BuildExtCommand, self).build_extension(ext)
-
-
-class BDistWheelCommand(wheel.bdist_wheel.bdist_wheel, object):
-    """Custom bdsit_wheel command that will change
-    default plat-name based on PEP 425 and PEP 513
-    """
-
-    @staticmethod
-    def _determine_platform_tag():
-        if sys.platform == 'win32':
-            if 'amd64' in sys.version.lower():
-                return 'win-amd64'
-            return sys.platform
-
-        if sys.platform == 'darwin':
-            _, _, _, _, machine = os.uname()
-            if machine == 'x86_64':
-                return 'macosx-10.9-{}'.format(machine)
-            if machine == 'arm64':
-                return 'macosx-11.0-{}'.format(machine)
-            else:
-                raise NotImplementedError
-
-        if os.name == 'posix':
-            _, _, _, _, machine = os.uname()
-            return 'manylinux2014-{}'.format(machine)
-
-        warnings.warn(
-            'Windows macos and linux are all not detected, '
-            'Proper distribution name cannot be determined.')
-        from distutils.util import get_platform
-        return get_platform()
-
-    def initialize_options(self):
-        super(BDistWheelCommand, self).initialize_options()
-        self.plat_name = self._determine_platform_tag()
-
-
-packages = ['opencc', 'opencc.clib']
+packages = ['opencc']
 
 version_info = get_version_info()
 author_info = get_author_info()
-
-setup_requires = []
-if not shutil.which('cmake'):
-    setup_requires.append('cmake')
 
 setuptools.setup(
     name='OpenCC',
@@ -213,12 +144,12 @@ setuptools.setup(
 
     packages=packages,
     package_dir={'opencc': 'python/opencc'},
-    ext_modules=[OpenCCExtension('opencc.clib.opencc_clib', 'python')],
-    cmdclass={
-        'build_ext': BuildExtCommand,
-        'bdist_wheel': BDistWheelCommand,
+    package_data={
+        'opencc': ['py.typed', 'config/*.json', 'dictionary/*.txt'],
     },
-    setup_requires=setup_requires,
+    cmdclass={
+        'build_py': BuildPyCommand,
+    },
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Replace the Python native extension wrapper with a self-contained pure Python implementation that mirrors the OpenCC conversion pipeline. Bundle mmseg JSON configs and text dictionaries into the Python package, expose only supported non-jieba configs, and simplify Python wheel/release workflows to build a py3-none-any package.

The plugin jieba is not supported at this time. Loading config from custom config path is not supported at this time.

From https://github.com/frankslin/OpenCC/pull/29