### PR TITLE
Create a schema definition for OpenCC configs and validation; non-BMP tests; data test reorg

### DIFF
--- a/data/config/BUILD.bazel
+++ b/data/config/BUILD.bazel
@@ -1,8 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
+CONFIGS = glob(
+    ["*.json"],
+    exclude = ["*.schema.json"],
+)
+
 filegroup(
     name = "config",
-    srcs = glob(["*.json"]),
+    srcs = CONFIGS,
+)
+
+filegroup(
+    name = "config_schema",
+    srcs = ["opencc_config.schema.json"],
 )
 
 cc_test(
@@ -19,5 +29,35 @@ cc_test(
         "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest_main",
         "@rapidjson",
+    ],
+)
+
+[
+    cc_test(
+        name = "config_schema_validation_" + config[:-5],
+        size = "small",
+        srcs = ["ConfigSchemaValidationTest.cpp"],
+        local_defines = [
+            "BAZEL",
+            "OPENCC_CONFIG_SCHEMA_TEST_FILE=\\\"" + config + "\\\"",
+        ],
+        data = [
+            config,
+            ":config_schema",
+        ],
+        deps = [
+            "@bazel_tools//tools/cpp/runfiles",
+            "@googletest//:gtest_main",
+            "@rapidjson",
+        ],
+    )
+    for config in CONFIGS
+]
+
+test_suite(
+    name = "config_schema_validation_test",
+    tests = [
+        ":config_schema_validation_" + config[:-5]
+        for config in CONFIGS
     ],
 )

--- a/data/config/BUILD.bazel
+++ b/data/config/BUILD.bazel
@@ -15,20 +15,35 @@ filegroup(
     srcs = ["opencc_config.schema.json"],
 )
 
