### PR TITLE
Fix Windows.h header case for cross-compilation on case-sensitive filesystems

### DIFF
--- a/src/UTF8Util.hpp
+++ b/src/UTF8Util.hpp
@@ -22,7 +22,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 #endif // _MSC_VER
 
 #include <cstring>

--- a/src/WinUtil.hpp
+++ b/src/WinUtil.hpp
@@ -23,7 +23,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 #include <string>
 


### PR DESCRIPTION
Closes #1217 