### PR TITLE
Fix marisa FlatVector zero initialization

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,13 @@ bazel_dep(name = "rules_python", version = "1.9.0")
 bazel_dep(name = "tclap", version = "1.2.5.bcr.1")
 bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4", dev_dependency = True)
 
+single_version_override(
+    module_name = "marisa-trie",
+    patches = ["//patches:marisa-flat-vector-zero-init.patch"],
+    patch_strip = 1,
+    version = "0.3.1.bcr.1",
+)
+
 # Node.js native addon build dependencies:
 #   - node-addon-api headers
 #   - Node.js headers

--- a/deps/marisa-0.3.1/lib/marisa/grimoire/vector/flat-vector.h
+++ b/deps/marisa-0.3.1/lib/marisa/grimoire/vector/flat-vector.h
@@ -117,10 +117,7 @@ class FlatVector {
       num_units += num_units % (64 / MARISA_WORD_SIZE);
     }
 
-    units_.resize(num_units);
-    if (num_units > 0) {
-      units_.back() = 0;
-    }
+    units_.resize(num_units, 0);
 
     value_size_ = value_size;
     if (value_size != 0) {

--- a/deps/marisa-0.3.1/tests/vector-test.cc
+++ b/deps/marisa-0.3.1/tests/vector-test.cc
@@ -231,6 +231,22 @@ void TestFlatVector() {
   ASSERT(vec.io_size() == (sizeof(std::uint64_t) * 4));
   ASSERT(vec[0] == 0);
 
+  {
+    std::stringstream stream;
+    {
+      marisa::grimoire::Writer writer;
+      writer.open(stream);
+      vec.write(writer);
+    }
+    const std::string data = stream.str();
+    ASSERT(data.size() == vec.io_size());
+    ASSERT(data.size() >= (sizeof(std::uint64_t) * 2));
+    for (std::size_t i = sizeof(std::uint64_t);
+         i < (sizeof(std::uint64_t) * 2); ++i) {
+      ASSERT(data[i] == '\0');
+    }
+  }
+
   values.push_back(255);
   vec.build(values);
 

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["marisa-flat-vector-zero-init.patch"])

--- a/patches/marisa-flat-vector-zero-init.patch
+++ b/patches/marisa-flat-vector-zero-init.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/marisa/grimoire/vector/flat-vector.h b/lib/marisa/grimoire/vector/flat-vector.h
+index 3b9d361..fab5dab 100644
+--- a/lib/marisa/grimoire/vector/flat-vector.h
++++ b/lib/marisa/grimoire/vector/flat-vector.h
+@@ -117,10 +117,7 @@ class FlatVector {
+       num_units += num_units % (64 / MARISA_WORD_SIZE);
+     }
+ 
+-    units_.resize(num_units);
+-    if (num_units > 0) {
+-      units_.back() = 0;
+-    }
++    units_.resize(num_units, 0);
+ 
+     value_size_ = value_size;
+     if (value_size != 0) {


### PR DESCRIPTION
This change will make ocd2 files generated on 32-bit and 64-bit envs identical.
https://github.com/BYVoid/OpenCC/issues/656