### PR TITLE
Share C++ streaming conversion with Node CLI

### DIFF
--- a/node/cli.js
+++ b/node/cli.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { Transform, pipeline } = require('stream');
 const OpenCC = require('./opencc');
 
 const BUILT_IN_CONFIGS = [
@@ -122,21 +123,6 @@ function parseArgs(args) {
   return options;
 }
 
-function readInput(inputFileName) {
-  if (inputFileName) {
-    return fs.readFileSync(inputFileName).toString('utf8');
-  }
-  return fs.readFileSync(0).toString('utf8');
-}
-
-function writeOutput(outputFileName, text) {
-  if (outputFileName) {
-    fs.writeFileSync(outputFileName, Buffer.from(text, 'utf8'));
-  } else {
-    process.stdout.write(text);
-  }
-}
-
 function resolveConfigPath(config) {
   if (BUILT_IN_CONFIG_NAMES.has(config) || OPTIONAL_JIEBA_CONFIGS.has(config) || path.isAbsolute(config)) {
     return config;
@@ -151,6 +137,44 @@ function resolveConfigPath(config) {
   }
 
   return path.resolve(process.cwd(), config);
+}
+
+function createConverterStream(converter) {
+  const nativeStream = converter._createConverterStream();
+  let pendingChunk = null;
+
+  return new Transform({
+    transform(chunk, encoding, callback) {
+      try {
+        const input = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+        if (pendingChunk === null) {
+          pendingChunk = Buffer.from(input);
+          callback();
+          return;
+        }
+        const output = nativeStream.convertChunk(pendingChunk);
+        pendingChunk = Buffer.from(input);
+        callback(null, output);
+      } catch (error) {
+        callback(error);
+      }
+    },
+    flush(callback) {
+      try {
+        callback(null, pendingChunk === null
+          ? nativeStream.finish()
+          : nativeStream.finish(pendingChunk));
+      } catch (error) {
+        callback(error);
+      }
+    },
+  });
+}
+
+function convertStream(converter, options, callback) {
+  const input = options.input ? fs.createReadStream(options.input) : process.stdin;
+  const output = options.output ? fs.createWriteStream(options.output) : process.stdout;
+  pipeline(input, createConverterStream(converter), output, callback);
 }
 
 function main() {
@@ -174,9 +198,12 @@ function main() {
 
   try {
     const converter = new OpenCC(resolveConfigPath(options.config));
-    const input = readInput(options.input);
-    const output = converter.convertSync(input);
-    writeOutput(options.output, output);
+    convertStream(converter, options, (error) => {
+      if (error) {
+        const message = error && error.message ? error.message : String(error);
+        fail(path.basename(process.argv[1]) + ': ' + message);
+      }
+    });
   } catch (error) {
     const message = error && error.message ? error.message : String(error);
     fail(path.basename(process.argv[1]) + ': ' + message);

--- a/node/cli.js
+++ b/node/cli.js
@@ -171,7 +171,26 @@ function createConverterStream(converter) {
   });
 }
 
+function isSameFile(inputFileName, outputFileName) {
+  if (!inputFileName || !outputFileName) {
+    return false;
+  }
+
+  try {
+    const inputStat = fs.statSync(inputFileName);
+    const outputStat = fs.statSync(outputFileName);
+    return inputStat.dev === outputStat.dev && inputStat.ino === outputStat.ino;
+  } catch (error) {
+    return path.resolve(process.cwd(), inputFileName) ===
+      path.resolve(process.cwd(), outputFileName);
+  }
+}
+
 function convertStream(converter, options, callback) {
+  if (isSameFile(options.input, options.output)) {
+    throw new Error('Input and output refer to the same file.');
+  }
+
   const input = options.input ? fs.createReadStream(options.input) : process.stdin;
   const output = options.output ? fs.createWriteStream(options.output) : process.stdout;
   pipeline(input, createConverterStream(converter), output, callback);

--- a/node/opencc.cc
+++ b/node/opencc.cc
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include <memory>
 #include <string>
 
 #include "src/Config.hpp"
@@ -93,6 +94,8 @@ public:
     return converter_->Convert(input);
   }
 
+  ConverterPtr GetConverter() const { return converter_; }
+
   static Napi::Value Version(const Napi::CallbackInfo& info) {
     return Napi::String::New(info.Env(), VERSION);
   }
@@ -164,8 +167,87 @@ public:
   }
 };
 
+class OpenccStreamBinding : public Napi::ObjectWrap<OpenccStreamBinding> {
+  std::unique_ptr<ConverterStream> stream_;
+
+public:
+  explicit OpenccStreamBinding(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<OpenccStreamBinding>(info), stream_() {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsObject()) {
+      Napi::TypeError::New(env, "Wrong arguments").ThrowAsJavaScriptException();
+      return;
+    }
+
+    OpenccBinding* owner =
+        Napi::ObjectWrap<OpenccBinding>::Unwrap(info[0].As<Napi::Object>());
+    stream_.reset(new ConverterStream(owner->GetConverter()));
+  }
+
+  Napi::Value ConvertChunk(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || (!info[0].IsBuffer() && !info[0].IsString())) {
+      Napi::TypeError::New(env, "Wrong arguments").ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
+    try {
+      std::string output;
+      if (info[0].IsBuffer()) {
+        Napi::Buffer<char> input = info[0].As<Napi::Buffer<char>>();
+        output = stream_->ConvertChunk(input.Data(), input.Length());
+      } else {
+        const std::string input = ToUtf8String(info[0]);
+        output = stream_->ConvertChunk(input.data(), input.size());
+      }
+      return Napi::String::New(env, output);
+    } catch (opencc::Exception& e) {
+      Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+  }
+
+  Napi::Value Finish(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() >= 1 && !info[0].IsBuffer() && !info[0].IsString()) {
+      Napi::TypeError::New(env, "Wrong arguments").ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
+    try {
+      if (info.Length() >= 1 && info[0].IsBuffer()) {
+        Napi::Buffer<char> input = info[0].As<Napi::Buffer<char>>();
+        return Napi::String::New(
+            env, stream_->Finish(input.Data(), input.Length()));
+      }
+      if (info.Length() >= 1) {
+        const std::string input = ToUtf8String(info[0]);
+        return Napi::String::New(env,
+                                 stream_->Finish(input.data(), input.size()));
+      }
+      return Napi::String::New(env, stream_->Finish());
+    } catch (opencc::Exception& e) {
+      Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+  }
+
+  static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    Napi::Function cons = DefineClass(
+        env, "OpenccStream",
+        {
+            InstanceMethod("convertChunk", &OpenccStreamBinding::ConvertChunk),
+            InstanceMethod("finish", &OpenccStreamBinding::Finish),
+        });
+    exports.Set("OpenccStream", cons);
+    return exports;
+  }
+};
+
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
-  return OpenccBinding::Init(env, exports);
+  OpenccBinding::Init(env, exports);
+  OpenccStreamBinding::Init(env, exports);
+  return exports;
 }
 
 NODE_API_MODULE(opencc, InitAll);

--- a/node/opencc.js
+++ b/node/opencc.js
@@ -253,3 +253,7 @@ OpenCC.prototype.convertPromise = function (input) {
     });
   });
 };
