### PR TITLE
Reformat config JSON and align s2twp conversion chain

### DIFF
--- a/data/config/hk2s.json
+++ b/data/config/hk2s.json
@@ -2,36 +2,31 @@
   "name": "Traditional Chinese (Hong Kong variant) to Simplified Chinese",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "TSPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "TSPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariantsRev.ocd2"
-      }] 
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "HKVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "HKVariantsRev.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TSPhrases.ocd2" },
+          {
+            "type": "ocd2",
+            "file": "TSCharactersExt.ocd2",
+            "may_output_tofu": true
+          },
+          { "type": "ocd2", "file": "TSCharacters.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TSPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TSCharactersExt.ocd2",
-        "may_output_tofu": true
-      }, {
-        "type": "ocd2",
-        "file": "TSCharacters.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/hk2t.json
+++ b/data/config/hk2t.json
@@ -2,21 +2,17 @@
   "name": "Traditional Chinese (Hong Kong variant) to Traditional Chinese (OpenCC Standard)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "HKVariantsRevPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "HKVariantsRevPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariantsRev.ocd2"
-      }] 
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "HKVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "HKVariantsRev.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/jp2t.json
+++ b/data/config/jp2t.json
@@ -2,24 +2,18 @@
   "name": "New Japanese Kanji (Shinjitai) to Traditional Chinese Characters (Kyūjitai)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "JPShinjitaiPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "JPShinjitaiPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "JPShinjitaiPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "JPShinjitaiCharacters.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "JPVariantsRev.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "JPShinjitaiPhrases.ocd2" },
+          { "type": "ocd2", "file": "JPShinjitaiCharacters.ocd2" },
+          { "type": "ocd2", "file": "JPVariantsRev.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/opencc_config.schema.json
+++ b/data/config/opencc_config.schema.json
@@ -3,185 +3,97 @@
   "id": "https://opencc.byvoid.com/schema/opencc_config.schema.json",
   "title": "OpenCC configuration",
   "type": "object",
-  "required": [
-    "segmentation",
-    "conversion_chain"
-  ],
+  "required": ["segmentation", "conversion_chain"],
   "additionalProperties": false,
   "properties": {
-    "name": {
-      "type": "string"
-    },
-    "segmentation": {
-      "$ref": "#/definitions/segmentation"
-    },
+    "name": { "type": "string" },
+    "segmentation": { "$ref": "#/definitions/segmentation" },
     "conversion_chain": {
       "type": "array",
       "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/conversion"
-      }
+      "items": { "$ref": "#/definitions/conversion" }
     }
   },
   "definitions": {
     "segmentation": {
       "anyOf": [
-        {
-          "$ref": "#/definitions/mmseg_segmentation"
-        },
-        {
-          "$ref": "#/definitions/plugin_segmentation"
-        }
+        { "$ref": "#/definitions/mmseg_segmentation" },
+        { "$ref": "#/definitions/plugin_segmentation" }
       ]
     },
     "mmseg_segmentation": {
       "type": "object",
-      "required": [
-        "type",
-        "dict"
-      ],
+      "required": ["type", "dict"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "enum": [
-            "mmseg"
-          ]
-        },
-        "dict": {
-          "$ref": "#/definitions/dict"
-        }
+        "type": { "enum": ["mmseg"] },
+        "dict": { "$ref": "#/definitions/dict" }
       }
     },
     "plugin_segmentation": {
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "not": {
-        "properties": {
-          "type": {
-            "enum": [
-              "mmseg"
-            ]
-          }
-        },
-        "required": [
-          "type"
-        ]
+        "properties": { "type": { "enum": ["mmseg"] } },
+        "required": ["type"]
       },
       "properties": {
-        "type": {
-          "type": "string",
-          "minLength": 1
-        },
+        "type": { "type": "string", "minLength": 1 },
         "resources": {
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "additionalProperties": { "type": "string" }
         }
       },
-      "additionalProperties": {
-        "type": "string"
-      }
+      "additionalProperties": { "type": "string" }
     },
     "conversion": {
       "type": "object",
-      "required": [
-        "dict"
-      ],
+      "required": ["dict"],
       "additionalProperties": false,
-      "properties": {
-        "dict": {
-          "$ref": "#/definitions/dict"
-        }
-      }
+      "properties": { "dict": { "$ref": "#/definitions/dict" } }
     },
     "dict": {
       "anyOf": [
-        {
-          "$ref": "#/definitions/file_dict"
-        },
-        {
-          "$ref": "#/definitions/inline_dict"
-        },
-        {
-          "$ref": "#/definitions/group_dict"
-        }
+        { "$ref": "#/definitions/file_dict" },
+        { "$ref": "#/definitions/inline_dict" },
+        { "$ref": "#/definitions/group_dict" }
       ]
     },
     "file_dict": {
       "type": "object",
-      "required": [
-        "type",
-        "file"
-      ],
+      "required": ["type", "file"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "enum": [
-            "text",
-            "ocd",
-            "ocd2"
-          ]
-        },
-        "file": {
-          "type": "string",
-          "minLength": 1
-        },
-        "may_output_tofu": {
-          "type": "boolean"
-        }
+        "type": { "enum": ["text", "ocd", "ocd2"] },
+        "file": { "type": "string", "minLength": 1 },
+        "may_output_tofu": { "type": "boolean" }
       }
     },
     "inline_dict": {
       "type": "object",
-      "required": [
-        "type",
-        "entries"
-      ],
+      "required": ["type", "entries"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "enum": [
-            "inline"
-          ]
-        },
+        "type": { "enum": ["inline"] },
         "entries": {
           "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
+          "patternProperties": { ".+": { "type": "string", "minLength": 1 } },
           "additionalProperties": false
         }
       }
     },
     "group_dict": {
       "type": "object",
-      "required": [
-        "type",
-        "dicts"
-      ],
+      "required": ["type", "dicts"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "enum": [
-            "group"
-          ]
-        },
+        "type": { "enum": ["group"] },
         "dicts": {
           "type": "array",
           "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/dict"
-          }
+          "items": { "$ref": "#/definitions/dict" }
         },
