### PR TITLE
Experiment with scoped opencc-jieba binary packages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,12 +53,16 @@ for:
     - copy build-npm-jieba-install\share\opencc\*jieba.json plugins\jieba\node\data\
     - xcopy /E /I /Y build-npm-jieba-install\share\opencc\jieba_dict plugins\jieba\node\data\jieba_dict
     - copy build-npm-jieba-install\bin\plugins\opencc-jieba.dll plugins\jieba\node\prebuilds\win32-x64\opencc-jieba.dll
+    - npm --prefix plugins\jieba\node run prepare:scoped-packages
+    - echo [opencc npm package] packing opencc-jieba win32-x64 scoped binary package
+    - npm pack plugins\jieba\node\dist\scoped-packages\@opencc\opencc-jieba-win32-x64
+    - for %%F in (opencc-opencc-jieba-win32-x64-*.tgz) do set OPENCC_JIEBA_WIN32_TGZ=%%~fF
     - echo [opencc npm package] packing opencc-jieba
     - npm pack plugins\jieba\node --ignore-scripts
     - for %%F in (opencc-jieba-*.tgz) do set OPENCC_JIEBA_TGZ=%%~fF
     - mkdir npm-smoke
     - echo [opencc npm smoke] installing packed packages
-    - npm --prefix npm-smoke install "%OPENCC_TGZ%" "%OPENCC_JIEBA_TGZ%"
+    - npm --prefix npm-smoke install "%OPENCC_TGZ%" "%OPENCC_JIEBA_TGZ%" "%OPENCC_JIEBA_WIN32_TGZ%"
     - .\npm-smoke\node_modules\.bin\opencc.cmd --version
     - .\npm-smoke\node_modules\.bin\opencc.cmd --help >nul
     - mkdir npm-smoke\測試
@@ -82,6 +86,8 @@ for:
     name: OpenCCNpmPackage
   - path: opencc-jieba-*.tgz
     name: OpenCCJiebaNpmPackage
+  - path: opencc-opencc-jieba-win32-x64-*.tgz
+    name: OpenCCJiebaWin32NpmPackage
 
 - matrix:
     only:

--- a/plugins/jieba/node/.gitignore
+++ b/plugins/jieba/node/.gitignore
@@ -1,2 +1,3 @@
 prebuilds/
 data/
+dist/

--- a/plugins/jieba/node/.npmignore
+++ b/plugins/jieba/node/.npmignore
@@ -1,2 +1,4 @@
 NPM_PACKAGE_DESIGN.md
 build.js
+scripts/
+dist/

--- a/plugins/jieba/node/NPM_PACKAGE_DESIGN.md
+++ b/plugins/jieba/node/NPM_PACKAGE_DESIGN.md
@@ -6,7 +6,7 @@
 
 Integrating the Jieba segmentation plugin into Node.js previously faced two major pain points:
 1. **Environment Variable Dependency**: The C++ core library relied on environment variables (like `OPENCC_SEGMENTATION_PLUGIN_PATH` and `OPENCC_DATA_DIR`) to locate dynamic libraries and dictionary files. This approach is prone to global pollution and is unsuitable for an independent NPM module.
-2. **Binary Artifact Management**: Committing large cross-platform build artifacts (`.dylib`, `.so`, `.dll`) and dictionary data directly into the Git repository causes uncontrollable repository bloat and severe merge conflicts during CI workflows and collaborative development.
+2. **Binary Artifact Management**: Committing large cross-platform build artifacts (`.dylib`, `.so`, `.dll`) and dictionary data directly into the Git repository causes uncontrollable repository bloat and severe merge conflicts during CI workflows and collaborative development. Publishing every platform binary in the main npm package also makes installs larger than necessary.
 
 To resolve these issues, we refactored `opencc-jieba` into a **fully self-contained, deterministic, and artifact-free** modern NPM package.
 
