### PR TITLE
Fix word boundary splitting in CommandLine streaming

### DIFF
--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -200,7 +200,7 @@ char* opencc_convert_utf8(opencc_t opencc, const char* input, size_t length) {
     SimpleConverter* instance = reinterpret_cast<SimpleConverter*>(opencc);
     std::string converted = instance->Convert(input, length);
     char* output = new char[converted.length() + 1];
-    strncpy(output, converted.c_str(), converted.length());
+    memcpy(output, converted.c_str(), converted.length());
     output[converted.length()] = '\0';
     return output;
   } catch (std::runtime_error& ex) {

--- a/src/UTF8Util.hpp
+++ b/src/UTF8Util.hpp
@@ -166,7 +166,7 @@ public:
   static std::string FromSubstr(const char* str, size_t length) {
     std::string newStr;
     newStr.resize(length);
-    strncpy(newStr.data(), str, length);
+    memcpy(newStr.data(), str, length);
     return newStr;
   }
 

--- a/src/tools/CommandLine.cpp
+++ b/src/tools/CommandLine.cpp
@@ -281,6 +281,7 @@ std::string ConvertLineByMode(const std::string& line) {
 
 void ConvertStream(FILE* fin, FILE* fout) {
   const int BUFFER_SIZE = 1024 * 1024;
+  const size_t MAX_KEEP_CHARS = 16;
   std::string buffer(BUFFER_SIZE + 1, '\0');
   char* bufferBegin = &buffer[0];
   const char* bufferEnd = bufferBegin + BUFFER_SIZE;
@@ -289,11 +290,12 @@ void ConvertStream(FILE* fin, FILE* fout) {
 
   while (!feof(fin)) {
     size_t length = fread(bufferPtr, sizeof(char), bufferSizeAvailble, fin);
-    if (length == 0) {
+    if (length == 0 && bufferPtr == bufferBegin) {
       break;
     }
     measurement.inputBytes += length;
     bufferPtr[length] = '\0';
+    size_t convertLength = (bufferPtr - bufferBegin) + length;
     size_t remainingLength = 0;
     std::string remainingTemp;
     if (length == bufferSizeAvailble) {
@@ -307,12 +309,27 @@ void ConvertStream(FILE* fin, FILE* fout) {
         }
         lastChPtr += nextCharLen;
       }
-      remainingLength = bufferEnd - lastChPtr;
+
+      // Also keep up to MAX_KEEP_CHARS complete characters before the boundary
+      // to preserve multi-character phrases that may span across buffer
+      // boundaries for correct longest-prefix segmentation.
+      char* keepStart = lastChPtr;
+      size_t charsKept = 0;
+      while (keepStart > bufferBegin && charsKept < MAX_KEEP_CHARS) {
+        size_t prevCharLen = UTF8Util::PrevCharLength(keepStart);
+        keepStart -= prevCharLen;
+        charsKept++;
+      }
+
+      convertLength = keepStart - bufferBegin;
+      remainingLength = bufferEnd - keepStart;
       if (remainingLength > 0) {
-        remainingTemp = UTF8Util::FromSubstr(lastChPtr, remainingLength);
-        *lastChPtr = '\0';
+        remainingTemp = UTF8Util::FromSubstr(keepStart, remainingLength);
       }
     }
+
+    // Null-terminate the portion to convert
+    bufferBegin[convertLength] = '\0';
 
     const auto convertStart = std::chrono::steady_clock::now();
     const std::string& converted = converter->Convert(bufferBegin);
@@ -330,7 +347,7 @@ void ConvertStream(FILE* fin, FILE* fout) {
     bufferPtr = bufferBegin + remainingLength;
     bufferSizeAvailble = BUFFER_SIZE - remainingLength;
     if (remainingLength > 0) {
-      strncpy(bufferBegin, remainingTemp.c_str(), remainingLength);
+      memcpy(bufferBegin, remainingTemp.c_str(), remainingLength);
     }
   }
 }

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -699,4 +699,65 @@ TEST_F(CommandLineConvertTest, SegmentationNoSpuriousEofRecord) {
     ASSERT_NE('\r', content.back());
     ASSERT_NE('\n', content.back());
   }
+
+  TEST_F(CommandLineConvertTest, ChunkingBoundaryTruncationFix) {
+    const std::string config = "s2t";
+    const std::string inputFile = InputFile("chunk_boundary_test");
+    const std::string outputFile = OutputFile("chunk_boundary_test");
+
+    {
+      std::ofstream ofs(inputFile, std::ios::binary);
+      ASSERT_TRUE(ofs.is_open());
+      // Create exactly 1MB - 3 bytes of padding. 
+      // This forces the "头" character (3 bytes) to end exactly at the 1MB 
+      // chunk boundary, while "发尾巴" falls into the next read chunk.
+      std::string padding(1048576 - 3, 'a');
+      ofs << padding << "头发尾巴";
+    }
+
+    ASSERT_EQ(0, system(TestCommand(config, inputFile, outputFile).c_str()));
+
+    // Read output in binary mode
+    std::ifstream ifs(outputFile, std::ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    ifs.close();
+
+    // 1. Verify EOF truncation bug is fixed (the output shouldn't be truncated)
+    // 2. Verify Semantic-safe chunking (the word shouldn't be split into 頭發)
+    const std::string expectedEnd = "頭髮尾巴";
+    ASSERT_GE(content.size(), expectedEnd.size());
+    EXPECT_EQ(expectedEnd, content.substr(content.size() - expectedEnd.size()));
+  }
+  
+  TEST_F(CommandLineConvertTest, ExactChunkSizeDoesNotTruncate) {
+    const std::string config = "s2t";
+    const std::string inputFile = InputFile("exact_chunk_test");
+    const std::string outputFile = OutputFile("exact_chunk_test");
+
+    {
+      std::ofstream ofs(inputFile, std::ios::binary);
+      ASSERT_TRUE(ofs.is_open());
+      // Create EXACTLY 1MB of data (1048576 bytes).
+      // This triggers the bug where fread reads exactly bufferSizeAvailable,
+      // defers MAX_KEEP_CHARS to the next iteration, and then the next fread
+      // returns 0. If the loop breaks immediately on fread returning 0, the
+      // deferred tail is lost.
+      std::string padding(1048576, 'a');
+      ofs << padding;
+    }
+
+    ASSERT_EQ(0, system(TestCommand(config, inputFile, outputFile).c_str()));
+
+    // Read output in binary mode
+    std::ifstream ifs(outputFile, std::ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    ifs.close();
+
+    // Verify output length is exactly 1MB.
+    EXPECT_EQ(1048576, content.size());
+  }
 } // namespace opencc


### PR DESCRIPTION
This commit addresses a long-standing issue in the C++ CLI ConvertStream where the 1MB buffer chunking could split multi-character phrases, breaking longest-prefix segmentation and leading to incorrect conversions.

Introduces a sliding window (MAX_KEEP_CHARS) to preserve up to 16 complete characters before the chunk boundary, ensuring cross-chunk phrase integrity. Additionally, refactors the EOF buffer flush logic to correctly output deferred sliding window characters without triggering silent data truncation at EOF.

Adds comprehensive tests (ChunkingBoundaryTruncationFix and ExactChunkSizeDoesNotTruncate) to verify semantic safety and EOF truncation resistance.