### PR TITLE
Add forward variant phrase dictionary scaffolding

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -14,8 +14,10 @@ set(
   TSPhrases
   TWPhrases
   TWPhrasesRev
+  TWVariantsPhrases
   TWVariants
   TWVariantsRevPhrases
+  HKVariantsPhrases
   HKVariants
   HKVariantsRevPhrases
   JPVariants

--- a/data/config/s2hk.json
+++ b/data/config/s2hk.json
@@ -20,8 +20,14 @@
     }
   }, {
     "dict": {
-      "type": "ocd2",
-      "file": "HKVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "HKVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "HKVariants.ocd2"
+      }]
     }
   }]
 }

--- a/data/config/s2tw.json
+++ b/data/config/s2tw.json
@@ -20,8 +20,14 @@
     }
   }, {
     "dict": {
-      "type": "ocd2",
-      "file": "TWVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "TWVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "TWVariants.ocd2"
+      }]
     }
   }]
 }

--- a/data/config/s2twp.json
+++ b/data/config/s2twp.json
@@ -25,8 +25,14 @@
     }
   }, {
     "dict": {
-      "type": "ocd2",
-      "file": "TWVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "TWVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "TWVariants.ocd2"
+      }]
     }
   }]
 }

--- a/data/config/t2hk.json
+++ b/data/config/t2hk.json
@@ -3,14 +3,26 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "HKVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "HKVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "HKVariants.ocd2"
+      }]
     }
   },
   "conversion_chain": [{
     "dict": {
-      "type": "ocd2",
-      "file": "HKVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "HKVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "HKVariants.ocd2"
+      }]
     }
   }]
 }

--- a/data/config/t2tw.json
+++ b/data/config/t2tw.json
@@ -3,14 +3,26 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "TWVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "TWVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "TWVariants.ocd2"
+      }]
     }
   },
   "conversion_chain": [{
     "dict": {
-      "type": "ocd2",
-      "file": "TWVariants.ocd2"
+      "type": "group",
+      "dicts": [{
+        "type": "ocd2",
+        "file": "TWVariantsPhrases.ocd2"
+      }, {
+        "type": "ocd2",
+        "file": "TWVariants.ocd2"
+      }]
     }
   }]
 }

--- a/data/dictionary/HKVariantsPhrases.txt
+++ b/data/dictionary/HKVariantsPhrases.txt
@@ -1,0 +1,6 @@
+# Open Chinese Convert (OpenCC) Dictionary
+# File: HKVariantsPhrases.txt
+# Format: key	value(s) (values separated by spaces)
+# License: Apache-2.0 (see LICENSE)
+# Source: https://github.com/ByVoid/OpenCC
+# Used in configs: s2hk.json, t2hk.json

--- a/data/dictionary/TWVariantsPhrases.txt
+++ b/data/dictionary/TWVariantsPhrases.txt
@@ -1,0 +1,6 @@
+# Open Chinese Convert (OpenCC) Dictionary
+# File: TWVariantsPhrases.txt
+# Format: key	value(s) (values separated by spaces)
+# License: Apache-2.0 (see LICENSE)
+# Source: https://github.com/ByVoid/OpenCC
+# Used in configs: s2tw.json, s2twp.json, t2tw.json

--- a/data/scripts/common.py
+++ b/data/scripts/common.py
@@ -5,10 +5,23 @@ import sys
 
 
 def sort_items(input_filename, output_filename):
+    with open(input_filename, "rb") as raw_input_file:
+        input_bytes = raw_input_file.read()
+    input_ends_with_newline = input_bytes.endswith((b"\n", b"\r"))
+
     input_file = codecs.open(input_filename, "r", encoding="utf-8")
 
     lines = [line.rstrip("\r\n") for line in input_file]
     input_file.close()