+
+OpenCC.prototype._createConverterStream = function () {
+  return new binding.OpenccStream(this.handler);
+};

--- a/node/test.js
+++ b/node/test.js
@@ -170,6 +170,25 @@ describe('npm CLI', function () {
     );
   });
 
+  it('preserves phrase conversion across stream chunk boundaries', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-boundary-'));
+    const input = path.join(dir, 'input.txt');
+    const output = path.join(dir, 'output.txt');
+    fs.writeFileSync(input, 'a'.repeat(65535) + '后台老板', 'utf8');
+    const result = childProcess.spawnSync(process.execPath, [
+      cli,
+      '--config=s2t.json',
+      '--input',
+      input,
+      '--output',
+      output,
+    ], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(output, 'utf8'), 'a'.repeat(65535) + '後臺老闆');
+  });
+
   it('resolves custom relative config paths from cwd', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-config-'));
     const assetsPath = getAssetsPath();

--- a/node/test.js
+++ b/node/test.js
@@ -170,6 +170,25 @@ describe('npm CLI', function () {
     );
   });
 
+  it('rejects converting an input file onto itself', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-same-file-'));
+    const input = path.join(dir, 'input.txt');
+    fs.writeFileSync(input, '汉字', 'utf8');
+    const result = childProcess.spawnSync(process.execPath, [
+      cli,
+      '--config=s2t.json',
+      '--input',
+      input,
+      '--output',
+      input,
+    ], {
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /same file/);
+    assert.equal(fs.readFileSync(input, 'utf8'), '汉字');
+  });
+
   it('preserves phrase conversion across stream chunk boundaries', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-boundary-'));
     const input = path.join(dir, 'input.txt');

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -22,6 +22,7 @@
 #include "ConversionInspection.hpp"
 #include "Converter.hpp"
 #include "Segments.hpp"
+#include "UTF8Util.hpp"
 
 using namespace opencc;
 
@@ -66,4 +67,55 @@ ConversionInspectionResult Converter::Inspect(const std::string& text) const {
   }
 
   return result;
+}
+
+std::string ConverterStream::ConvertChunk(const char* input, size_t length) {
+  if (length > 0) {
+    pending.append(input, length);
+  }
+  if (pending.empty()) {
+    return std::string();
+  }
+
+  const char* bufferBegin = pending.data();
+  const char* bufferEnd = bufferBegin + pending.size();
+  const char* completeEnd = bufferBegin;
+  while (completeEnd < bufferEnd) {
+    const size_t nextCharLen = UTF8Util::NextCharLength(completeEnd);
+    if (completeEnd + nextCharLen > bufferEnd) {
+      break;
+    }
+    completeEnd += nextCharLen;
+  }
+
+  const char* keepStart = completeEnd;
+  size_t charsKept = 0;
+  while (keepStart > bufferBegin && charsKept < maxKeepChars) {
+    const size_t prevCharLen = UTF8Util::PrevCharLength(keepStart);
+    keepStart -= prevCharLen;
+    charsKept++;
+  }
+
+  if (keepStart == bufferBegin) {
+    return std::string();
+  }
+
+  const std::string output = converter->Convert(
+      std::string(bufferBegin, static_cast<size_t>(keepStart - bufferBegin)));
+  pending.erase(0, static_cast<size_t>(keepStart - bufferBegin));
+  return output;
+}
+
+std::string ConverterStream::Finish() {
+  const std::string output = pending.empty() ? std::string()
+                                             : converter->Convert(pending);
+  pending.clear();
+  return output;
+}
+
+std::string ConverterStream::Finish(const char* input, size_t length) {
+  if (length > 0) {
+    pending.append(input, length);
+  }
+  return Finish();
 }

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <string>
+
 #include "Common.hpp"
 #include "ConversionInspection.hpp"
 #include "Segmentation.hpp"