-cc_test(
+[
+    cc_test(
+        name = "config_dict_validation_" + config[:-5],
+        size = "small",
+        srcs = ["ConfigDictValidationTest.cpp"],
+        local_defines = [
+            "BAZEL",
+            "OPENCC_CONFIG_DICT_TEST_FILE=\\\"" + config + "\\\"",
+        ],
+        data = [
+            config,
+            "//data/dictionary:binary_dictionaries",
+            "//test/testcases",
+        ],
+        deps = [
+            "//src:simple_converter",
+            "@bazel_tools//tools/cpp/runfiles",
+            "@googletest//:gtest_main",
+            "@rapidjson",
+        ],
+    )
+    for config in CONFIGS
+]
+
+test_suite(
     name = "config_dict_validation_test",
-    size = "small",
-    srcs = ["ConfigDictValidationTest.cpp"],
-    data = [
-        ":config",
-        "//data/dictionary:binary_dictionaries",
-        "//test/testcases",
-    ],
-    deps = [
-        "//src:simple_converter",
-        "@bazel_tools//tools/cpp/runfiles",
-        "@googletest//:gtest_main",
-        "@rapidjson",
+    tests = [
+        ":config_dict_validation_" + config[:-5]
+        for config in CONFIGS
     ],
 )
 

--- a/data/config/ConfigDictValidationTest.cpp
+++ b/data/config/ConfigDictValidationTest.cpp
@@ -25,6 +25,10 @@ using bazel::tools::cpp::runfiles::Runfiles;
 namespace opencc {
 namespace {
 
+#ifndef OPENCC_CONFIG_DICT_TEST_FILE
+#error "OPENCC_CONFIG_DICT_TEST_FILE must be defined"
+#endif
+
 class ConfigDictValidationTest : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -32,8 +36,15 @@ protected:
     runfiles_.reset(Runfiles::CreateForTest());
     ASSERT_NE(nullptr, runfiles_);
     testcasesPath_ = runfiles_->Rlocation("_main/test/testcases/testcases.json");
-    const std::string configFile =
-        runfiles_->Rlocation("_main/data/config/hk2s.json");
+    configName_ = OPENCC_CONFIG_DICT_TEST_FILE;
+    const std::string suffix = ".json";
+    if (configName_.size() >= suffix.size() &&
+        configName_.compare(configName_.size() - suffix.size(), suffix.size(),
+                            suffix) == 0) {
+      configName_.erase(configName_.size() - suffix.size());
+    }
+    const std::string configFile = runfiles_->Rlocation(
+        "_main/data/config/" + std::string(OPENCC_CONFIG_DICT_TEST_FILE));
     configDir_ = configFile.substr(0, configFile.find_last_of("/\\"));
     const std::string dictFile =
         runfiles_->Rlocation("_main/data/dictionary/STCharacters.ocd2");
@@ -66,6 +77,7 @@ protected:
   }
 
   std::unique_ptr<Runfiles> runfiles_;
+  std::string configName_;
   std::string testcasesPath_;
   std::string configDir_;
   std::string dictDir_;
@@ -83,6 +95,7 @@ TEST_F(ConfigDictValidationTest, ConvertExpectedOutputs) {
   const auto& cases = doc["cases"];
   ASSERT_TRUE(cases.IsArray());
 
+  size_t checkedCases = 0;
   for (auto& testcase : cases.GetArray()) {
     ASSERT_TRUE(testcase.IsObject());
     ASSERT_TRUE(testcase.HasMember("input"));
@@ -95,16 +108,19 @@ TEST_F(ConfigDictValidationTest, ConvertExpectedOutputs) {
     ASSERT_TRUE(testcase.HasMember("expected"));
     const auto& expectedObj = testcase["expected"];
     ASSERT_TRUE(expectedObj.IsObject());
-    for (auto itr = expectedObj.MemberBegin(); itr != expectedObj.MemberEnd();
-         ++itr) {
-      const std::string config = itr->name.GetString();
-      ASSERT_TRUE(itr->value.IsString());
-      const std::string expected = itr->value.GetString();
-      SimpleConverter& converter = GetConverter(config);
-      EXPECT_EQ(expected, converter.Convert(input))
-          << "config=" << config << " case=" << id;
+    if (!expectedObj.HasMember(configName_.c_str())) {
+      continue;
     }
+    const auto& expectedValue = expectedObj[configName_.c_str()];
+    ASSERT_TRUE(expectedValue.IsString())
+        << "config=" << configName_ << " case=" << id;
+    const std::string expected = expectedValue.GetString();
+    SimpleConverter& converter = GetConverter(configName_);
+    EXPECT_EQ(expected, converter.Convert(input))
+        << "config=" << configName_ << " case=" << id;
+    ++checkedCases;
   }
+  EXPECT_GT(checkedCases, 0) << "No testcases found for config=" << configName_;
 }
 
 } // namespace

--- a/data/config/ConfigSchemaValidationTest.cpp
+++ b/data/config/ConfigSchemaValidationTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * Open Chinese Convert
+ *
+ * Validate bundled JSON configurations against opencc_config.schema.json.
+ */
+
+#ifndef BAZEL
+// This test is Bazel-only; CMake builds should skip compiling it.
+static_assert(false, "ConfigSchemaValidationTest is only supported under Bazel");
+#else
+
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "rapidjson/document.h"
+#include "rapidjson/error/en.h"
+#include "rapidjson/schema.h"
+#include "rapidjson/stringbuffer.h"
+
+#include "tools/cpp/runfiles/runfiles.h"
+using bazel::tools::cpp::runfiles::Runfiles;
+
+namespace opencc {
+namespace {
+
+#ifndef OPENCC_CONFIG_SCHEMA_TEST_FILE
+#error "OPENCC_CONFIG_SCHEMA_TEST_FILE must be defined"
+#endif
+
+std::string ReadFile(const std::string& path) {
+  std::ifstream ifs(path);
+  EXPECT_TRUE(ifs.is_open()) << path;
+  std::stringstream buffer;
+  buffer << ifs.rdbuf();
+  return buffer.str();
+}
+
+std::string StringifyPointer(const rapidjson::Pointer& pointer) {
+  rapidjson::StringBuffer buffer;
+  pointer.Stringify(buffer);
+  return buffer.GetString();
+}
+
+TEST(ConfigSchemaValidationTest, BundledConfigsMatchSchema) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+  ASSERT_NE(nullptr, runfiles);
+
+  const std::string configFile = OPENCC_CONFIG_SCHEMA_TEST_FILE;
+  const std::string schemaPath =
+      runfiles->Rlocation("_main/data/config/opencc_config.schema.json");
+  const std::string schemaJson = ReadFile(schemaPath);
+  rapidjson::Document schemaDoc;
+  schemaDoc.Parse(schemaJson.c_str());
+  ASSERT_FALSE(schemaDoc.HasParseError())
+      << "schema parse error at offset " << schemaDoc.GetErrorOffset() << ": "
+      << rapidjson::GetParseError_En(schemaDoc.GetParseError());
+  ASSERT_TRUE(schemaDoc.IsObject());
+  rapidjson::SchemaDocument schema(schemaDoc);
+
+  const std::string configPath =
+      runfiles->Rlocation("_main/data/config/" + configFile);
+  const std::string configJson = ReadFile(configPath);
+  rapidjson::Document configDoc;
+  configDoc.Parse(configJson.c_str());
+  ASSERT_FALSE(configDoc.HasParseError())
+      << configFile << " parse error at offset " << configDoc.GetErrorOffset()
+      << ": " << rapidjson::GetParseError_En(configDoc.GetParseError());
+
+  rapidjson::SchemaValidator validator(schema);
+  EXPECT_TRUE(configDoc.Accept(validator))
+      << configFile << " violates schema at document path "
+      << StringifyPointer(validator.GetInvalidDocumentPointer())
+      << ", schema path "
+      << StringifyPointer(validator.GetInvalidSchemaPointer()) << ", keyword "
+      << validator.GetInvalidSchemaKeyword();
+}
+
+} // namespace
+} // namespace opencc
+
+#endif // BAZEL

--- a/data/config/opencc_config.schema.json
+++ b/data/config/opencc_config.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://opencc.byvoid.com/schema/opencc_config.schema.json",
+  "title": "OpenCC configuration",
+  "type": "object",
+  "required": [
+    "segmentation",
+    "conversion_chain"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "segmentation": {
+      "$ref": "#/definitions/segmentation"
+    },
+    "conversion_chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/conversion"
+      }
+    }
+  },
+  "definitions": {
+    "segmentation": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/mmseg_segmentation"
+        },
+        {
+          "$ref": "#/definitions/plugin_segmentation"
+        }
+      ]
+    },
+    "mmseg_segmentation": {
+      "type": "object",
+      "required": [
+        "type",
+        "dict"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "mmseg"
+          ]
+        },
+        "dict": {
+          "$ref": "#/definitions/dict"
+        }
+      }
+    },
+    "plugin_segmentation": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "not": {
+        "properties": {
+          "type": {
+            "enum": [
+              "mmseg"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "conversion": {
+      "type": "object",
+      "required": [
+        "dict"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "dict": {
+          "$ref": "#/definitions/dict"
+        }
+      }
+    },
+    "dict": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file_dict"
+        },
+        {
+          "$ref": "#/definitions/group_dict"
+        }
+      ]
+    },
+    "file_dict": {
+      "type": "object",
+      "required": [
+        "type",
+        "file"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "text",
+            "ocd",
+            "ocd2"
+          ]
+        },
+        "file": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "group_dict": {
+      "type": "object",
+      "required": [
+        "type",
+        "dicts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": [
+            "group"
+          ]
+        },
+        "dicts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/dict"
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/dictionary/BUILD.bazel
+++ b/data/dictionary/BUILD.bazel
@@ -56,20 +56,52 @@ filegroup(
     srcs = [txt.replace(".txt", ".ocd2") for txt in TEXT_DICTS],
 )
 
+[
+    cc_test(
+        name = "dictionary_" + txt[:-4] + "_test",
+        size = "small",
+        srcs = ["DictionaryTest.cpp"],
+        local_defines = [
+            "OPENCC_DICTIONARY_TEST_FILE=\\\"" + txt + "\\\"",
+        ],
+        data = [
+            txt,
+            txt.replace(".txt", ".ocd2"),
+        ],
+        deps = [
+            "//src:lexicon",
+            "//src:marisa_dict",
+            "//src:utf8_util",
+            "@bazel_tools//tools/cpp/runfiles",
+            "@googletest//:gtest_main",
+        ],
+    )
+    for txt in TEXT_DICTS
+]
+
 cc_test(
-    name = "dictionary_test",
+    name = "dictionary_TWPhrases_reverse_mapping_test",
     size = "small",
-    srcs = ["DictionaryTest.cpp"],
+    srcs = ["DictionaryReverseMappingTest.cpp"],
     data = [
-        ":binary_dictionaries",
-        ":text_dictionaries",
+        "TWPhrases.txt",
+        "TWPhrasesRev.txt",
     ],
     deps = [
         "//src:lexicon",
-        "//src:marisa_dict",
         "//src:utf8_util",
         "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest_main",
+    ],
+)
+
+test_suite(
+    name = "dictionary_test",
+    tests = [
+        ":dictionary_" + txt[:-4] + "_test"
+        for txt in TEXT_DICTS
+    ] + [
+        ":dictionary_TWPhrases_reverse_mapping_test",
     ],
 )
 

--- a/data/dictionary/BUILD.bazel
+++ b/data/dictionary/BUILD.bazel
@@ -22,6 +22,15 @@ TEXT_DICTS = glob(["*.txt"]) + [
     "JPVariantsRev.txt",
 ]
 
+NON_BMP_TEXT_DICTS = [
+    txt
+    for txt in TEXT_DICTS
+    if txt not in [
+        "STCharacters.txt",
+        "TSCharacters.txt",
+    ]
+]
+
 [
     genrule(
         name = "generate_bin_" + txt[:-4],
@@ -61,5 +70,31 @@ cc_test(
         "//src:utf8_util",
         "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest_main",
+    ],
+)
+
+[
+    cc_test(
+        name = "dictionary_non_bmp_" + txt[:-4] + "_test",
+        size = "small",
+        srcs = ["DictionaryNonBmpTest.cpp"],
+        local_defines = [
+            "OPENCC_DICTIONARY_NON_BMP_TEST_FILE=\\\"" + txt + "\\\"",
+        ],
+        data = [txt],
+        deps = [
+            "//src:utf8_util",
+            "@bazel_tools//tools/cpp/runfiles",
+            "@googletest//:gtest_main",
+        ],
+    )
+    for txt in NON_BMP_TEXT_DICTS
+]
+
+test_suite(
+    name = "dictionary_non_bmp_test",
+    tests = [
+        ":dictionary_non_bmp_" + txt[:-4] + "_test"
+        for txt in NON_BMP_TEXT_DICTS
     ],
 )

--- a/data/dictionary/DictionaryNonBmpTest.cpp
+++ b/data/dictionary/DictionaryNonBmpTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Open Chinese Convert
+ *
+ * Validate non-BMP characters in phrase and variant dictionaries.
+ */
+
+#include "gtest/gtest.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "src/UTF8Util.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+namespace opencc {
+namespace {
+
+#ifndef OPENCC_DICTIONARY_NON_BMP_TEST_FILE
+#error "OPENCC_DICTIONARY_NON_BMP_TEST_FILE must be defined"
+#endif
+
+struct NonBmpException {
+  const char* dictionary;
+  const char* character;
+};
+
+constexpr std::array<NonBmpException, 3> kAllowedNonBmpCharacters = {{
+    {"STPhrases", "\xF0\xAA\xA2\xAE"}, // U+2A8AE
+    {"STPhrases", "\xF0\xAB\x97\xA7"}, // U+2B5E7
+    {"TSPhrases", "\xF0\xAB\xAB\x87"}, // U+2BAC7
+}};
+
+uint32_t DecodeUtf8CodePoint(const char* str, size_t length) {
+  const unsigned char* bytes = reinterpret_cast<const unsigned char*>(str);
+  if (length == 1) {
+    return bytes[0];
+  }
+  if (length == 2) {
+    return ((bytes[0] & 0x1F) << 6) | (bytes[1] & 0x3F);
+  }
+  if (length == 3) {
+    return ((bytes[0] & 0x0F) << 12) | ((bytes[1] & 0x3F) << 6) |
+           (bytes[2] & 0x3F);
+  }
+  if (length == 4) {
+    return ((bytes[0] & 0x07) << 18) | ((bytes[1] & 0x3F) << 12) |
+           ((bytes[2] & 0x3F) << 6) | (bytes[3] & 0x3F);
+  }
+  return 0;
+}
+
+std::string FormatCodePoint(uint32_t codePoint) {
+  char buffer[11];
+  snprintf(buffer, sizeof(buffer), "U+%04X", codePoint);
+  return buffer;
+}
+
+bool IsAllowedNonBmpCharacter(const std::string& dictionary,
+                              const std::string& character) {
+  for (const auto& exception : kAllowedNonBmpCharacters) {
+    if (dictionary == exception.dictionary && character == exception.character) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(DictionaryNonBmpTest, OnlyAllowlistedCharactersOutsideCharacterDicts) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+  ASSERT_NE(nullptr, runfiles);
+
+  std::string dictionaryName = OPENCC_DICTIONARY_NON_BMP_TEST_FILE;
+  const std::string suffix = ".txt";
+  ASSERT_TRUE(dictionaryName.size() >= suffix.size());
+  ASSERT_EQ(suffix, dictionaryName.substr(dictionaryName.size() - suffix.size()));
+  dictionaryName.erase(dictionaryName.size() - suffix.size());
+
+  const std::string dictionaryFileName = runfiles->Rlocation(
+      "_main/data/dictionary/" +
+      std::string(OPENCC_DICTIONARY_NON_BMP_TEST_FILE));
+  std::ifstream ifs(UTF8Util::GetPlatformString(dictionaryFileName));
+  ASSERT_TRUE(ifs.is_open()) << dictionaryFileName;
+
+  std::string line;
+  size_t lineNumber = 0;
+  while (std::getline(ifs, line)) {
+    ++lineNumber;
+    for (const char* cursor = line.c_str(); *cursor != '\0';) {
+      const size_t length = UTF8Util::NextCharLength(cursor);
+      const uint32_t codePoint = DecodeUtf8CodePoint(cursor, length);
+      if (codePoint > 0xFFFF) {
+        const std::string character(cursor, length);
+        EXPECT_TRUE(IsAllowedNonBmpCharacter(dictionaryName, character))
+            << dictionaryName << ":" << lineNumber
+            << " contains non-BMP character " << FormatCodePoint(codePoint)
+            << ". Add it to kAllowedNonBmpCharacters only if it is intentional.";
+      }
+      cursor += length;
+    }
+  }
+}
+
+} // namespace
+} // namespace opencc

--- a/data/dictionary/DictionaryReverseMappingTest.cpp
+++ b/data/dictionary/DictionaryReverseMappingTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Open Chinese Convert
+ *
+ * Validate generated reverse phrase dictionaries.
+ */
+
+#include "gtest/gtest.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "src/Exception.hpp"
+#include "src/Lexicon.hpp"
+#include "src/UTF8Util.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+namespace opencc {
+namespace {
+
+static FILE* OpenFile(const std::string& path) {
+#ifdef _MSC_VER
+  return _wfopen(UTF8Util::GetPlatformString(path).c_str(), L"rb");
+#else
+  return fopen(UTF8Util::GetPlatformString(path).c_str(), "rb");
+#endif
+}
+
+TEST(DictionaryReverseMappingTest, TWPhrasesReverseMapping) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+  ASSERT_NE(nullptr, runfiles);
+
+  const std::string twPhrasesFile =
+      runfiles->Rlocation("_main/data/dictionary/TWPhrases.txt");
+  const std::string twPhrasesRevFile =
+      runfiles->Rlocation("_main/data/dictionary/TWPhrasesRev.txt");
+
+  auto loadLexicon = [](const std::string& path) -> LexiconPtr {
+    FILE* fp = OpenFile(path);
+    EXPECT_NE(fp, nullptr) << path;
+    if (fp == nullptr) {
+      return LexiconPtr();
+    }
+    return Lexicon::ParseLexiconFromFile(fp);
+  };
+
+  auto buildMap = [](const LexiconPtr& lexicon)
+      -> std::unordered_map<std::string, std::unordered_set<std::string>> {
+    std::unordered_map<std::string, std::unordered_set<std::string>> map;
+    if (!lexicon) {
+      return map;
+    }
+    for (size_t i = 0; i < lexicon->Length(); ++i) {
+      const DictEntry* entry = lexicon->At(i);
+      auto& values = map[entry->Key()];
+      for (const auto& value : entry->Values()) {
+        values.insert(value);
+      }
+    }
+    return map;
+  };
+
+  try {
+    LexiconPtr twPhrases = loadLexicon(twPhrasesFile);
+    LexiconPtr twPhrasesRev = loadLexicon(twPhrasesRevFile);
+    ASSERT_NE(twPhrases, nullptr);
+    ASSERT_NE(twPhrasesRev, nullptr);
+
+    auto twMap = buildMap(twPhrases);
+    auto twRevMap = buildMap(twPhrasesRev);
+
+    for (const auto& entry : twMap) {
+      const std::string& key = entry.first;
+      for (const auto& value : entry.second) {
+        auto it = twRevMap.find(value);
+        EXPECT_TRUE(it != twRevMap.end() && it->second.count(key) > 0)
+            << "Missing reverse mapping: " << key << " -> " << value;
+      }
+    }
+
+    for (const auto& entry : twRevMap) {
+      const std::string& key = entry.first;
+      for (const auto& value : entry.second) {
+        auto it = twMap.find(value);
+        EXPECT_TRUE(it != twMap.end() && it->second.count(key) > 0)
+            << "Missing reverse mapping: " << key << " -> " << value;
+      }
+    }
+  } catch (const Exception& ex) {
+    FAIL() << "Exception: " << ex.what();
+  } catch (const std::exception& ex) {
+    FAIL() << "std::exception: " << ex.what();
+  } catch (...) {
+    FAIL() << "Unknown exception thrown during reverse mapping check.";
+  }
+}
+
+} // namespace
+} // namespace opencc

--- a/data/dictionary/DictionaryTest.cpp
+++ b/data/dictionary/DictionaryTest.cpp
@@ -18,9 +18,6 @@
 
 #include "gtest/gtest.h"
 
-#include <unordered_map>
-#include <unordered_set>
-
 #include "src/Lexicon.hpp"
 #include "src/MarisaDict.hpp"
 #include "src/UTF8Util.hpp"
@@ -29,6 +26,11 @@
 using bazel::tools::cpp::runfiles::Runfiles;
 
 namespace opencc {
+namespace {
+
+#ifndef OPENCC_DICTIONARY_TEST_FILE
+#error "OPENCC_DICTIONARY_TEST_FILE must be defined"
+#endif
 
 static FILE* OpenFile(const std::string& path) {
 #ifdef _MSC_VER
@@ -38,8 +40,7 @@ static FILE* OpenFile(const std::string& path) {
 #endif
 }
 
-class DictionaryTest : public ::testing::Test,
-                       public ::testing::WithParamInterface<std::string> {
+class DictionaryTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
     runfiles_.reset(Runfiles::CreateForTest());
@@ -51,50 +52,33 @@ protected:
 
 std::unique_ptr<Runfiles> DictionaryTest::runfiles_;
 
-class DictionaryRunfilesTest : public ::testing::Test {
-protected:
-  static void SetUpTestSuite() {
-    runfiles_.reset(Runfiles::CreateForTest());
-    ASSERT_NE(nullptr, runfiles_);
-  }
-
-  static std::unique_ptr<Runfiles> runfiles_;
-};
-
-std::unique_ptr<Runfiles> DictionaryRunfilesTest::runfiles_;
-
-INSTANTIATE_TEST_SUITE_P(
-    , DictionaryTest,
-    ::testing::Values(
-        "HKVariants", "HKVariantsRev", "HKVariantsRevPhrases",
-        "JPShinjitaiCharacters", "JPShinjitaiPhrases", "JPVariants",
-        "JPVariantsRev", "STCharacters", "STPhrases", "TSCharacters",
-        "TSPhrases", "TWPhrases", "TWPhrasesRev", "TWVariants",
-        "TWVariantsRev", "TWVariantsRevPhrases"),
-    [](const testing::TestParamInfo<DictionaryTest::ParamType>& info) {
-      return info.param;
-    });
-
-TEST_P(DictionaryTest, UniqueSortedTest) {
+TEST_F(DictionaryTest, UniqueSortedTest) {
+  const std::string dictionary = OPENCC_DICTIONARY_TEST_FILE;
   const std::string dictionaryFileName =
-      runfiles_->Rlocation("_main/data/dictionary/" + GetParam() + ".txt");
+      runfiles_->Rlocation("_main/data/dictionary/" + dictionary);
   FILE* fp = OpenFile(dictionaryFileName);
   ASSERT_NE(fp, nullptr);
   LexiconPtr lexicon = Lexicon::ParseLexiconFromFile(fp);
-  EXPECT_TRUE(lexicon->IsUnique()) << GetParam() << " has duplicated keys.";
-  EXPECT_TRUE(lexicon->IsSorted()) << GetParam() << " is not sorted.";
+  EXPECT_TRUE(lexicon->IsUnique()) << dictionary << " has duplicated keys.";
+  EXPECT_TRUE(lexicon->IsSorted()) << dictionary << " is not sorted.";
 }
 
-TEST_P(DictionaryTest, BinaryTest) {
-  const std::string binaryDictionaryFileName =
-      runfiles_->Rlocation("_main/data/dictionary/" + GetParam() + ".ocd2");
+TEST_F(DictionaryTest, BinaryTest) {
+  std::string dictionary = OPENCC_DICTIONARY_TEST_FILE;
+  const std::string suffix = ".txt";
+  ASSERT_TRUE(dictionary.size() >= suffix.size());
+  ASSERT_EQ(suffix, dictionary.substr(dictionary.size() - suffix.size()));
+  dictionary.erase(dictionary.size() - suffix.size());
+
+  const std::string binaryDictionaryFileName = runfiles_->Rlocation(
+      "_main/data/dictionary/" + dictionary + ".ocd2");
   FILE* fp_bin = OpenFile(binaryDictionaryFileName);
   ASSERT_NE(fp_bin, nullptr);
   MarisaDictPtr dict = MarisaDict::NewFromFile(fp_bin);
   ASSERT_NE(dict, nullptr);
 
   const std::string textDictionaryFileName =
-      runfiles_->Rlocation("_main/data/dictionary/" + GetParam() + ".txt");
+      runfiles_->Rlocation("_main/data/dictionary/" + dictionary + ".txt");
   FILE* fp_txt = OpenFile(textDictionaryFileName);
   ASSERT_NE(fp_txt, nullptr);
   LexiconPtr txt_lexicon = Lexicon::ParseLexiconFromFile(fp_txt);
@@ -102,70 +86,5 @@ TEST_P(DictionaryTest, BinaryTest) {
   EXPECT_EQ(dict->GetLexicon()->Length(), txt_lexicon->Length());
 }
 
-TEST_F(DictionaryRunfilesTest, TWPhrasesReverseMapping) {
-  const std::string twPhrasesFile =
-      runfiles_->Rlocation("_main/data/dictionary/TWPhrases.txt");
-  const std::string twPhrasesRevFile =
-      runfiles_->Rlocation("_main/data/dictionary/TWPhrasesRev.txt");
-
-  auto loadLexicon = [](const std::string& path) -> LexiconPtr {
-    FILE* fp = OpenFile(path);
-    EXPECT_NE(fp, nullptr) << path;
-    if (fp == nullptr) {
-      return LexiconPtr();
-    }
-    return Lexicon::ParseLexiconFromFile(fp);
-  };
-
-  auto buildMap = [](const LexiconPtr& lexicon)
-      -> std::unordered_map<std::string, std::unordered_set<std::string>> {
-    std::unordered_map<std::string, std::unordered_set<std::string>> map;
-    if (!lexicon) {
-      return map;
-    }
-    for (size_t i = 0; i < lexicon->Length(); ++i) {
-      const DictEntry* entry = lexicon->At(i);
-      auto& values = map[entry->Key()];
-      for (const auto& value : entry->Values()) {
-        values.insert(value);
-      }
-    }
-    return map;
-  };
-
-  try {
-    LexiconPtr twPhrases = loadLexicon(twPhrasesFile);
-    LexiconPtr twPhrasesRev = loadLexicon(twPhrasesRevFile);
-    ASSERT_NE(twPhrases, nullptr);
-    ASSERT_NE(twPhrasesRev, nullptr);
-
-    auto twMap = buildMap(twPhrases);
-    auto twRevMap = buildMap(twPhrasesRev);
-
-    for (const auto& entry : twMap) {
-      const std::string& key = entry.first;
-      for (const auto& value : entry.second) {
-        auto it = twRevMap.find(value);
-        EXPECT_TRUE(it != twRevMap.end() && it->second.count(key) > 0)
-            << "Missing reverse mapping: " << key << " -> " << value;
-      }
-    }
-
-    for (const auto& entry : twRevMap) {
-      const std::string& key = entry.first;
-      for (const auto& value : entry.second) {
-        auto it = twMap.find(value);
-        EXPECT_TRUE(it != twMap.end() && it->second.count(key) > 0)
-            << "Missing reverse mapping: " << key << " -> " << value;
-      }
-    }
-  } catch (const Exception& ex) {
-    FAIL() << "Exception: " << ex.what();
-  } catch (const std::exception& ex) {
-    FAIL() << "std::exception: " << ex.what();
-  } catch (...) {
-    FAIL() << "Unknown exception thrown during reverse mapping check.";
-  }
-}
-
+} // namespace
 } // namespace opencc


### PR DESCRIPTION
- Created a JSON schema and added validation tests
- Added tests to ensure dictionaries other than {ST,TS}Characters don't accidentally introduce non-BMP characters
- Reorganize //data/... tests to run against individual files in parallel