### PR TITLE
Replace add_definitions with add_compile_options for non -D flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,20 +217,20 @@ add_definitions(
 
 set(CMAKE_CXX_STANDARD 17) # default C++ version for new target afterward
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  add_definitions(
+  add_compile_options(
     -Wall
   )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
   if (CMAKE_BUILD_TYPE MATCHES Debug)
-    add_definitions(-O0 -g3)
+    add_compile_options(-O0 -g3)
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  add_definitions(
+  add_compile_options(
     -Wall
   )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
   if (CMAKE_BUILD_TYPE MATCHES Debug)
-    add_definitions(-O0 -g3)
+    add_compile_options(-O0 -g3)
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   add_definitions(


### PR DESCRIPTION
When building with GCC 16.1.0 + CMake 4.3.2 on MSYS2, flags added with `add_definitions` will be passed to `windres` for RC files, but `windres` doesn't recognize these flags, causing build failure.

```
[1/53] Building RC object src/tools/CMakeFiles/opencc_dict.dir/version_opencc_dict.rc.obj
FAILED: [code=1] src/tools/CMakeFiles/opencc_dict.dir/version_opencc_dict.rc.obj 
D:\msys64\ucrt64\bin\windres.exe -O coff -DENABLE_DARTS -DLOCALEDIR=\"/ucrt64/share/locale\" -DOPENCC_SEGMENTATION_PLUGIN_DIR=\"/ucrt64/bin/plugins\" -DOpencc_BUILT_AS_STATIC -DPACKAGE_NAME=\"opencc\" -DPKGDATADIR=\"/ucrt64/share/opencc\" -DVERSION=\"1.3.1+gsrcinfo-cache-33315-g417747f6a0.dirty\" -I D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/build-UCRT64-static/src -I D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/opencc-1.3.1/src -I D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/opencc-1.3.1 -I D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/opencc-1.3.1/src/../deps/tclap-1.2.5 -I D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/opencc-1.3.1/src/../deps/darts-clone-0.32 -Wall D:/msys64/usr/local/build/MINGW-packages/mingw-w64-opencc/src/build-UCRT64-static/src/tools/version_opencc_dict.rc src/tools/CMakeFiles/opencc_dict.dir/version_opencc_dict.rc.obj
D:\msys64\ucrt64\bin\windres.exe: invalid option -- W
Usage: D:\msys64\ucrt64\bin\windres.exe [option(s)] [input-file] [output-file]
 The options are:
  -i --input=<file>            Name input file
  -o --output=<file>           Name output file
  -J --input-format=<format>   Specify input format
  -O --output-format=<format>  Specify output format
  -F --target=<target>         Specify COFF target
     --preprocessor=<program>  Program to use to preprocess rc file
     --preprocessor-arg=<arg>  Additional preprocessor argument
  -I --include-dir=<dir>       Include directory when preprocessing rc file
  -D --define <sym>[=<val>]    Define SYM when preprocessing rc file
  -U --undefine <sym>          Undefine SYM when preprocessing rc file
  -v --verbose                 Verbose - tells you what it's doing
  -c --codepage=<codepage>     Specify default codepage
  -l --language=<val>          Set language when reading rc file
     --use-temp-file           Use a temporary file instead of popen to read
                               the preprocessor output
     --no-use-temp-file        Use popen (default)
  -r                           Ignored for compatibility with rc
  @<file>                      Read options from <file>
  -h --help                    Print this help message
  -V --version                 Print version information
FORMAT is one of rc, res, or coff, and is deduced from the file name
extension if not specified.  A single file name is an input file.
No input-file is stdin, default rc.  No output-file is stdout, default rc.
D:\msys64\ucrt64\bin\windres.exe: supported targets: pe-x86-64 pei-x86-64 pe-bigobj-x86-64 elf64-x86-64 pe-i386 pe-bigobj-i386 pei-i386 elf32-i386 elf32-iamcu pdb elf64-little elf64-big elf32-little elf32-big srec symbolsrec verilog tekhex binary ihex plugin
```