@@ -50,5 +53,22 @@ private:
   const std::string name;
   const SegmentationPtr segmentation;
   const ConversionChainPtr conversionChain;
+};
+
+class OPENCC_EXPORT ConverterStream {
+public:
+  explicit ConverterStream(ConverterPtr _converter, size_t _maxKeepChars = 16)
+      : converter(_converter), maxKeepChars(_maxKeepChars) {}
+
+  std::string ConvertChunk(const char* input, size_t length);
+
+  std::string Finish();
+
+  std::string Finish(const char* input, size_t length);
+
+private:
+  ConverterPtr converter;
+  size_t maxKeepChars;
+  std::string pending;
 };
 } // namespace opencc

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -36,8 +36,8 @@
 #include "src/Config.hpp"
 #include "src/ConversionInspection.hpp"
 #include "src/Converter.hpp"
+#include "src/Exception.hpp"
 #include "src/Segments.hpp"
-#include "src/UTF8Util.hpp"
 #include "src/tools/CommandLineMain.hpp"
 #include "src/tools/PlatformIO.hpp"
 
@@ -311,58 +311,20 @@ std::string ConvertLineByMode(const std::string& line) {
 
 void ConvertStream(FILE* fin, FILE* fout) {
   const int BUFFER_SIZE = 1024 * 1024;
-  const size_t MAX_KEEP_CHARS = 16;
-  std::string buffer(BUFFER_SIZE + 1, '\0');
-  char* bufferBegin = &buffer[0];
-  const char* bufferEnd = bufferBegin + BUFFER_SIZE;
-  char* bufferPtr = bufferBegin;
-  size_t bufferSizeAvailble = BUFFER_SIZE;
+  std::string buffer(BUFFER_SIZE, '\0');
+  ConverterStream stream(converter);
 
   while (!feof(fin)) {
-    size_t length = fread(bufferPtr, sizeof(char), bufferSizeAvailble, fin);
-    if (length == 0 && bufferPtr == bufferBegin) {
+    size_t length = fread(&buffer[0], sizeof(char), buffer.size(), fin);
+    if (length == 0) {
       break;
     }
     measurement.inputBytes += length;
-    bufferPtr[length] = '\0';
-    size_t convertLength = (bufferPtr - bufferBegin) + length;
-    size_t remainingLength = 0;
-    std::string remainingTemp;
-    if (length == bufferSizeAvailble) {
-      // fread may break a UTF-8 character. Keep the partial character for the
-      // next chunk and convert only complete characters.
-      char* lastChPtr = bufferBegin;
-      while (lastChPtr < bufferEnd) {
-        size_t nextCharLen = UTF8Util::NextCharLength(lastChPtr);
-        if (lastChPtr + nextCharLen > bufferEnd) {
-          break;
-        }
-        lastChPtr += nextCharLen;
-      }
-
-      // Also keep up to MAX_KEEP_CHARS complete characters before the boundary
-      // to preserve multi-character phrases that may span across buffer
-      // boundaries for correct longest-prefix segmentation.
-      char* keepStart = lastChPtr;
-      size_t charsKept = 0;
-      while (keepStart > bufferBegin && charsKept < MAX_KEEP_CHARS) {
-        size_t prevCharLen = UTF8Util::PrevCharLength(keepStart);
-        keepStart -= prevCharLen;
-        charsKept++;
-      }
-
-      convertLength = keepStart - bufferBegin;
-      remainingLength = bufferEnd - keepStart;
-      if (remainingLength > 0) {
-        remainingTemp = UTF8Util::FromSubstr(keepStart, remainingLength);
-      }
-    }
-
-    // Null-terminate the portion to convert
-    bufferBegin[convertLength] = '\0';
 
     const auto convertStart = std::chrono::steady_clock::now();
-    const std::string& converted = converter->Convert(bufferBegin);
+    const std::string& converted =
+        length == buffer.size() ? stream.ConvertChunk(buffer.data(), length)
+                                : stream.Finish(buffer.data(), length);
     measurement.convertMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - convertStart);
     measurement.outputBytes += converted.size();
@@ -373,13 +335,23 @@ void ConvertStream(FILE* fin, FILE* fout) {
     }
     measurement.writeMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - writeStart);
-
-    bufferPtr = bufferBegin + remainingLength;
-    bufferSizeAvailble = BUFFER_SIZE - remainingLength;
-    if (remainingLength > 0) {
-      memcpy(bufferBegin, remainingTemp.c_str(), remainingLength);
+    if (length < buffer.size()) {
+      return;
     }
   }
+
+  const auto convertStart = std::chrono::steady_clock::now();
+  const std::string& converted = stream.Finish();
+  measurement.convertMs += DurationToMilliseconds(
+      std::chrono::steady_clock::now() - convertStart);
+  measurement.outputBytes += converted.size();
+  const auto writeStart = std::chrono::steady_clock::now();
+  fputs(converted.c_str(), fout);
+  if (!noFlush) {
+    fflush(fout);
+  }
+  measurement.writeMs += DurationToMilliseconds(
+      std::chrono::steady_clock::now() - writeStart);
 }
 
 void ConvertLineByLine() {

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -322,9 +322,10 @@ void ConvertStream(FILE* fin, FILE* fout) {
     measurement.inputBytes += length;
 
     const auto convertStart = std::chrono::steady_clock::now();
+    const bool isFinalChunk = length < buffer.size() && feof(fin);
     const std::string& converted =
-        length == buffer.size() ? stream.ConvertChunk(buffer.data(), length)
-                                : stream.Finish(buffer.data(), length);
+        isFinalChunk ? stream.Finish(buffer.data(), length)
+                     : stream.ConvertChunk(buffer.data(), length);
     measurement.convertMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - convertStart);
     measurement.outputBytes += converted.size();
@@ -335,7 +336,7 @@ void ConvertStream(FILE* fin, FILE* fout) {
     }
     measurement.writeMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - writeStart);
-    if (length < buffer.size()) {
+    if (isFinalChunk) {
       return;
     }
   }

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -241,6 +241,29 @@ protected:
 #endif
   }
 