-        "may_output_tofu": {
-          "type": "boolean"
-        }
+        "may_output_tofu": { "type": "boolean" }
       }
     }
   }

--- a/data/config/s2hk.json
+++ b/data/config/s2hk.json
@@ -2,32 +2,26 @@
   "name": "Simplified Chinese to Traditional Chinese (Hong Kong variant)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "STPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "STPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "HKVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "HKVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/s2t.json
+++ b/data/config/s2t.json
@@ -2,21 +2,17 @@
   "name": "Simplified Chinese to Traditional Chinese (OpenCC Standard)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "STPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "STPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/s2tw.json
+++ b/data/config/s2tw.json
@@ -2,32 +2,26 @@
   "name": "Simplified Chinese to Traditional Chinese (Taiwan Standard)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "STPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "STPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/s2twp.json
+++ b/data/config/s2twp.json
@@ -2,37 +2,27 @@
   "name": "Simplified Chinese to Traditional Chinese (Taiwan Standard, with Taiwan Phrases)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "STPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "STPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "ocd2",
-      "file": "TWPhrases.ocd2"
-    }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/t2hk.json
+++ b/data/config/t2hk.json
@@ -4,25 +4,21 @@
     "type": "mmseg",
     "dict": {
       "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariants.ocd2"
-      }]
+      "dicts": [
+        { "type": "ocd2", "file": "HKVariantsPhrases.ocd2" },
+        { "type": "ocd2", "file": "HKVariants.ocd2" }
+      ]
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariants.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "HKVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "HKVariants.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/t2jp.json
+++ b/data/config/t2jp.json
@@ -2,15 +2,9 @@
   "name": "Traditional Chinese Characters (Kyūjitai) to New Japanese Kanji (Shinjitai)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "JPVariants.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "JPVariants.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "ocd2",
-      "file": "JPVariants.ocd2"
-    }
-  }]
+  "conversion_chain": [
+    { "dict": { "type": "ocd2", "file": "JPVariants.ocd2" } }
+  ]
 }

--- a/data/config/t2s.json
+++ b/data/config/t2s.json
@@ -2,25 +2,22 @@
   "name": "Traditional Chinese (OpenCC Standard) to Simplified Chinese",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "TSPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "TSPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TSPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TSCharactersExt.ocd2",