+
+    def close_output_file(output_file):
+        if not input_ends_with_newline:
+            position = output_file.tell()
+            if position > 0:
+                output_file.seek(position - 1)
+                if output_file.read(1) == b"\n":
+                    output_file.truncate(position - 1)
+        output_file.close()
 
     def line_type(line):
         if line == "" or line.strip() == "":
@@ -37,15 +50,13 @@ def sort_items(input_filename, output_filename):
         if current:
             header_blocks.append(list(current))
 
-        output_file = open(output_filename, "wb")
+        output_file = open(output_filename, "w+b")
         for idx, block in enumerate(header_blocks):
             for line in block:
                 output_file.write((line + "\n").encode("utf-8"))
             if idx < len(header_blocks) - 1:
                 output_file.write(b"\n")
-        if header_blocks:
-            output_file.write(b"\n")
-        output_file.close()
+        close_output_file(output_file)
         return
 
     first_entry = entry_lines[0]
@@ -137,7 +148,7 @@ def sort_items(input_filename, output_filename):
     for block in floating_blocks:
         floating_by_anchor.setdefault(block["anchor"], []).append(block["lines"])
 
-    output_file = open(output_filename, "wb")
+    output_file = open(output_filename, "w+b")
 
     for idx, block in enumerate(header_blocks):
         for line in block:
@@ -175,7 +186,7 @@ def sort_items(input_filename, output_filename):
             if idx < len(footer_blocks) - 1:
                 output_file.write(b"\n")
 
-    output_file.close()
+    close_output_file(output_file)
 
 
 def reverse_items(input_filename, output_filename):

--- a/node/dicts.gypi
+++ b/node/dicts.gypi
@@ -69,6 +69,14 @@
       "outputs": ["<(output_prefix)TSPhrases.ocd2"],
       "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
     }, {
+      "action_name": "TWVariantsPhrases",
+      "variables": {
+        "input": "<(input_prefix)TWVariantsPhrases.txt",
+      },
+      "inputs": ["<(input)"],
+      "outputs": ["<(output_prefix)TWVariantsPhrases.ocd2"],
+      "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
+    }, {
       "action_name": "TWVariants",
       "variables": {
         "input": "<(input_prefix)TWVariants.txt",
@@ -123,6 +131,14 @@
       },
       "inputs": ["<(input)"],
       "outputs": ["<(output_prefix)TWPhrasesRev.ocd2"],
+      "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
+    }, {
+      "action_name": "HKVariantsPhrases",
+      "variables": {
+        "input": "<(input_prefix)HKVariantsPhrases.txt",
+      },
+      "inputs": ["<(input)"],
+      "outputs": ["<(output_prefix)HKVariantsPhrases.ocd2"],
       "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
     }, {
       "action_name": "HKVariants",


### PR DESCRIPTION
Introduce empty TWVariantsPhrases and HKVariantsPhrases dictionaries so future phrase-level regional variant exceptions can live outside the character variant dictionaries.

Wire s2tw, s2twp, and t2tw to consult TWVariantsPhrases before TWVariants, and wire s2hk and t2hk to consult HKVariantsPhrases before HKVariants. This preserves the existing character-level behavior while creating a phrase-level override point for later entries.

Register the new dictionaries in the CMake dictionary list and the Node dictionary generation actions. Bazel picks them up through the existing dictionary glob.

No dictionary entries are added in this change.

Validation: `bazel test //data/dictionary:dictionary_TWVariantsPhrases_test //data/dictionary:dictionary_HKVariantsPhrases_test //data/config:config_schema_validation_s2hk //data/config:config_schema_validation_s2tw //data/config:config_schema_validation_s2twp //data/config:config_schema_validation_t2hk //data/config:config_schema_validation_t2tw //data/config:config_dict_validation_s2hk //data/config:config_dict_validation_s2tw //data/config:config_dict_validation_s2twp; bazel test //data/config:config_dict_validation_t2hk //data/config:config_dict_validation_t2tw; bazel test //test:command_line_converter_test --test_filter=CommandLineConvertTest.ConvertFromJson`