+#ifndef _WIN32
+  std::string TestPipeCommand(const std::string& config,
+                              const std::string& outputFile) const {
+    std::string cmd = "(printf '后台'; sleep 0.1; printf '老板') | " +
+                      QuotePath(OpenccCommand()) + " -c " +
+                      QuotePath(ConfigurationDirectory() + config + ".json");
+#ifdef BAZEL
+    const std::string dictFile =
+        runfiles_->Rlocation("_main/data/dictionary/STCharacters.ocd2");
+    const std::string dictDir =
+        dictFile.substr(0, dictFile.find_last_of("/\\"));
+    const std::string configFile =
+        runfiles_->Rlocation("_main/data/config/s2t.json");
+    const std::string configDir =
+        configFile.substr(0, configFile.find_last_of("/\\"));
+    cmd += " --path " + QuotePath(dictDir + "/") +
+           " --path " + QuotePath(configDir + "/");
+#endif
+    cmd += " > " + QuotePath(outputFile);
+    return cmd;
+  }
+#endif
+
   char* originalWorkingDirectory;
 
 #ifdef BAZEL
@@ -352,6 +375,16 @@ TEST_F(CommandLineConvertTest, StdinPreservesLineEndingsAndUnknownCharacters) {
   ASSERT_EQ(0, system(TestStdinCommand(config, inputFile, outputFile).c_str()));
   EXPECT_EQ("鼠標=mouse\r\n123\n未登錄", GetFileContents(outputFile));
 }
+
+#ifndef _WIN32
+TEST_F(CommandLineConvertTest, PipeShortReadContinuesUntilEof) {
+  const std::string outputFile = OutputFile("pipe_short_read");
+
+  ASSERT_EQ(0, system(TestPipeCommand("s2t", outputFile).c_str()));
+
+  ASSERT_EQ("後臺老闆", GetFileContents(outputFile));
+}
+#endif
 
 TEST_F(CommandLineConvertTest, ConvertsFilesWithUnicodePaths) {
   const fs::path unicodeDir =


### PR DESCRIPTION
Move chunk boundary handling into a reusable ConverterStream in the C++ core so native CLI and Node bindings share UTF-8 and phrase-boundary behavior.

Expose the stream state through the Node native addon and update the npm CLI to use a Transform pipeline instead of reading the whole input into memory. The JS layer now handles only Node stream plumbing and leaves conversion state to C++.

Add CLI coverage for phrase conversion across stream chunk boundaries.