-        "may_output_tofu": true
-      }, {
-        "type": "ocd2",
-        "file": "TSCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TSPhrases.ocd2" },
+          {
+            "type": "ocd2",
+            "file": "TSCharactersExt.ocd2",
+            "may_output_tofu": true
+          },
+          { "type": "ocd2", "file": "TSCharacters.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/t2tw.json
+++ b/data/config/t2tw.json
@@ -4,25 +4,21 @@
     "type": "mmseg",
     "dict": {
       "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
+      "dicts": [
+        { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+        { "type": "ocd2", "file": "TWVariants.ocd2" }
+      ]
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariants.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/data/config/tw2s.json
+++ b/data/config/tw2s.json
@@ -2,36 +2,31 @@
   "name": "Traditional Chinese (Taiwan Standard) to Simplified Chinese",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "TSPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "TSPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRev.ocd2"
-      }] 
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRev.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TSPhrases.ocd2" },
+          {
+            "type": "ocd2",
+            "file": "TSCharactersExt.ocd2",
+            "may_output_tofu": true
+          },
+          { "type": "ocd2", "file": "TSCharacters.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TSPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TSCharactersExt.ocd2",
-        "may_output_tofu": true
-      }, {
-        "type": "ocd2",
-        "file": "TSCharacters.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/tw2sp.json
+++ b/data/config/tw2sp.json
@@ -2,39 +2,32 @@
   "name": "Traditional Chinese (Taiwan Standard) to Simplified Chinese (Mainland China Phrases)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "TSPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "TSPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWPhrasesRev.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRev.ocd2"
-      }] 
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWPhrasesRev.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRev.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TSPhrases.ocd2" },
+          {
+            "type": "ocd2",
+            "file": "TSCharactersExt.ocd2",
+            "may_output_tofu": true
+          },
+          { "type": "ocd2", "file": "TSCharacters.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TSPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TSCharactersExt.ocd2",
-        "may_output_tofu": true
-      }, {
-        "type": "ocd2",
-        "file": "TSCharacters.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/data/config/tw2t.json
+++ b/data/config/tw2t.json
@@ -2,21 +2,17 @@
   "name": "Traditional Chinese (Taiwan Standard) to Traditional Chinese (OpenCC Standard)",
   "segmentation": {
     "type": "mmseg",
-    "dict": {
-      "type": "ocd2",
-      "file": "TWVariantsRevPhrases.ocd2"
-    }
+    "dict": { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRev.ocd2"
-      }] 
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRev.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/plugins/jieba/data/config/s2hk_jieba.json
+++ b/plugins/jieba/data/config/s2hk_jieba.json
@@ -7,27 +7,24 @@
       "model_path": "jieba_dict/hmm_model.utf8"
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "HKVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "HKVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "HKVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "HKVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/plugins/jieba/data/config/s2t_jieba.json
+++ b/plugins/jieba/data/config/s2t_jieba.json
@@ -7,16 +7,15 @@
       "model_path": "jieba_dict/hmm_model.utf8"
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
     }
-  }]
+  ]
 }

--- a/plugins/jieba/data/config/s2tw_jieba.json
+++ b/plugins/jieba/data/config/s2tw_jieba.json
@@ -7,27 +7,24 @@
       "model_path": "jieba_dict/hmm_model.utf8"
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/plugins/jieba/data/config/s2twp_jieba.json
+++ b/plugins/jieba/data/config/s2twp_jieba.json
@@ -7,32 +7,25 @@
       "model_path": "jieba_dict/hmm_model.utf8"
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "STPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "STCharacters.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "STPhrases.ocd2" },
+          { "type": "ocd2", "file": "STCharacters.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariants.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "ocd2",
-      "file": "TWPhrases.ocd2"
-    }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWVariantsPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariants.ocd2"
-      }]
-    }
-  }]
+  ]
 }

--- a/plugins/jieba/data/config/tw2sp_jieba.json
+++ b/plugins/jieba/data/config/tw2sp_jieba.json
@@ -7,34 +7,30 @@
       "model_path": "jieba_dict/hmm_model.utf8"
     }
   },
-  "conversion_chain": [{
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TWPhrasesRev.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRevPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TWVariantsRev.ocd2"
-      }]
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TWPhrasesRev.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" },
+          { "type": "ocd2", "file": "TWVariantsRev.ocd2" }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          { "type": "ocd2", "file": "TSPhrases.ocd2" },
+          {
+            "type": "ocd2",
+            "file": "TSCharactersExt.ocd2",
+            "may_output_tofu": true
+          },
+          { "type": "ocd2", "file": "TSCharacters.ocd2" }
+        ]
+      }
     }
-  }, {
-    "dict": {
-      "type": "group",
-      "dicts": [{
-        "type": "ocd2",
-        "file": "TSPhrases.ocd2"
-      }, {
-        "type": "ocd2",
-        "file": "TSCharactersExt.ocd2",
-        "may_output_tofu": true
-      }, {
-        "type": "ocd2",
-        "file": "TSCharacters.ocd2"
-      }]
-    }
-  }]
+  ]
 }


### PR DESCRIPTION
Format all data/config JSON files in a more readable compact style.

Change s2twp so TWPhrases participates in the same grouped conversion stage as TWVariantsPhrases and TWVariants. This means a TWPhrases match is treated as the final phrase conversion for that span instead of continuing through the later Taiwan variant stage, making the forward chain symmetric with the reverse tw2sp chain.

Verified with: bazel test //data/config:config_dict_validation_test; bazel test //test:command_line_converter_test.