### PR TITLE
Add resource provider abstraction

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     hdrs = [
         "//src:ConversionInspection.hpp",
         "//src:Export.hpp",
+        "//src:ResourceProvider.hpp",
         "//src:SimpleConverter.hpp",
         "//src:opencc.h",
     ],

--- a/README.md
+++ b/README.md
@@ -115,6 +115,34 @@ int main() {
 
 [Full example with Bazel](https://github.com/BYVoid/opencc-bazel-example)
 
+When OpenCC is embedded in a server binary or self-contained application, the
+JSON config can stay small while dictionary resources are loaded from explicit
+resource directories:
+
+```c++
+#include <memory>
+#include <vector>
+
+#include "SimpleConverter.hpp"
+
+int main() {
+  auto resources = std::make_shared<opencc::FilesystemResourceProvider>(
+      std::vector<std::string>{
+          "/opt/my-app/opencc",
+          "/opt/my-app/plugins/opencc-jieba",
+          "/usr/share/opencc",
+      });
+  const opencc::SimpleConverter converter("s2t.json", resources);
+  converter.Convert("汉字");
+  return 0;
+}
+```
+
+`FilesystemResourceProvider` searches directories in order. Existing
+`SimpleConverter("s2t.json")` and CLI behavior continue to use the config file
+location, current directory, explicit paths, and installed OpenCC data directory
+as before.
+
 ### C
 
 ```c

--- a/node/node_opencc.gypi
+++ b/node/node_opencc.gypi
@@ -18,6 +18,7 @@
         "../src/MaxMatchSegmentation.cpp",
         "../src/PluginSegmentation.cpp",
         "../src/PrefixMatch.cpp",
+        "../src/ResourceProvider.cpp",
         "../src/Segmentation.cpp",
         "../src/SerializableDict.cpp",
         "../src/SerializedValues.cpp",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "src/PluginSegmentation.hpp",
     "src/PrefixMatch.cpp",
     "src/PrefixMatch.hpp",
+    "src/ResourceProvider.cpp",
+    "src/ResourceProvider.hpp",
     "src/Segmentation.cpp",
     "src/Segmentation.hpp",
     "src/Segments.hpp",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -74,6 +74,24 @@ resolving them at runtime. Relative resource paths are expected to resolve
 within the existing OpenCC data layout rather than a plugin-specific ad hoc
 directory tree.
 
+For dictionary files referenced by OpenCC configs, embedded applications can
+compose a single resource provider from the main application, plugin, and
+system OpenCC data directories:
+
+```c++
+auto resources = std::make_shared<opencc::FilesystemResourceProvider>(
+    std::vector<std::string>{
+        main_app_resource_dir,
+        plugin_resource_dir,
+        system_opencc_data_dir,
+    });
+opencc::SimpleConverter converter("s2twp_jieba.json", resources);
+```
+
+Plugins only need to tell the host which resource directory they ship. The
+OpenCC core resolves dictionary resource names through the provider and does
+not need plugin-specific lookup logic.
+
 ## Segmentation ABI
 
 The current segmentation plugin ABI entry point is:

--- a/scripts/build-cli-windows-zig.sh
+++ b/scripts/build-cli-windows-zig.sh
@@ -79,6 +79,7 @@ sources=(
   src/PluginSegmentation.cpp
   src/PhraseExtract.cpp
   src/PrefixMatch.cpp
+  src/ResourceProvider.cpp
   src/Segmentation.cpp
   src/SerializableDict.cpp
   src/SerializedValues.cpp

--- a/scripts/build-node-windows-zig.sh
+++ b/scripts/build-node-windows-zig.sh
@@ -40,6 +40,7 @@ sources=(
   src/MaxMatchSegmentation.cpp
   src/PluginSegmentation.cpp
   src/PrefixMatch.cpp
+  src/ResourceProvider.cpp
   src/Segmentation.cpp
   src/SerializableDict.cpp
   src/SerializedValues.cpp

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -15,7 +15,10 @@ filegroup(
 
 cc_library(
     name = "opencc_lib",
-    hdrs = ["ConversionInspection.hpp"],
+    hdrs = [
+        "ConversionInspection.hpp",
+        "ResourceProvider.hpp",
+    ],
     deps = [
         ":binary_dict_lib",
         ":common_lib",
@@ -34,6 +37,7 @@ cc_library(
         ":max_match_segmentation_lib",
         ":plugin_segmentation_lib",
         ":phrase_extract_lib",
+        ":resource_provider_lib",
         ":segmentation_lib",
         ":segments_lib",
         ":serializable_dict_lib",
@@ -100,10 +104,20 @@ cc_library(
         ":marisa_dict_lib",
         ":max_match_segmentation_lib",
         ":plugin_segmentation_lib",
+        ":resource_provider_lib",
         ":text_dict_lib",
         ":utf8_util_lib",
         ":win_util_lib",
         "//deps/rapidjson-1.1.0:rapidjson",
+    ],
+)
+
+cc_library(
+    name = "resource_provider_lib",
+    srcs = ["ResourceProvider.cpp"],
+    hdrs = ["ResourceProvider.hpp"],
+    deps = [
+        ":exception_lib",
     ],
 )
 
@@ -117,6 +131,7 @@ cc_test(
         ":config_test_base_lib",
         ":converter_lib",
         ":exception_lib",
+        ":resource_provider_lib",
         ":test_utils_utf8_lib",
         "@googletest//:gtest_main",
     ],
@@ -531,6 +546,7 @@ cc_library(
         ":common_lib",
         ":config_lib",
         ":converter_lib",
+        ":resource_provider_lib",
         ":utf8_util_lib",
         "@bazel_tools//tools/cpp/runfiles",
     ],

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -118,6 +118,7 @@ cc_library(
     hdrs = ["ResourceProvider.hpp"],
     deps = [
         ":exception_lib",
+        ":win_util_lib",
     ],
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(
   PluginSegmentation.hpp
   PhraseExtract.hpp
   PrefixMatch.hpp
+  ResourceProvider.hpp
   Segmentation.hpp
   Segments.hpp
   SerializableDict.hpp
@@ -64,6 +65,7 @@ set(
   PluginSegmentation.cpp
   PhraseExtract.cpp
   PrefixMatch.cpp
+  ResourceProvider.cpp
   SerializableDict.cpp
   SerializedValues.cpp
   SimpleConverter.cpp

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -573,13 +573,14 @@ Config::NewFromFile(const std::string& fileName,
   impl->paths.clear();
   impl->resourceProvider = provider;
   std::string prefixedFileName;
-  try {
-    prefixedFileName = impl->FindConfigFile(fileName);
-  } catch (const FileNotFound&) {
-    if (provider == nullptr) {
-      throw;
+  if (provider != nullptr) {
+    try {
+      prefixedFileName = provider->Resolve(fileName);
+    } catch (const FileNotFound&) {
+      prefixedFileName = impl->FindConfigFile(fileName);
     }
-    prefixedFileName = provider->Resolve(fileName);
+  } else {
+    prefixedFileName = impl->FindConfigFile(fileName);
   }
   if (!isRegularFile(prefixedFileName)) {
     throw FileNotFound(prefixedFileName);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -572,7 +572,15 @@ Config::NewFromFile(const std::string& fileName,
   impl->options = options;
   impl->paths.clear();
   impl->resourceProvider = provider;
-  std::string prefixedFileName = impl->FindConfigFile(fileName);
+  std::string prefixedFileName;
+  try {
+    prefixedFileName = impl->FindConfigFile(fileName);
+  } catch (const FileNotFound&) {
+    if (provider == nullptr) {
+      throw;
+    }
+    prefixedFileName = provider->Resolve(fileName);
+  }
   if (!isRegularFile(prefixedFileName)) {
     throw FileNotFound(prefixedFileName);
   }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -264,6 +264,7 @@ class ConfigInternal {
 public:
   std::vector<std::string> paths;
   std::string configDirectory;
+  std::shared_ptr<ResourceProvider> resourceProvider;
   ConfigLoadOptions options;
 
   const JSONValue& GetProperty(const JSONValue& doc, const char* name) {
@@ -310,61 +311,58 @@ public:
   }
 
   template <typename DICT>
-  DictPtr LoadDictWithPaths(const std::string& cachePrefix,
-                            const std::string& fileName) {
-    std::vector<std::string> candidates;
-    candidates.push_back(fileName);
-    for (const std::string& dirPath : paths) {
-      candidates.push_back(dirPath + '/' + fileName);
+  DictPtr LoadDictWithResourceProvider(const std::string& cachePrefix,
+                                       const std::string& fileName) {
+    if (resourceProvider == nullptr) {
+      throw FileNotFound(fileName);
     }
 
-    for (const std::string& path : candidates) {
-      std::string cacheKey = cachePrefix;
-      cacheKey.push_back('\n');
-      if (!GetFileCacheKey(path, &cacheKey)) {
-        continue;
-      }
-      {
-        std::lock_guard<std::mutex> lock(DictCacheMutex());
-        PruneExpiredDictCache();
-        const auto cached = DictCache().find(cacheKey);
-        if (cached != DictCache().end()) {
-          DictPtr dict = cached->second.lock();
-          if (dict != nullptr) {
-            return dict;
-          }
-        }
-      }
-
-      std::shared_ptr<DICT> dict;
-      if (SerializableDict::TryLoadFromFile<DICT>(path, &dict)) {
-        std::lock_guard<std::mutex> lock(DictCacheMutex());
-        PruneExpiredDictCache();
-        std::weak_ptr<Dict>& cached = DictCache()[cacheKey];
-        DictPtr cachedDict = cached.lock();
-        if (cachedDict == nullptr) {
-          cached = dict;
+    const std::string path = resourceProvider->Resolve(fileName);
+    std::string cacheKey = cachePrefix;
+    cacheKey.push_back('\n');
+    if (!GetFileCacheKey(path, &cacheKey)) {
+      throw FileNotFound(path);
+    }
+    {
+      std::lock_guard<std::mutex> lock(DictCacheMutex());
+      PruneExpiredDictCache();
+      const auto cached = DictCache().find(cacheKey);
+      if (cached != DictCache().end()) {
+        DictPtr dict = cached->second.lock();
+        if (dict != nullptr) {
           return dict;
         }
-        return cachedDict;
       }
     }
-    throw FileNotFound(fileName);
+
+    std::shared_ptr<DICT> dict;
+    if (SerializableDict::TryLoadFromFile<DICT>(path, &dict)) {
+      std::lock_guard<std::mutex> lock(DictCacheMutex());
+      PruneExpiredDictCache();
+      std::weak_ptr<Dict>& cached = DictCache()[cacheKey];
+      DictPtr cachedDict = cached.lock();
+      if (cachedDict == nullptr) {
+        cached = dict;
+        return dict;
+      }
+      return cachedDict;
+    }
+    throw FileNotFound(path);
   }
 
   DictPtr LoadDictFromFile(const std::string& type,
                            const std::string& fileName) {
     if (type == "text") {
-      DictPtr dict = LoadDictWithPaths<TextDict>("text", fileName);
+      DictPtr dict = LoadDictWithResourceProvider<TextDict>("text", fileName);
       return MarisaDict::NewFromDict(*dict.get());
     }
 #ifdef ENABLE_DARTS
     if (type == "ocd") {
-      return LoadDictWithPaths<DartsDict>("ocd", fileName);
+      return LoadDictWithResourceProvider<DartsDict>("ocd", fileName);
     }
 #endif
     if (type == "ocd2") {
-      return LoadDictWithPaths<MarisaDict>("ocd2", fileName);
+      return LoadDictWithResourceProvider<MarisaDict>("ocd2", fileName);
     }
     throw InvalidFormat("Unknown dictionary type: " + type);
     return nullptr;
@@ -533,6 +531,23 @@ bool isRegularFile(const std::string& path) {
 #endif
 }
 
+std::shared_ptr<ResourceProvider>
+NewFilesystemResourceProvider(const std::string& configDirectory,
+                              const std::vector<std::string>& paths) {
+  std::vector<std::string> searchPaths;
+  if (!configDirectory.empty()) {
+    searchPaths.push_back(configDirectory);
+  }
+  searchPaths.push_back(".");
+  for (const std::string& path : paths) {
+    if (!path.empty()) {
+      searchPaths.push_back(path);
+    }
+  }
+  return std::shared_ptr<ResourceProvider>(
+      new FilesystemResourceProvider(searchPaths));
+}
+
 } // namespace
 
 Config::Config() : internal(new ConfigInternal()) {}
@@ -541,6 +556,37 @@ Config::~Config() { delete reinterpret_cast<ConfigInternal*>(internal); }
 
 ConverterPtr Config::NewFromFile(const std::string& fileName) {
   return NewFromFile(fileName, std::vector<std::string>{}, nullptr);
+}
+
+ConverterPtr
+Config::NewFromFile(const std::string& fileName,
+                    std::shared_ptr<ResourceProvider> provider) {
+  return NewFromFile(fileName, provider, ConfigLoadOptions());
+}
+
+ConverterPtr
+Config::NewFromFile(const std::string& fileName,
+                    std::shared_ptr<ResourceProvider> provider,
+                    const ConfigLoadOptions& options) {
+  ConfigInternal* impl = reinterpret_cast<ConfigInternal*>(internal);
+  impl->options = options;
+  impl->paths.clear();
+  impl->resourceProvider = provider;
+  std::string prefixedFileName = impl->FindConfigFile(fileName);
+  if (!isRegularFile(prefixedFileName)) {
+    throw FileNotFound(prefixedFileName);
+  }
+  std::string content = ReadFileUtf8(prefixedFileName);
+
+#if defined(_WIN32) || defined(_WIN64)
+  UTF8Util::ReplaceAll(prefixedFileName, "\\", "/");
+#endif // if defined(_WIN32) || defined(_WIN64)
+  size_t slashPos = prefixedFileName.rfind("/");
+  impl->configDirectory = "";
+  if (slashPos != std::string::npos) {
+    impl->configDirectory = prefixedFileName.substr(0, slashPos) + "/";
+  }
+  return NewFromString(content, provider, options);
 }
 
 ConverterPtr Config::NewFromFile(const std::string& fileName,
@@ -590,7 +636,9 @@ ConverterPtr Config::NewFromFile(const std::string& fileName,
     impl->paths.push_back(configDirectory);
   }
   impl->configDirectory = configDirectory;
-  return NewFromString(content, impl->paths, options);
+  impl->resourceProvider =
+      NewFilesystemResourceProvider(configDirectory, impl->paths);
+  return NewFromString(content, impl->resourceProvider, options);
 }
 
 ConverterPtr Config::NewFromString(const std::string& json,
@@ -614,6 +662,24 @@ ConverterPtr Config::NewFromString(const std::string& json,
 ConverterPtr Config::NewFromString(const std::string& json,
                                    const std::vector<std::string>& paths,
                                    const ConfigLoadOptions& options) {
+  ConfigInternal* impl = reinterpret_cast<ConfigInternal*>(internal);
+  impl->paths = paths;
+  impl->configDirectory = paths.empty() ? "" : paths.front();
+  impl->resourceProvider =
+      NewFilesystemResourceProvider(impl->configDirectory, paths);
+  return NewFromString(json, impl->resourceProvider, options);
+}
+
+ConverterPtr
+Config::NewFromString(const std::string& json,
+                      std::shared_ptr<ResourceProvider> provider) {
+  return NewFromString(json, provider, ConfigLoadOptions());
+}
+
+ConverterPtr
+Config::NewFromString(const std::string& json,
+                      std::shared_ptr<ResourceProvider> provider,
+                      const ConfigLoadOptions& options) {
   rapidjson::Document doc;
 
   doc.ParseInsitu<0>(const_cast<char*>(json.c_str()));
@@ -632,10 +698,7 @@ ConverterPtr Config::NewFromString(const std::string& json,
 
   ConfigInternal* impl = reinterpret_cast<ConfigInternal*>(internal);
   impl->options = options;
-  impl->paths = paths;
-  if (impl->configDirectory.empty()) {
-    impl->configDirectory = paths.empty() ? "" : paths.front();
-  }
+  impl->resourceProvider = provider;
 
   // Required: segmentation
   SegmentationPtr segmentation =

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "Common.hpp"
+#include "ResourceProvider.hpp"
 
 namespace opencc {
 
@@ -48,7 +49,21 @@ public:
                              const std::vector<std::string>& paths,
                              const ConfigLoadOptions& options);
 
+  ConverterPtr NewFromString(const std::string& json,
+                             std::shared_ptr<ResourceProvider> provider);
+
+  ConverterPtr NewFromString(const std::string& json,
+                             std::shared_ptr<ResourceProvider> provider,
+                             const ConfigLoadOptions& options);
+
   ConverterPtr NewFromFile(const std::string& fileName);
+
+  ConverterPtr NewFromFile(const std::string& fileName,
+                           std::shared_ptr<ResourceProvider> provider);
+
+  ConverterPtr NewFromFile(const std::string& fileName,
+                           std::shared_ptr<ResourceProvider> provider,
+                           const ConfigLoadOptions& options);
 
   ConverterPtr NewFromFile(const std::string& fileName,
                            const std::vector<std::string>& paths,

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -183,6 +183,34 @@ TEST_F(ConfigTest, ExplicitProviderFindsConfigNameAndResources) {
   fs::remove_all(tempDir);
 }
 
+TEST_F(ConfigTest, ExplicitProviderConfigOverridesInstalledOrCwdConfigName) {
+  const fs::path tempDir = MakeTempDir("opencc-provider-config-override-test");
+  const fs::path cwdDir = tempDir / "cwd";
+  const fs::path resourceDir = tempDir / "resources";
+  fs::create_directories(cwdDir);
+  fs::create_directories(resourceDir);
+  WriteFile(cwdDir / "config.json", SingleDictConfig("dict_a.txt"));
+  WriteFile(resourceDir / "config.json", SingleDictConfig("dict_b.txt"));
+  WriteFile(resourceDir / "dict_a.txt", utf8("鼠标\t甲\n"));
+  WriteFile(resourceDir / "dict_b.txt", utf8("鼠标\t乙\n"));
+
+  const fs::path originalCwd = fs::current_path();
+  try {
+    fs::current_path(cwdDir);
+    std::shared_ptr<ResourceProvider> provider(
+        new FilesystemResourceProvider({PathString(resourceDir)}));
+    const ConverterPtr tempConverter =
+        config.NewFromFile("config.json", provider);
+    EXPECT_EQ(utf8("乙"), tempConverter->Convert(utf8("鼠标")));
+    fs::current_path(originalCwd);
+  } catch (...) {
+    fs::current_path(originalCwd);
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
 TEST_F(ConfigTest, RelativeParentDictionaryPathStillWorks) {
   const fs::path tempDir = MakeTempDir("opencc-relative-parent-resource-test");
   const fs::path configDir = tempDir / "config";

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -183,6 +183,27 @@ TEST_F(ConfigTest, ExplicitProviderFindsConfigNameAndResources) {
   fs::remove_all(tempDir);
 }
 
+TEST_F(ConfigTest, RelativeParentDictionaryPathStillWorks) {
+  const fs::path tempDir = MakeTempDir("opencc-relative-parent-resource-test");
+  const fs::path configDir = tempDir / "config";
+  const fs::path dictionaryDir = tempDir / "dictionary";
+  fs::create_directories(configDir);
+  fs::create_directories(dictionaryDir);
+  WriteFile(configDir / "config.json",
+            SingleDictConfig("../dictionary/dict.txt"));
+  WriteFile(dictionaryDir / "dict.txt", utf8("鼠标\t滑鼠\n"));
+
+  try {
+    const ConverterPtr tempConverter =
+        config.NewFromFile(PathString(configDir / "config.json"));
+    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
 TEST_F(ConfigTest, MultipleSearchPathsUseFirstMatch) {
   const fs::path tempDir = MakeTempDir("opencc-provider-order-test");
   const fs::path configDir = tempDir / "config";

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -163,6 +163,26 @@ TEST_F(ConfigTest, ExplicitProviderFindsResources) {
   fs::remove_all(tempDir);
 }
 
+TEST_F(ConfigTest, ExplicitProviderFindsConfigNameAndResources) {
+  const fs::path tempDir = MakeTempDir("opencc-provider-config-test");
+  const fs::path resourceDir = tempDir / "resources";
+  fs::create_directories(resourceDir);
+  WriteFile(resourceDir / "provider_config.json", SingleDictConfig("dict.txt"));
+  WriteFile(resourceDir / "dict.txt", utf8("鼠标\t滑鼠\n"));
+
+  try {
+    std::shared_ptr<ResourceProvider> provider(
+        new FilesystemResourceProvider({PathString(resourceDir)}));
+    const ConverterPtr tempConverter =
+        config.NewFromFile("provider_config.json", provider);
+    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
 TEST_F(ConfigTest, MultipleSearchPathsUseFirstMatch) {
   const fs::path tempDir = MakeTempDir("opencc-provider-order-test");
   const fs::path configDir = tempDir / "config";

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -18,18 +18,63 @@
 
 #include <fstream>
 #include <filesystem>
+#include <memory>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "Config.hpp"
 #include "ConfigTestBase.hpp"
 #include "Converter.hpp"
 #include "Exception.hpp"
+#include "ResourceProvider.hpp"
 #include "TestUtilsUTF8.hpp"
 
 namespace opencc {
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string PathString(const fs::path& path) { return path.u8string(); }
+
+fs::path MakeTempDir(const std::string& name) {
+#if defined(_WIN32) || defined(_WIN64)
+  const auto suffix = std::to_string(GetCurrentProcessId());
+#else
+  const auto suffix = std::to_string(getpid());
+#endif
+  fs::path dir = fs::temp_directory_path() / (name + "-" + suffix);
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  return dir;
+}
+
+void WriteFile(const fs::path& path, const std::string& content) {
+  std::ofstream ofs(path, std::ios::binary);
+  ofs << content;
+}
+
+std::string SingleDictConfig(const std::string& dictFile) {
+  return std::string("{\n"
+                     "  \"name\": \"Resource Provider Test\",\n"
+                     "  \"segmentation\": {\n"
+                     "    \"type\": \"mmseg\",\n"
+                     "    \"dict\": {\"type\": \"text\", \"file\": \"") +
+         dictFile +
+         "\"}\n"
+         "  },\n"
+         "  \"conversion_chain\": [{\n"
+         "    \"dict\": {\"type\": \"text\", \"file\": \"" +
+         dictFile +
+         "\"}\n"
+         "  }]\n"
+         "}\n";
+}
+
+} // namespace
 
 class ConfigTest : public ConfigTestBase {
 protected:
@@ -74,6 +119,120 @@ TEST_F(ConfigTest, NewFromStringWitoutTrailingSlash) {
                       (std::istreambuf_iterator<char>()));
 
   const ConverterPtr _ = config.NewFromString(content, CONFIG_TEST_DIR_PATH);
+}
+
+TEST_F(ConfigTest, DefaultConfigPathFindsAdjacentResources) {
+  const fs::path tempDir = MakeTempDir("opencc-adjacent-resource-test");
+  fs::copy_file(fs::u8path(CONFIG_TEST_DIR_PATH) / "config_test.json",
+                tempDir / "config_test.json");
+  fs::copy_file(fs::u8path(CONFIG_TEST_DIR_PATH) / "config_test_phrases.txt",
+                tempDir / "config_test_phrases.txt");
+  fs::copy_file(fs::u8path(CONFIG_TEST_DIR_PATH) / "config_test_characters.txt",
+                tempDir / "config_test_characters.txt");
+
+  try {
+    const ConverterPtr tempConverter =
+        config.NewFromFile(PathString(tempDir / "config_test.json"));
+    EXPECT_EQ(expected, tempConverter->Convert(input));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
+TEST_F(ConfigTest, ExplicitProviderFindsResources) {
+  const fs::path tempDir = MakeTempDir("opencc-explicit-provider-test");
+  const fs::path configDir = tempDir / "config";
+  const fs::path resourceDir = tempDir / "resources";
+  fs::create_directories(configDir);
+  fs::create_directories(resourceDir);
+  WriteFile(configDir / "config.json", SingleDictConfig("dict.txt"));
+  WriteFile(resourceDir / "dict.txt", utf8("鼠标\t滑鼠\n"));
+
+  try {
+    std::shared_ptr<ResourceProvider> provider(
+        new FilesystemResourceProvider({PathString(resourceDir)}));
+    const ConverterPtr tempConverter =
+        config.NewFromFile(PathString(configDir / "config.json"), provider);
+    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
+TEST_F(ConfigTest, MultipleSearchPathsUseFirstMatch) {
+  const fs::path tempDir = MakeTempDir("opencc-provider-order-test");
+  const fs::path configDir = tempDir / "config";
+  const fs::path firstDir = tempDir / "first";
+  const fs::path secondDir = tempDir / "second";
+  fs::create_directories(configDir);
+  fs::create_directories(firstDir);
+  fs::create_directories(secondDir);
+  WriteFile(configDir / "config.json", SingleDictConfig("dict.txt"));
+  WriteFile(firstDir / "dict.txt", utf8("鼠标\t第一\n"));
+  WriteFile(secondDir / "dict.txt", utf8("鼠标\t第二\n"));
+
+  try {
+    std::shared_ptr<ResourceProvider> provider(
+        new FilesystemResourceProvider(
+            {PathString(firstDir), PathString(secondDir)}));
+    const ConverterPtr tempConverter =
+        config.NewFromFile(PathString(configDir / "config.json"), provider);
+    EXPECT_EQ(utf8("第一"), tempConverter->Convert(utf8("鼠标")));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
+}
+
+TEST_F(ConfigTest, MissingResourceListsSearchedPaths) {
+  const fs::path tempDir = MakeTempDir("opencc-provider-missing-test");
+  const fs::path firstDir = tempDir / "first";
+  const fs::path secondDir = tempDir / "second";
+  fs::create_directories(firstDir);
+  fs::create_directories(secondDir);
+
+  try {
+    FilesystemResourceProvider provider(
+        {PathString(firstDir), PathString(secondDir)});
+    provider.Resolve("missing.ocd2");
+    FAIL() << "Expected FileNotFound";
+  } catch (const FileNotFound& e) {
+    const std::string message = e.what();
+    EXPECT_NE(std::string::npos, message.find("missing.ocd2"));
+    EXPECT_NE(std::string::npos, message.find(PathString(firstDir)));
+    EXPECT_NE(std::string::npos, message.find(PathString(secondDir)));
+  }
+  fs::remove_all(tempDir);
+}
+
+TEST_F(ConfigTest, PluginLikeResourcePathSupplementsMainPath) {
+  const fs::path tempDir = MakeTempDir("opencc-plugin-resource-test");
+  const fs::path configDir = tempDir / "config";
+  const fs::path mainDir = tempDir / "main";
+  const fs::path pluginDir = tempDir / "plugin";
+  fs::create_directories(configDir);
+  fs::create_directories(mainDir);
+  fs::create_directories(pluginDir);
+  WriteFile(configDir / "config.json", SingleDictConfig("plugin_dict.txt"));
+  WriteFile(pluginDir / "plugin_dict.txt", utf8("服务器\t伺服器\n"));
+
+  try {
+    std::shared_ptr<ResourceProvider> provider(
+        new FilesystemResourceProvider(
+            {PathString(mainDir), PathString(pluginDir)}));
+    const ConverterPtr tempConverter =
+        config.NewFromFile(PathString(configDir / "config.json"), provider);
+    EXPECT_EQ(utf8("伺服器"), tempConverter->Convert(utf8("服务器")));
+  } catch (...) {
+    fs::remove_all(tempDir);
+    throw;
+  }
+  fs::remove_all(tempDir);
 }
 
 #if defined(_MSC_VER)

--- a/src/README.md
+++ b/src/README.md
@@ -24,11 +24,16 @@ The data files that drive this pipeline live outside this directory:
   - Finds and parses JSON configuration files.
   - Builds segmenters, dictionaries, dictionary groups, conversions, and
     converters.
-  - Maintains dictionary search paths from explicit `--path` values,
-    `argv[0]`, installed package data paths, and Windows portable-layout
-    locations.
+  - Resolves dictionary/resource files through `ResourceProvider`.
+  - Keeps config loading separate from dictionary resource lookup.
   - Uses UTF-16-capable file checks on Windows for internal config and
     resource paths.
+- `ResourceProvider.hpp`, `ResourceProvider.cpp`
+  - Provides `ResourceProvider` and `FilesystemResourceProvider`.
+  - `FilesystemResourceProvider` searches configured resource directories in
+    order and returns a resolved path for lower-level dictionary loaders.
+  - Embedded hosts can combine application, plugin, and system OpenCC data
+    directories without changing config JSON.
 
 ### Segmentation
 
@@ -103,7 +108,8 @@ behavior because phrase priority and multi-stage conversion order matter.
 
 - `SimpleConverter.hpp`, `SimpleConverter.cpp`
   - High-level C++ wrapper around `Config` and `Converter`.
-  - Accepts a config name/path and optional search paths.
+  - Accepts a config name/path, optional search paths, or an explicit
+    `ResourceProvider`.
   - Throws C++ exceptions on failures.
 
 ### C API

--- a/src/ResourceProvider.cpp
+++ b/src/ResourceProvider.cpp
@@ -61,21 +61,6 @@ bool IsRegularFileUtf8(const std::string& path) {
 #endif
 }
 
-bool HasParentReference(const std::string& path) {
-  size_t start = 0;
-  while (start <= path.size()) {
-    size_t end = start;
-    while (end < path.size() && !IsSeparator(path[end])) {
-      ++end;
-    }
-    if (path.substr(start, end - start) == "..") {
-      return true;
-    }
-    start = end + 1;
-  }
-  return false;
-}
-
 std::string JoinPath(const std::string& root, const std::string& resource) {
   if (root.empty()) {
     return resource;
@@ -103,10 +88,6 @@ FilesystemResourceProvider::Resolve(std::string_view resourceName) const {
     if (IsRegularFileUtf8(resourcePath)) {
       return resourcePath;
     }
-    throw FileNotFound(resourcePath);
-  }
-
-  if (HasParentReference(resourcePath)) {
     throw FileNotFound(resourcePath);
   }
 

--- a/src/ResourceProvider.cpp
+++ b/src/ResourceProvider.cpp
@@ -1,0 +1,130 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ResourceProvider.hpp"
+
+#include <sstream>
+#include <sys/stat.h>
+
+#if defined(_WIN32) || defined(_WIN64)
+#include "WinUtil.hpp"
+#endif
+
+#include "Exception.hpp"
+
+namespace opencc {
+namespace {
+
+bool IsSeparator(char ch) { return ch == '/' || ch == '\\'; }
+
+bool IsAbsolutePath(const std::string& path) {
+  if (path.empty()) {
+    return false;
+  }
+  if (IsSeparator(path[0])) {
+    return true;
+  }
+#if defined(_WIN32) || defined(_WIN64)
+  return path.size() >= 3 && path[1] == ':' && IsSeparator(path[2]);
+#else
+  return false;
+#endif
+}
+
+bool IsRegularFileUtf8(const std::string& path) {
+#if defined(_WIN32) || defined(_WIN64)
+  const DWORD attributes =
+      GetFileAttributesW(internal::WideFromUtf8(path).c_str());
+  return attributes != INVALID_FILE_ATTRIBUTES &&
+         (attributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+#else
+  struct stat info;
+  if (stat(path.c_str(), &info) != 0) {
+    return false;
+  }
+  return (info.st_mode & S_IFMT) == S_IFREG;
+#endif
+}
+
+bool HasParentReference(const std::string& path) {
+  size_t start = 0;
+  while (start <= path.size()) {
+    size_t end = start;
+    while (end < path.size() && !IsSeparator(path[end])) {
+      ++end;
+    }
+    if (path.substr(start, end - start) == "..") {
+      return true;
+    }
+    start = end + 1;
+  }
+  return false;
+}
+
+std::string JoinPath(const std::string& root, const std::string& resource) {
+  if (root.empty()) {
+    return resource;
+  }
+  if (IsSeparator(root.back())) {
+    return root + resource;
+  }
+  return root + "/" + resource;
+}
+
+} // namespace
+
+FilesystemResourceProvider::FilesystemResourceProvider(
+    std::vector<std::string> searchPaths_)
+    : searchPaths(std::move(searchPaths_)) {}
+
+std::string
+FilesystemResourceProvider::Resolve(std::string_view resourceName) const {
+  const std::string resourcePath(resourceName);
+  if (resourcePath.empty()) {
+    throw FileNotFound(resourcePath);
+  }
+
+  if (IsAbsolutePath(resourcePath)) {
+    if (IsRegularFileUtf8(resourcePath)) {
+      return resourcePath;
+    }
+    throw FileNotFound(resourcePath);
+  }
+
+  if (HasParentReference(resourcePath)) {
+    throw FileNotFound(resourcePath);
+  }
+
+  std::ostringstream searched;
+  for (size_t i = 0; i < searchPaths.size(); i++) {
+    const std::string& root = searchPaths[i];
+    if (i != 0) {
+      searched << ", ";
+    }
+    searched << root;
+
+    const std::string candidate = JoinPath(root, resourcePath);
+    if (IsRegularFileUtf8(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw FileNotFound(resourcePath + " (searched: " + searched.str() + ")");
+}
+
+} // namespace opencc

--- a/src/ResourceProvider.hpp
+++ b/src/ResourceProvider.hpp
@@ -1,0 +1,46 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2010-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Export.hpp"
+
+namespace opencc {
+
+class OPENCC_EXPORT ResourceProvider {
+public:
+  virtual ~ResourceProvider() = default;
+
+  virtual std::string Resolve(std::string_view resourceName) const = 0;
+};
+
+class OPENCC_EXPORT FilesystemResourceProvider : public ResourceProvider {
+public:
+  explicit FilesystemResourceProvider(std::vector<std::string> searchPaths);
+
+  std::string Resolve(std::string_view resourceName) const override;
+
+private:
+  std::vector<std::string> searchPaths;
+};
+
+} // namespace opencc

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -63,6 +63,17 @@ struct InternalData {
       throw std::runtime_error(ex.what());
     }
   }
+
+  static InternalData* NewInternalData(
+      const std::string& configFileName,
+      const std::shared_ptr<ResourceProvider>& provider) {
+    try {
+      Config config;
+      return new InternalData(config.NewFromFile(configFileName, provider));
+    } catch (Exception& ex) {
+      throw std::runtime_error(ex.what());
+    }
+  }
 };
 
 } // namespace
@@ -79,6 +90,10 @@ SimpleConverter::SimpleConverter(const std::string& configFileName,
                                  const char* argv0)
     : internalData(
           InternalData::NewInternalData(configFileName, paths, argv0)) {}
+
+SimpleConverter::SimpleConverter(const std::string& configFileName,
+                                 std::shared_ptr<ResourceProvider> provider)
+    : internalData(InternalData::NewInternalData(configFileName, provider)) {}
 
 SimpleConverter::~SimpleConverter() { delete (InternalData*)internalData; }
 

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -17,6 +17,7 @@
  */
 
 #include "Export.hpp"
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -24,6 +24,7 @@
 #define __OPENCC_SIMPLECONVERTER_HPP_
 
 #include "ConversionInspection.hpp"
+#include "ResourceProvider.hpp"
 
 /**
  * @defgroup opencc_simple_api OpenCC C++ Simple API
@@ -63,6 +64,15 @@ public:
    */
   SimpleConverter(const std::string& configFileName,
                   const std::vector<std::string>& paths, const char* argv0);
+
+  /**
+   * Constructor of SimpleConverter
+   * @param configFileName File name of configuration.
+   * @param provider Provider used to locate dictionary/resource files
+   * referenced by the configuration.
+   */
+  SimpleConverter(const std::string& configFileName,
+                  std::shared_ptr<ResourceProvider> provider);
 
   ~SimpleConverter();
 


### PR DESCRIPTION
Decouple dictionary/resource lookup from config file loading by introducing ResourceProvider and FilesystemResourceProvider. Config files keep their existing loading behavior, while dictionary files referenced by JSON configs are resolved through the provider before being passed to existing file-based dictionary loaders.

The default file-based config path now builds a filesystem provider that prioritizes the config directory, then keeps existing current-directory, explicit-path, and installed-data-directory fallbacks. Explicit providers let embedded/server/plugin hosts compose resource directories without changing config JSON.

Add Config and SimpleConverter provider overloads, update Bazel/CMake exports, cover provider lookup behavior in tests, and document embedded and plugin resource-directory usage.

Compatibility:
- Existing SimpleConverter("s2t.json"), C API, and CLI behavior are preserved.
- No existing public virtual class is modified.
- A new exported ResourceProvider interface is added.