### PR TITLE
改進維護 Python 腳本

### DIFF
--- a/data/scripts/BUILD.bazel
+++ b/data/scripts/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -18,4 +19,12 @@ py_binary(
 py_binary(
     name = "extract_tofu_risk",
     srcs = ["extract_tofu_risk.py"],
+)
+
+py_test(
+    name = "common_test",
+    size = "small",
+    srcs = ["common_test.py"],
+    imports = ["."],
+    deps = [":common"],
 )

--- a/data/scripts/common.py
+++ b/data/scripts/common.py
@@ -1,237 +1,160 @@
 # -*- coding: utf-8 -*-
 
-import codecs
-import sys
+class BaseDict:
+    def _iter(self, file):
+        with open(file, 'r', encoding='utf-8') as fh:
+            yield from fh
+
+    def iter(self, file):
+        for i, line in enumerate(self._iter(file)):
+            if line.startswith('#') or not line.strip():
+                continue
+            key, value = line.rstrip('\n').split('\t', 1)
+            yield {
+                'key': key,
+                'values': value.split(' '),
+                'line': i + 1,
+            }
+
+    def load(self, file):
+        self.entries = list(self.iter(file))
+
+    def dump(self, file):
+        with open(file, 'wb') as fh:
+            for entry in self.entries:
+                fh.write(self.get_line(entry).encode('utf-8'))
+
+    @classmethod
+    def from_file(cls, file):
+        table = cls()
+        table.load(file)
+        return table
+
+    @staticmethod
+    def get_line(entry):
+        return entry['key'] + '\t' + ' '.join(entry['values']) + '\n'
+
+
+class Dict(BaseDict):
+    def sort(self):
+        self.entries.sort(key=lambda e: e['key'])
+
+    def swap(self):
+        dic = {}
+        for entry in self.entries:
+            key = entry['key']
+            for value in entry['values']:
+                if value in dic:
+                    dic[value].append(key)
+                else:
+                    dic[value] = [key]
+        self.entries = [{'key': key, 'values': values} for key, values in dic.items()]
+
+
+class RichDict(Dict):
+    def load(self, file):
+        entries = []
+        block_map = {}
+        block = []
+        _line = ''
+        for i, _line in enumerate(self._iter(file)):
+            line = _line.rstrip('\n')
+            if self.get_line_type(line) == 'entry':
+                entry_index = len(entries)
+
+                if block:
+                    if entry_index == 0:
+                        last_empty_idx = next(
+                            (i for i in range(len(block) - 1, -1, -1) if not block[i].strip()), 
+                            -1
+                        )
+                        block_anchored = block[last_empty_idx + 1:]
+                        del block[last_empty_idx + 1:]
+                        if block:
+                            block_map[-1] = block
+                        if block_anchored:
+                            block_map[0] = block_anchored
+                    else:
+                        block_map[entry_index] = block
+
+                key, value = line.split('\t', 1)
+                entries.append({
+                    'key': key,
+                    'values': value.split(' '),
+                    'line': i + 1,
+                    'orig_index': entry_index,
+                })
+
+                block = []
+
+            else:
+                block.append(line)
+        else:
+            if block:
+                block_map[None] = block
+            final_newline = _line.endswith('\n')
+
+        self.final_newline = final_newline
+        self.entries = entries
+        self.blocks = block_map
+
+    def dump(self, file):
+        def write_block(fh, block):
+            if block is None:
+                return
+            for line in block:
+                fh.write((line + '\n').encode('utf-8'))
+
+        def write_entry(fh, entry):
+            fh.write(self.get_line(entry).encode('utf-8'))
+
+        index_map = {-1: -1, None: None}
+        for i, e in enumerate(self.entries):
+            idx = e.get('orig_index')
+            if idx is not None:
+                index_map[idx] = i
+        blocks = {index_map[i]: block for i, block in self.blocks.items() if i in index_map}
+
+        with open(file, 'w+b') as fh:
+            write_block(fh, blocks.get(-1))
+            for i, entry in enumerate(self.entries):
+                write_block(fh, blocks.get(i))
+                write_entry(fh, entry)
+            write_block(fh, blocks.get(None))
+
+            if not self.final_newline:
+                pos = fh.tell()
+                if pos > 0:
+                    fh.seek(pos - 1)
+                    if fh.read(1) == b'\n':
+                        fh.truncate(pos - 1)
+
+    @staticmethod
+    def get_line_type(line):
+        if not line.strip():
+            return 'empty'
+        if line.startswith('#'):
+            return 'comment'
+        if '\t' in line:
+            return 'entry'
+        raise ValueError('Invalid dictionary line: ' + line)
 
 
 def sort_items(input_filename, output_filename):
-    with open(input_filename, "rb") as raw_input_file:
-        input_bytes = raw_input_file.read()
-    input_ends_with_newline = input_bytes.endswith((b"\n", b"\r"))
-
-    input_file = codecs.open(input_filename, "r", encoding="utf-8")
-
-    lines = [line.rstrip("\r\n") for line in input_file]
-    input_file.close()
-
-    def close_output_file(output_file):
-        if not input_ends_with_newline:
-            position = output_file.tell()
-            if position > 0:
-                output_file.seek(position - 1)
-                if output_file.read(1) == b"\n":
-                    output_file.truncate(position - 1)
-        output_file.close()
-
-    def line_type(line):
-        if line == "" or line.strip() == "":
-            return "empty"
-        if line.startswith("#"):
-            return "comment"
-        if "\t" in line:
-            return "entry"
-        raise ValueError("Invalid dictionary line: " + line)
-
-    parsed = []
-    for line in lines:
-        parsed.append({"type": line_type(line), "content": line})
-
-    entry_lines = [i for i, p in enumerate(parsed) if p["type"] == "entry"]
-    if not entry_lines:
-        header_blocks = []
-        current = []
-        for p in parsed:
-            if p["type"] == "comment":
-                current.append(p["content"])
-            elif p["type"] == "empty":
-                if current:
-                    header_blocks.append(list(current))
-                    current = []
-        if current:
-            header_blocks.append(list(current))
-
-        output_file = open(output_filename, "w+b")
-        for idx, block in enumerate(header_blocks):
-            for line in block:
-                output_file.write((line + "\n").encode("utf-8"))
-            if idx < len(header_blocks) - 1:
-                output_file.write(b"\n")
-        close_output_file(output_file)
-        return
-
-    first_entry = entry_lines[0]
-    last_entry = entry_lines[-1]
-
-    header_end = -1
-    for i in range(first_entry - 1, -1, -1):
-        if parsed[i]["type"] == "empty":
-            header_end = i
-            break
-
-    header_blocks = []
-    current = []
-    for i in range(0, header_end + 1):
-        if parsed[i]["type"] == "comment":
-            current.append(parsed[i]["content"])
-        elif parsed[i]["type"] == "empty":
-            if current:
-                header_blocks.append(list(current))
-                current = []
-    if current:
-        header_blocks.append(list(current))
-
-    footer_blocks = []
-    current = []
-    for i in range(last_entry + 1, len(parsed)):
-        if parsed[i]["type"] == "comment":
-            current.append(parsed[i]["content"])
-        elif parsed[i]["type"] == "empty":
-            if current:
-                footer_blocks.append(list(current))
-                current = []
-    if current:
-        footer_blocks.append(list(current))
-
-    annotated_entries = []
-    floating_blocks = []
-    current = []
-    entry_index = 0
-    for i in range(header_end + 1, last_entry + 1):
-        p = parsed[i]
-        if p["type"] == "comment":
-            current.append(p["content"])
-            continue
-        if p["type"] == "empty":
-            if current:
-                floating_blocks.append({"anchor": entry_index, "lines": list(current)})
-                current = []
-            continue
-        if p["type"] == "entry":
-            attached = None
-            if current:
-                has_empty = False
-                for j in range(i - 1, header_end, -1):
-                    if parsed[j]["type"] == "entry":
-                        break
-                    if parsed[j]["type"] == "empty":
-                        has_empty = True
-                        break
-                if has_empty:
-                    floating_blocks.append({"anchor": entry_index, "lines": list(current)})
-                else:
-                    attached = list(current)
-                current = []
-
-            key, value = p["content"].split("\t", 1)
-            annotated_entries.append(
-                {
-                    "key": key,
-                    "value": value,
-                    "attached": attached,
-                    "original_index": entry_index,
-                }
-            )
-            entry_index += 1
-
-    if current:
-        floating_blocks.append({"anchor": entry_index, "lines": list(current)})
-
-    annotated_entries.sort(key=lambda e: e["key"])
-    index_map = {e["original_index"]: i for i, e in enumerate(annotated_entries)}
-    for block in floating_blocks:
-        if block["anchor"] in index_map:
-            block["anchor"] = index_map[block["anchor"]]
-        else:
-            block["anchor"] = len(annotated_entries)
-
-    floating_by_anchor = {}
-    for block in floating_blocks:
-        floating_by_anchor.setdefault(block["anchor"], []).append(block["lines"])
-
-    output_file = open(output_filename, "w+b")
-
-    for idx, block in enumerate(header_blocks):
-        for line in block:
-            output_file.write((line + "\n").encode("utf-8"))
-        if idx < len(header_blocks) - 1:
-            output_file.write(b"\n")
-    if header_blocks and annotated_entries:
-        output_file.write(b"\n")
-
-    for i, entry in enumerate(annotated_entries):
-        for block in floating_by_anchor.get(i, []):
-            output_file.write(b"\n")
-            for line in block:
-                output_file.write((line + "\n").encode("utf-8"))
-            output_file.write(b"\n")
-
-        if entry["attached"]:
-            for line in entry["attached"]:
-                output_file.write((line + "\n").encode("utf-8"))
-        output_file.write(
-            (entry["key"] + "\t" + entry["value"] + "\n").encode("utf-8")
-        )
-
-    for block in floating_by_anchor.get(len(annotated_entries), []):
-        output_file.write(b"\n")
-        for line in block:
-            output_file.write((line + "\n").encode("utf-8"))
-
-    if footer_blocks:
-        if annotated_entries:
-            output_file.write(b"\n")
-        for idx, block in enumerate(footer_blocks):
-            for line in block:
-                output_file.write((line + "\n").encode("utf-8"))
-            if idx < len(footer_blocks) - 1:
-                output_file.write(b"\n")
-
-    close_output_file(output_file)
+    table = RichDict.from_file(input_filename)
+    table.sort()
+    table.dump(output_filename)
 
 
 def reverse_items(input_filename, output_filename):
-    input_file = codecs.open(input_filename, "r", encoding="utf-8")
-    dic = {}
-
-    for line in input_file:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        key, value = line.split("\t")
-        while value[-1] == "\n" or value[-1] == "\r":
-            value = value[:-1]
-
-        value_list = value.split(" ")
-        for value in value_list:
-            if value in dic:
-                dic[value].append(key)
-            else:
-                dic[value] = [key]
-
-    input_file.close()
-
-    output_file = open(output_filename, "wb")
-
-    for key in sorted(dic.keys()):
-        line = key + "\t" + " ".join(dic[key]) + "\n"
-        output_file.write(line.encode('utf-8'))
-
-    output_file.close()
+    table = Dict.from_file(input_filename)
+    table.swap()
+    table.sort()
+    table.dump(output_filename)
 
 
 def find_target_items(input_filename, keyword):
-    input_file = codecs.open(input_filename, "r", encoding="utf-8")
-    for line in input_file:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        key, value = line.split("\t")
-        while value[-1] == "\n" or value[-1] == "\r":
-            value = value[:-1]
-
-        value_list = value.split(" ")
-        for value in value_list:
+    for entry in Dict().iter(input_filename):
+        for value in entry['values']:
             if keyword in value:
-                sys.stdout.write(line)
-
-    input_file.close()
+                print(Dict.get_line(entry), end='')

--- a/data/scripts/common.py
+++ b/data/scripts/common.py
@@ -9,7 +9,7 @@ class BaseDict:
         for i, line in enumerate(self._iter(file)):
             if line.startswith('#') or not line.strip():
                 continue
-            key, value = line.rstrip('\n').split('\t', 1)
+            key, value = line.rstrip('\r\n').split('\t', 1)
             yield {
                 'key': key,
                 'values': value.split(' '),
@@ -58,7 +58,7 @@ class RichDict(Dict):
         block = []
         _line = ''
         for i, _line in enumerate(self._iter(file)):
-            line = _line.rstrip('\n')
+            line = _line.rstrip('\r\n')
             if self.get_line_type(line) == 'entry':
                 entry_index = len(entries)
 

--- a/data/scripts/common_test.py
+++ b/data/scripts/common_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from common import find_target_items, reverse_items, sort_items
+
+
+class CommonScriptTest(unittest.TestCase):
+    def run_file_op(self, func, input_text, *, input_bytes=None):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "in.txt")
+            dst = os.path.join(tmpdir, "out.txt")
+
+            if input_bytes is not None:
+                with open(src, "wb") as f:
+                    f.write(input_bytes)
+            else:
+                with open(src, "w", encoding="utf-8") as f:
+                    f.write(input_text)
+
+            func(src, dst)
+
+            with open(dst, "rb") as f:
+                return f.read()
+
+    def test_sort_entries(self):
+        out = self.run_file_op(sort_items, "b\tB\na\tA\n")
+        self.assertEqual(out.decode("utf-8"), "a\tA\nb\tB\n")
+
+    def test_sort_moves_comment_with_following_entry(self):
+        out = self.run_file_op(sort_items, "b\tB\n# comment for a\na\tA\n")
+        self.assertEqual(
+            out.decode("utf-8"),
+            "# comment for a\na\tA\nb\tB\n",
+        )
+
+    def test_sort_preserves_blank_lines_in_anchored_block(self):
+        out = self.run_file_op(sort_items, "b\tB\n\n# comment for a\na\tA\n")
+        self.assertEqual(
+            out.decode("utf-8"),
+            "\n# comment for a\na\tA\nb\tB\n",
+        )
+
+    def test_sort_splits_header_from_first_entry_comment(self):
+        out = self.run_file_op(
+            sort_items,
+            "# Header\n\n# comment for b\nb\tB\na\tA\n",
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            "# Header\n\na\tA\n# comment for b\nb\tB\n",
+        )
+
+    def test_sort_keeps_footer_at_end(self):
+        out = self.run_file_op(sort_items, "b\tB\na\tA\n\n# footer\n")
+        self.assertEqual(
+            out.decode("utf-8"),
+            "a\tA\nb\tB\n\n# footer\n",
+        )
+
+    def test_sort_preserves_missing_final_newline(self):
+        out = self.run_file_op(
+            sort_items,
+            "",
+            input_bytes=b"b\tB\na\tA",
+        )
+        self.assertEqual(out, b"a\tA\nb\tB")
+
+    def test_sort_normalizes_crlf_input(self):
+        out = self.run_file_op(
+            sort_items,
+            "",
+            input_bytes=b"b\tB\r\na\tA\r\n",
+        )
+        self.assertEqual(out, b"a\tA\nb\tB\n")
+
+    def test_reverse_items(self):
+        out = self.run_file_op(reverse_items, "A\tx y\nB\tx\n")
+        self.assertEqual(
+            out.decode("utf-8"),
+            "x\tA B\ny\tA\n",
+        )
+
+    def test_find_target_items_matches_values_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "in.txt")
+            with open(src, "w", encoding="utf-8") as f:
+                f.write("foo\tbar baz\n")
+                f.write("target\txxx\n")
+                f.write("abc\ttarget-value\n")
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                find_target_items(src, "target")
+
+            self.assertEqual(buf.getvalue(), "abc\ttarget-value\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
將維護腳本模組化、類別化，並改為更適合 Python 的語法風格，統一檔案讀取、寫入接口，使之更為一致，方便未來使用腳本檢查及更新詞典檔。

將 `codecs.open`（Python 3.14 開始聲明棄用）替換為較建議的 `open`。

調整註解區塊的處理行為：
- 將原來的 Attached、Floating 統一為單一 anchored block，錨定至後面的資料行。
- 維持原始程式碼非資料行中的換行與空白字元，不再主動插入或刪除。
- 改進演算法。