@@ -28,7 +28,7 @@ std::shared_ptr<PluginLibrary> plugin =
 ```
 
 **[Node.js Integration]**
-On the Node.js side, `plugins/jieba/node/index.js` now exports the exact absolute paths to the platform-specific dynamic library (`pluginLibrary`) and the data directory (`dataDir`).
+On the Node.js side, `plugins/jieba/node/index.js` now exports the exact absolute paths to the platform-specific dynamic library (`pluginLibrary`) and the data directory (`dataDir`). It first resolves the matching optional scoped package (`@opencc/opencc-jieba-<platform>-<arch>`), then falls back to the local `prebuilds/<platform>-<arch>/` directory for development builds.
 When the upper-level Node.js wrapper (e.g., the `opencc` npm package) parses user-specified JSON configurations, it dynamically injects these **absolute paths** into the `__plugin_library` field. This guarantees 100% stable plugin discovery, completely unaffected by environment variables.
 
 ### 2.2 Separation of Artifacts and Source Code
@@ -44,8 +44,11 @@ To ensure a seamless NPM publishing experience, we introduced `plugins/jieba/nod
    - Copies the upstream raw dictionaries and the compiled `.ocd2` binary dictionary into `data/jieba_dict/`.
    - Copies segmentation-specific JSON configurations into `data/`.
 
+**[Scoped Binary Package Preparation: `scripts/prepare-scoped-packages.js`]**
+The main `opencc-jieba` package now ships JavaScript and data only. `scripts/prepare-scoped-packages.js` converts the local `prebuilds/<platform>-<arch>/` tree into publishable packages under `dist/scoped-packages/@opencc/opencc-jieba-<platform>-<arch>/`. These packages contain only `index.js`, `package.json`, and the native library for that platform.
+
 **[Automated NPM Hooks: `package.json`]**
-We configured `"prepack": "npm run build"` in the `scripts` section of `package.json`. This ensures that whether running `npm pack` locally or `npm publish` in CI, NPM will automatically invoke `build.js` to populate the latest artifact directories. End users running `npm install` simply download the prebuilt package without needing to compile from source or install Bazel.
+We configured `"prepack": "npm run build:all"` in the `scripts` section of `package.json`. This ensures that whether running `npm pack` locally or `npm publish` in CI, NPM will automatically invoke `build.js` to populate the latest artifact directories. Before publishing, maintainers can run `npm run prepare:scoped-packages` and publish each generated scoped package first; end users install only the platform package selected by npm optional dependency resolution.
 
 ### 2.3 Highly Optimized Cross-Platform Compilation
 

--- a/plugins/jieba/node/PUBLISHING.md
+++ b/plugins/jieba/node/PUBLISHING.md
@@ -95,6 +95,7 @@ Each generated package contains only:
 ```text
 index.js
 package.json
+README.md
 prebuilds/<platform>-<arch>/<native-library>
 ```
 
