### PR TITLE
Fix `Dict` destructor UB with ABI-conscious vtable ordering

### DIFF
--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -30,7 +30,6 @@ namespace opencc {
  */
 class OPENCC_EXPORT Dict {
 public:
-  virtual ~Dict() = default;
   /**
    * Matches a word exactly and returns the DictEntry or Optional::Null().
    */
@@ -98,5 +97,7 @@ public:
   virtual const std::list<DictPtr>* GetDictGroupItems() const {
     return nullptr;
   }
+
+  virtual ~Dict() = default;
 };
 } // namespace opencc

--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -30,6 +30,7 @@ namespace opencc {
  */
 class OPENCC_EXPORT Dict {
 public:
+  virtual ~Dict() = default;
   /**
    * Matches a word exactly and returns the DictEntry or Optional::Null().
    */


### PR DESCRIPTION
`opencc::Dict` is a polymorphic base type without a virtual destructor, so deleting derived instances through `Dict*` is undefined behavior. This change adds a virtual destructor while placing it at the end of the virtual member declarations to reduce ABI disruption.

- **Base-class lifetime safety**
  - Add a virtual defaulted destructor to `Dict` so polymorphic destruction is defined.

- **ABI impact minimization**
  - Place `virtual ~Dict() = default;` after existing virtual member declarations instead of at the top of the class to avoid unnecessary virtual slot reordering beyond what is required.

```cpp
class OPENCC_EXPORT Dict {
public:
  // ... existing virtual API ...
  virtual const std::list<DictPtr>* GetDictGroupItems() const {
    return nullptr;
  }

  virtual ~Dict() = default;
};
```