### PR TITLE
Quiet RapidJSON iterator deprecation warnings

### DIFF
--- a/data/config/BUILD.bazel
+++ b/data/config/BUILD.bazel
@@ -33,7 +33,7 @@ filegroup(
             "//src:simple_converter",
             "@bazel_tools//tools/cpp/runfiles",
             "@googletest//:gtest_main",
-            "@rapidjson",
+            "//deps/rapidjson-1.1.0:rapidjson",
         ],
     )
     for config in CONFIGS
@@ -63,7 +63,7 @@ test_suite(
         deps = [
             "@bazel_tools//tools/cpp/runfiles",
             "@googletest//:gtest_main",
-            "@rapidjson",
+            "//deps/rapidjson-1.1.0:rapidjson",
         ],
     )
     for config in CONFIGS

--- a/deps/rapidjson-1.1.0/BUILD.bazel
+++ b/deps/rapidjson-1.1.0/BUILD.bazel
@@ -1,5 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
+cc_library(
+    name = "rapidjson",
+    hdrs = glob(["rapidjson/**/*.h"]),
+    includes = ["."],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["rapidjson/**/*.h"]),

--- a/deps/rapidjson-1.1.0/rapidjson/document.h
+++ b/deps/rapidjson-1.1.0/rapidjson/document.h
@@ -22,6 +22,7 @@
 #include "internal/strfunc.h"
 #include "memorystream.h"
 #include "encodedstream.h"
+#include <cstddef>
 #include <new>      // placement new
 #include <limits>
 
@@ -45,7 +46,7 @@ RAPIDJSON_DIAG_OFF(terminate) // ignore throwing RAPIDJSON_ASSERT in RAPIDJSON_N
 #endif // __GNUC__
 
 #ifndef RAPIDJSON_NOMEMBERITERATORCLASS
-#include <iterator> // std::iterator, std::random_access_iterator_tag
+#include <iterator> // std::random_access_iterator_tag
 #endif
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -98,16 +99,13 @@ struct GenericMember {
     \see GenericMember, GenericValue::MemberIterator, GenericValue::ConstMemberIterator
  */
 template <bool Const, typename Encoding, typename Allocator>
-class GenericMemberIterator
-    : public std::iterator<std::random_access_iterator_tag
-        , typename internal::MaybeAddConst<Const,GenericMember<Encoding,Allocator> >::Type> {
+class GenericMemberIterator {
 
     friend class GenericValue<Encoding,Allocator>;
     template <bool, typename, typename> friend class GenericMemberIterator;
 
     typedef GenericMember<Encoding,Allocator> PlainType;
     typedef typename internal::MaybeAddConst<Const,PlainType>::Type ValueType;
-    typedef std::iterator<std::random_access_iterator_tag,ValueType> BaseType;
 
 public:
     //! Iterator type itself
@@ -117,12 +115,22 @@ public:
     //! Non-constant iterator type
     typedef GenericMemberIterator<false,Encoding,Allocator> NonConstIterator;
 
-    //! Pointer to (const) GenericMember
-    typedef typename BaseType::pointer         Pointer;
-    //! Reference to (const) GenericMember
-    typedef typename BaseType::reference       Reference;
+    //! Category tag required by random access iterator traits.
+    typedef std::random_access_iterator_tag iterator_category;
+    //! Value type required by iterator traits.
+    typedef ValueType value_type;
     //! Signed integer type (e.g. \c ptrdiff_t)
-    typedef typename BaseType::difference_type DifferenceType;
+    typedef std::ptrdiff_t difference_type;
+    //! Pointer to (const) GenericMember
+    typedef ValueType* pointer;
+    //! Reference to (const) GenericMember
+    typedef ValueType& reference;
+    //! Backward-compatible RapidJSON pointer type alias.
+    typedef pointer Pointer;
+    //! Backward-compatible RapidJSON reference type alias.
+    typedef reference Reference;
+    //! Backward-compatible RapidJSON difference type alias.
+    typedef difference_type DifferenceType;
 
     //! Default constructor (singular value)
     /*! Creates an iterator pointing to no element.

--- a/plugins/jieba/BUILD.bazel
+++ b/plugins/jieba/BUILD.bazel
@@ -105,6 +105,6 @@ cc_test(
         "//test:portable_util",
         "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest_main",
-        "@rapidjson",
+        "//deps/rapidjson-1.1.0:rapidjson",
     ],
 )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -100,7 +100,7 @@ cc_library(
         ":max_match_segmentation",
         ":plugin_segmentation",
         ":text_dict",
-        "@rapidjson",
+        "//deps/rapidjson-1.1.0:rapidjson",
     ],
 )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -46,6 +46,6 @@ cc_test(
         "//src:common",
         "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest_main",
-        "@rapidjson",
+        "//deps/rapidjson-1.1.0:rapidjson",
     ],
 )


### PR DESCRIPTION
Replace RapidJSON's deprecated `std::iterator` inheritance with explicit iterator traits so C++17 builds do not emit noisy member iterator warnings.

Add a Bazel target for the vendored RapidJSON headers and point OpenCC's Bazel users at it, ensuring Bazel uses the patched copy instead of the external module.

Verified with `cmake --build build/codex --target opencc -j2`, `bazel build //src:opencc //src/tools:command_line`, and `bazel test //src:config_test`.