@@ -118,7 +119,8 @@ npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-linux-x64
 npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-win32-x64
 ```
 
-Each scoped tarball should contain one native library for its own platform.
+Each scoped tarball should contain one native library for its own platform plus
+a short package-specific README.
 
 ## Publish order
 

--- a/plugins/jieba/node/PUBLISHING.md
+++ b/plugins/jieba/node/PUBLISHING.md
@@ -1,0 +1,177 @@
+# Publishing opencc-jieba npm packages
+
+This document describes the current experimental release flow for the
+`opencc-jieba` npm package family.
+
+The split-package layout is intentionally being tried on `opencc-jieba` first:
+
+- `opencc-jieba` contains JavaScript, Jieba configs, and Jieba dictionary data.
+- `@opencc/opencc-jieba-<platform>-<arch>` contains exactly one native plugin
+  library for one platform.
+
+If this install and publishing model works well, the same approach can later be
+applied to the main `opencc` npm package.
+
+## Package names
+
+The main package declares the scoped packages as optional dependencies:
+
+```text
+opencc-jieba
+@opencc/opencc-jieba-darwin-arm64
+@opencc/opencc-jieba-linux-arm64
+@opencc/opencc-jieba-linux-x64
+@opencc/opencc-jieba-win32-x64
+```
+
+The versions must stay in sync. For example, when publishing
+`opencc-jieba@1.3.2-next1`, every scoped binary package should also be published
+as `1.3.2-next1`.
+
+## Prerequisites
+
+- npm account access to publish `opencc-jieba`.
+- npm organization access to publish public packages under `@opencc`.
+- Bazel configured for the platform builds used by `build.js`.
+- For the current local all-in-one flow, an ARM64 macOS machine with the remote
+  Linux build configs available.
+
+At the moment, maintainers are assumed to run this release process from an
+ARM64 macOS development machine. In the future, the per-platform build and
+publish steps should move to GitHub Actions so the release process no longer
+depends on the maintainer's local platform.
+
+## Build
+
+From the repository root:
+
+```sh
+cd plugins/jieba/node
+npm run build:all
+```
+
+This creates:
+
+```text
+data/
+prebuilds/darwin-arm64/libopencc-jieba.dylib
+prebuilds/linux-arm64/libopencc-jieba.so
+prebuilds/linux-x64/libopencc-jieba.so
+prebuilds/win32-x64/opencc-jieba.dll
+```
+
+For one platform only:
+
+```sh
+npm run build
+npm run build linux-x64
+npm run build linux-arm64
+npm run build win32-x64
+```
+
+`npm run build` builds the host platform, so on an Apple Silicon Mac it produces
+`darwin-arm64`.
+
+## Prepare scoped binary packages
+
+After the `prebuilds/` tree exists, generate publishable scoped package
+directories:
+
+```sh
+npm run prepare:scoped-packages
+```
+
+This writes packages under:
+
+```text
+dist/scoped-packages/@opencc/opencc-jieba-darwin-arm64
+dist/scoped-packages/@opencc/opencc-jieba-linux-arm64
+dist/scoped-packages/@opencc/opencc-jieba-linux-x64
+dist/scoped-packages/@opencc/opencc-jieba-win32-x64
+```
+
+Each generated package contains only:
+
+```text
+index.js
+package.json
+prebuilds/<platform>-<arch>/<native-library>
+```
+
+## Verify package contents
+
+Dry-run the main package without running `prepack` again:
+
+```sh
+npm pack --dry-run --ignore-scripts
+```
+
+The main package tarball should contain `index.js`, `README.md`, `package.json`,
+and `data/`, but not `prebuilds/`.
+
+Dry-run each scoped package:
+
+```sh
+npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-darwin-arm64
+npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-linux-arm64
+npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-linux-x64
+npm pack --dry-run dist/scoped-packages/@opencc/opencc-jieba-win32-x64
+```
+
+Each scoped tarball should contain one native library for its own platform.
+
+## Publish order
+
+Publish the scoped binary packages first. The main package depends on them via
+`optionalDependencies`, so they should already exist by the time users install
+the main package.
+
+For a prerelease version such as `1.3.2-next1`, use the `next` dist-tag:
+
+```sh
+npm publish dist/scoped-packages/@opencc/opencc-jieba-darwin-arm64 --access public --tag next
+npm publish dist/scoped-packages/@opencc/opencc-jieba-linux-arm64 --access public --tag next
+npm publish dist/scoped-packages/@opencc/opencc-jieba-linux-x64 --access public --tag next
+npm publish dist/scoped-packages/@opencc/opencc-jieba-win32-x64 --access public --tag next
+npm publish --tag next
+```
+
+For a stable release, use `latest` or omit `--tag`:
+
+```sh
+npm publish dist/scoped-packages/@opencc/opencc-jieba-darwin-arm64 --access public
+npm publish dist/scoped-packages/@opencc/opencc-jieba-linux-arm64 --access public
+npm publish dist/scoped-packages/@opencc/opencc-jieba-linux-x64 --access public
+npm publish dist/scoped-packages/@opencc/opencc-jieba-win32-x64 --access public
+npm publish
+```
+
+`--access public` is required for the first publish of scoped public packages.
+It is harmless to keep using it for later publishes.
+
+## Install-test after publishing
+
+Use a temporary directory and install both packages from npm:
+
+```sh
+mkdir /tmp/opencc-jieba-install-test
+cd /tmp/opencc-jieba-install-test
+npm init -y
+npm install opencc@1.3.2-next1 opencc-jieba@1.3.2-next1 --tag next
+node -e "const OpenCC = require('opencc'); const cc = new OpenCC('s2twp_jieba'); cc.convert('鼠标里面的硅二极管坏了', (err, text) => { if (err) throw err; console.log(text); });"
+```
+
+The install should pull exactly one matching
+`@opencc/opencc-jieba-<platform>-<arch>` optional package for the current
+machine.
+
+## Future CI shape
+
+The intended CI release flow is:
+
+1. Build each scoped binary package on its matching platform or runner.
+2. Upload scoped package artifacts.
+3. Publish all scoped binary packages with the chosen version and dist-tag.
+4. Publish the main `opencc-jieba` package after the scoped packages exist.
+
+Until that CI flow exists, the local flow above is the source of truth.

--- a/plugins/jieba/node/README.md
+++ b/plugins/jieba/node/README.md
@@ -15,8 +15,8 @@ npm install opencc-jieba
 > **Note**: This package is intended to be used alongside the `opencc` npm package (`>= 1.3.2`).
 > npm installs the matching optional `@opencc/opencc-jieba-<platform>-<arch>` package automatically on supported platforms.
 
-Maintainers should follow [PUBLISHING.md](PUBLISHING.md) for the split-package
-build and release flow.
+Maintainers should follow the repository publishing guide at
+`plugins/jieba/node/PUBLISHING.md` for the split-package build and release flow.
 
 ## Usage
 

--- a/plugins/jieba/node/README.md
+++ b/plugins/jieba/node/README.md
@@ -15,6 +15,9 @@ npm install opencc-jieba
 > **Note**: This package is intended to be used alongside the `opencc` npm package (`>= 1.3.2`).
 > npm installs the matching optional `@opencc/opencc-jieba-<platform>-<arch>` package automatically on supported platforms.
 
+Maintainers should follow [PUBLISHING.md](PUBLISHING.md) for the split-package
+build and release flow.
+
 ## Usage
 
 This package acts as an underlying plugin provider. It exports absolute paths to the cross-platform native binaries and dictionary files, which can then be dynamically injected into the OpenCC configuration.

--- a/plugins/jieba/node/README.md
+++ b/plugins/jieba/node/README.md
@@ -2,7 +2,7 @@
 
 Jieba segmentation plugin for OpenCC (Node.js).
 
-This package provides pre-compiled native dynamic libraries (`.dylib`, `.so`, `.dll`) and Jieba dictionary data (`.ocd2`, `.utf8`) to allow [OpenCC](https://github.com/BYVoid/OpenCC) to use the Jieba algorithm for Chinese text segmentation.
+This package provides Jieba dictionary data (`.ocd2`, `.utf8`) and loads the matching pre-compiled native dynamic library (`.dylib`, `.so`, `.dll`) from an optional platform package such as `@opencc/opencc-jieba-darwin-arm64` or `@opencc/opencc-jieba-linux-x64`.
 
 By leveraging this standalone NPM package, users do not need to manually install C++ toolchains or configure complex environment variables (such as `OPENCC_SEGMENTATION_PLUGIN_PATH` or `OPENCC_DATA_DIR`). The prebuilt libraries are deterministic and fully self-contained.
 
@@ -13,6 +13,7 @@ npm install opencc-jieba
 ```
 
 > **Note**: This package is intended to be used alongside the `opencc` npm package (`>= 1.3.2`).
