### PR TITLE
Preserve trailing newline in stdin line-by-line conversion path

### DIFF
--- a/src/tools/CommandLine.cpp
+++ b/src/tools/CommandLine.cpp
@@ -285,6 +285,7 @@ void ConvertLineByLine() {
   std::istream& inputStream = std::cin;
   FILE* fout = GetOutputStream();
   bool isFirstLine = true;
+  bool inputEndedWithNewline = false;
   std::string line;
   while (std::getline(inputStream, line)) {
     if (!isFirstLine) {
@@ -292,6 +293,7 @@ void ConvertLineByLine() {
     } else {
       isFirstLine = false;
     }
+    inputEndedWithNewline = !inputStream.eof();
     measurement.inputBytes += line.size();
     const std::string& output = ConvertLineByMode(line);
     measurement.outputBytes += output.size();
@@ -303,6 +305,12 @@ void ConvertLineByLine() {
     }
     measurement.writeMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - writeStart);
+  }
+  if (inputEndedWithNewline) {
+    fputs("\n", fout);
+    if (!noFlush) {
+      fflush(fout);
+    }
   }
   fclose(fout);
 }

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -139,7 +139,8 @@ protected:
 #ifdef BAZEL
     const std::string dictFile =
         runfiles_->Rlocation("_main/data/dictionary/STCharacters.ocd2");
-    const std::string dictDir = dictFile.substr(0, dictFile.find_last_of("/\\"));
+    const std::string dictDir =
+        dictFile.substr(0, dictFile.find_last_of("/\\"));
     const std::string configFile =
         runfiles_->Rlocation("_main/data/config/s2t.json");
     const std::string configDir =
@@ -166,6 +167,31 @@ protected:
       const {
     return TestCommand(config, inputFile, outputFile, measuredResultFile,
                        extraFlags);
+  }
+
+  std::string TestStdinCommand(const std::string& config,
+                               const std::string& inputFile,
+                               const std::string& outputFile) const {
+    std::string cmd = QuotePath(OpenccCommand()) + " -c " +
+                      QuotePath(ConfigurationDirectory() + config + ".json");
+#ifdef BAZEL
+    const std::string dictFile =
+        runfiles_->Rlocation("_main/data/dictionary/STCharacters.ocd2");
+    const std::string dictDir =
+        dictFile.substr(0, dictFile.find_last_of("/\\"));
+    const std::string configFile =
+        runfiles_->Rlocation("_main/data/config/s2t.json");
+    const std::string configDir =
+        configFile.substr(0, configFile.find_last_of("/\\"));
+    cmd += " --path " + QuotePath(dictDir + "/") +
+           " --path " + QuotePath(configDir + "/");
+#endif
+    cmd += " < " + QuotePath(inputFile) + " > " + QuotePath(outputFile);
+#ifdef _WIN32
+    return "\"" + cmd + "\"";
+#else
+    return cmd;
+#endif
   }
 
   char* originalWorkingDirectory;
@@ -263,6 +289,33 @@ TEST_F(CommandLineConvertTest, ConvertFromJson) {
     }
     EXPECT_EQ(idx, entry.second.size()) << "config=" << config;
   }
+}
+
+TEST_F(CommandLineConvertTest, StdinPreservesTrailingNewline) {
+  const std::string config = "s2t";
+  const std::string inputWithNewline = InputFile("stdin_with_newline");
+  const std::string outputWithNewline = OutputFile("stdin_with_newline");
+  const std::string inputWithoutNewline = InputFile("stdin_without_newline");
+  const std::string outputWithoutNewline = OutputFile("stdin_without_newline");
+
+  {
+    std::ofstream ofs(inputWithNewline, std::ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    ofs << "123\n";
+  }
+  {
+    std::ofstream ofs(inputWithoutNewline, std::ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    ofs << "123";
+  }
+
+  ASSERT_EQ(0, system(TestStdinCommand(config, inputWithNewline,
+                                       outputWithNewline).c_str()));
+  EXPECT_EQ("123\n", GetFileContents(outputWithNewline));
+
+  ASSERT_EQ(0, system(TestStdinCommand(config, inputWithoutNewline,
+                                       outputWithoutNewline).c_str()));
+  EXPECT_EQ("123", GetFileContents(outputWithoutNewline));
 }
 
 TEST_F(CommandLineConvertTest, WritesMeasuredResultJson) {


### PR DESCRIPTION
After this change, on Windows:

`echo 123 | opencc.exe` will output `123\n`
`printf 123 | opencc.exe` will output `123` without trailing `\n`

Mac and Linux users are not affected because POSIX pipes and stdio buffering generally flush and propagate EOF more predictably, while Windows CRT uses fully buffered pipes by default, which can cause `readline()`-based wrappers to block indefinitely when no trailing newline is written.