+> npm installs the matching optional `@opencc/opencc-jieba-<platform>-<arch>` package automatically on supported platforms.
 
 ## Usage
 
@@ -23,11 +24,11 @@ const openccJieba = require('opencc-jieba');
 
 // Absolute path to the directory containing the dynamic library
 console.log(openccJieba.pluginDir);
-// e.g. ".../node_modules/opencc-jieba/prebuilds/darwin-arm64"
+// e.g. ".../node_modules/@opencc/opencc-jieba-darwin-arm64/prebuilds/darwin-arm64"
 
 // Absolute path to the specific dynamic library file
 console.log(openccJieba.pluginLibrary);
-// e.g. ".../node_modules/opencc-jieba/prebuilds/darwin-arm64/libopencc-jieba.dylib"
+// e.g. ".../node_modules/@opencc/opencc-jieba-darwin-arm64/prebuilds/darwin-arm64/libopencc-jieba.dylib"
 
 // Absolute path to the data directory containing config JSONs and dictionaries
 console.log(openccJieba.dataDir);

--- a/plugins/jieba/node/index.js
+++ b/plugins/jieba/node/index.js
@@ -4,6 +4,7 @@ const os = require('os');
 const platform = os.platform();
 const arch = os.arch();
 const prebuildDir = path.join(__dirname, 'prebuilds', `${platform}-${arch}`);
+const scopedPackageName = `@opencc/opencc-jieba-${platform}-${arch}`;
 
 // Platform-specific plugin library filename
 const libName = platform === 'win32' ? 'opencc-jieba.dll'
@@ -12,6 +13,23 @@ const libName = platform === 'win32' ? 'opencc-jieba.dll'
 
 const dataDir = path.join(__dirname, 'data');
 const configDir = dataDir;
+
+function requireOptionalPackage(packageName) {
+  try {
+    return require(packageName);
+  } catch (error) {
+    if (error && error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+const scopedPackage = requireOptionalPackage(scopedPackageName);
+const pluginLibrary = scopedPackage && scopedPackage.pluginLibrary
+  ? scopedPackage.pluginLibrary
+  : path.join(prebuildDir, libName);
+const pluginDir = path.dirname(pluginLibrary);
 
 function resolveConfigPath(config) {
   if (typeof config !== 'string' || path.isAbsolute(config)) {
@@ -35,9 +53,9 @@ function resolveConfigPath(config) {
 
 module.exports = {
   /** Directory containing the prebuilt libopencc-jieba shared library. */
-  pluginDir: prebuildDir,
+  pluginDir,
   /** Absolute path to the platform-specific plugin shared library. */
-  pluginLibrary: path.join(prebuildDir, libName),
+  pluginLibrary,
   /** Root data directory (config files and jieba_dict/ live here). */
   dataDir,
   /** Directory containing jieba-backed OpenCC configuration JSON files. */

--- a/plugins/jieba/node/package.json
+++ b/plugins/jieba/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencc-jieba",
-  "version": "1.3.2",
+  "version": "1.3.2-next1",
   "description": "Jieba segmentation plugin for OpenCC",
   "author": "Carbo Kuo and OpenCC contributors",
   "license": "Apache-2.0",
@@ -8,14 +8,20 @@
   "peerDependencies": {
     "opencc": ">=1.3.2"
   },
+  "optionalDependencies": {
+    "@opencc/opencc-jieba-darwin-arm64": "1.3.2-next1",
+    "@opencc/opencc-jieba-linux-arm64": "1.3.2-next1",
+    "@opencc/opencc-jieba-linux-x64": "1.3.2-next1",
+    "@opencc/opencc-jieba-win32-x64": "1.3.2-next1"
+  },
   "files": [
     "index.js",
-    "prebuilds",
     "data"
   ],
   "scripts": {
     "build": "node build.js",
     "build:all": "npm run build && npm run build linux-x64 && npm run build linux-arm64 && npm run build win32-x64",
+    "prepare:scoped-packages": "node scripts/prepare-scoped-packages.js",
     "prepack": "npm run build:all"
   }
 }

--- a/plugins/jieba/node/package.json
+++ b/plugins/jieba/node/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "index.js",
+    "PUBLISHING.md",
     "data"
   ],
   "scripts": {

--- a/plugins/jieba/node/package.json
+++ b/plugins/jieba/node/package.json
@@ -16,7 +16,6 @@
   },
   "files": [
     "index.js",
-    "PUBLISHING.md",
     "data"
   ],
   "scripts": {

--- a/plugins/jieba/node/scripts/prepare-scoped-packages.js
+++ b/plugins/jieba/node/scripts/prepare-scoped-packages.js
@@ -34,6 +34,36 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function writeReadme(packageDir, packageName, dirname, libraryName) {
+  fs.writeFileSync(path.join(packageDir, 'README.md'), [
+    `# ${packageName}`,
+    '',
+    `Native Jieba segmentation plugin binary for OpenCC on \`${dirname}\`.`,
+    '',
+    'This package is installed automatically as an optional dependency of',
+    '`opencc-jieba`. Most users should install `opencc-jieba` instead of',
+    'installing this package directly.',
+    '',
+    '## Contents',
+    '',
+    '```text',
+    `prebuilds/${dirname}/${libraryName}`,
+    '```',
+    '',
+    '## Usage',
+    '',
+    '```javascript',
+    `const binary = require('${packageName}');`,
+    'console.log(binary.pluginLibrary);',
+    '```',
+    '',
+    '## License',
+    '',
+    `${parentPackage.license}`,
+    '',
+  ].join('\n'));
+}
+
 function preparePackage(dirname) {
   const parsed = parsePlatformArch(dirname);
   if (!parsed) {
@@ -77,6 +107,7 @@ function preparePackage(dirname) {
     cpu: [arch],
     files: [
       'index.js',
+      'README.md',
       relativeLibraryPath,
     ],
   });
@@ -93,6 +124,7 @@ function preparePackage(dirname) {
     '',
   ].join('\n'));
 
+  writeReadme(packageDir, packageName, dirname, libraryName);
   copyFile(sourceLibrary, path.join(packageDir, relativeLibraryPath));
   return packageDir;
 }

--- a/plugins/jieba/node/scripts/prepare-scoped-packages.js
+++ b/plugins/jieba/node/scripts/prepare-scoped-packages.js
@@ -86,7 +86,7 @@ function preparePackage(dirname) {
 
   const packageName = `@opencc/opencc-jieba-${dirname}`;
   const packageDir = path.join(outputRoot, packageName);
-  const relativeLibraryPath = path.join('prebuilds', dirname, libraryName);
+  const relativeLibraryPath = path.posix.join('prebuilds', dirname, libraryName);
 
   fs.rmSync(packageDir, { recursive: true, force: true });
   fs.mkdirSync(packageDir, { recursive: true });

--- a/plugins/jieba/node/scripts/prepare-scoped-packages.js
+++ b/plugins/jieba/node/scripts/prepare-scoped-packages.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const packageRoot = path.resolve(__dirname, '..');
+const sourcePrebuildsDir = path.join(packageRoot, 'prebuilds');
+const outputRoot = path.join(packageRoot, 'dist', 'scoped-packages');
+const parentPackage = require(path.join(packageRoot, 'package.json'));
+
+const libraryNameByPlatform = {
+  darwin: 'libopencc-jieba.dylib',
+  linux: 'libopencc-jieba.so',
+  win32: 'opencc-jieba.dll',
+};
+
+function parsePlatformArch(dirname) {
+  const index = dirname.indexOf('-');
+  if (index === -1) {
+    return null;
+  }
+  return {
+    platform: dirname.slice(0, index),
+    arch: dirname.slice(index + 1),
+  };
+}
+
+function copyFile(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function preparePackage(dirname) {
+  const parsed = parsePlatformArch(dirname);
+  if (!parsed) {
+    console.warn(`Skipping unexpected prebuild directory: ${dirname}`);
+    return null;
+  }
+
+  const { platform, arch } = parsed;
+  const libraryName = libraryNameByPlatform[platform];
+  if (!libraryName) {
+    console.warn(`Skipping unsupported platform: ${dirname}`);
+    return null;
+  }
+
+  const sourceLibrary = path.join(sourcePrebuildsDir, dirname, libraryName);
+  if (!fs.existsSync(sourceLibrary)) {
+    console.warn(`Skipping ${dirname}; missing ${libraryName}`);
+    return null;
+  }
+
+  const packageName = `@opencc/opencc-jieba-${dirname}`;
+  const packageDir = path.join(outputRoot, packageName);
+  const relativeLibraryPath = path.join('prebuilds', dirname, libraryName);
+
+  fs.rmSync(packageDir, { recursive: true, force: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+
+  writeJson(path.join(packageDir, 'package.json'), {
+    name: packageName,
+    version: parentPackage.version,
+    description: `${parentPackage.description} (${dirname} binary)`,
+    license: parentPackage.license,
+    author: parentPackage.author,
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/BYVoid/OpenCC.git',
+      directory: 'plugins/jieba/node',
+    },
+    main: 'index.js',
+    os: [platform],
+    cpu: [arch],
+    files: [
+      'index.js',
+      relativeLibraryPath,
+    ],
+  });
+
+  fs.writeFileSync(path.join(packageDir, 'index.js'), [
+    "const path = require('path');",
+    '',
+    `const pluginLibrary = path.join(__dirname, ${JSON.stringify(relativeLibraryPath)});`,
+    '',
+    'module.exports = {',
+    '  pluginDir: path.dirname(pluginLibrary),',
+    '  pluginLibrary,',
+    '};',
+    '',
+  ].join('\n'));
+
+  copyFile(sourceLibrary, path.join(packageDir, relativeLibraryPath));
+  return packageDir;
+}
+
+function main() {
+  if (!fs.existsSync(sourcePrebuildsDir)) {
+    console.error(`Missing prebuilds directory: ${sourcePrebuildsDir}`);
+    process.exit(1);
+  }
+
+  fs.rmSync(outputRoot, { recursive: true, force: true });
+  fs.mkdirSync(outputRoot, { recursive: true });
+
+  const prepared = fs.readdirSync(sourcePrebuildsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => preparePackage(entry.name))
+    .filter(Boolean);
+
+  if (prepared.length === 0) {
+    console.error('No scoped binary packages were prepared.');
+    process.exit(1);
+  }
+
+  console.log('Prepared scoped binary packages:');
+  for (const packageDir of prepared) {
+    console.log(`  ${path.relative(packageRoot, packageDir)}`);
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Try the per-platform scoped npm package layout on the smaller `opencc-jieba` package first. The main `opencc-jieba` package now carries JS and data, while `@opencc/opencc-jieba-*` optional packages carry the native plugin binaries.

If this install and publishing model works well in practice, extend the same split-package approach to the main `opencc` npm package later.