### PR TITLE
Support JSONC with comments and trailing commas in testcases.json across all test suites

### DIFF
--- a/data/config/ConfigDictValidationTest.cpp
+++ b/data/config/ConfigDictValidationTest.cpp
@@ -88,7 +88,8 @@ protected:
 TEST_F(ConfigDictValidationTest, ConvertExpectedOutputs) {
   const std::string json = ReadFile(testcasesPath_);
   rapidjson::Document doc;
-  doc.Parse(json.c_str());
+  doc.Parse<rapidjson::kParseCommentsFlag |
+            rapidjson::kParseTrailingCommasFlag>(json.c_str());
   ASSERT_FALSE(doc.HasParseError());
   ASSERT_TRUE(doc.IsObject());
   ASSERT_TRUE(doc.HasMember("cases"));

--- a/node/opencc.js
+++ b/node/opencc.js
@@ -272,8 +272,6 @@ function parseJSON(str) {
 OpenCC.OpenCC = OpenCC;
 OpenCC._parseJSON = parseJSON;
 
-module.exports = OpenCC;
-
 /**
  * The version of OpenCC library.
  *

--- a/node/opencc.js
+++ b/node/opencc.js
@@ -264,12 +264,15 @@ const OpenCC = module.exports = function (config, options) {
 };
 
 function parseJSON(str) {
-  const cleanStr = str.replace(/"(?:[^"\\]|\\.)*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+  const cleanStr = str.replace(/"(?:[^"\\]|\\.)*"|(\/\/.*|\/\*[\s\S]*?\*\/)|(,\s*(?=[\]}]))/g, (m, g1, g2) => (g1 || g2) ? "" : m);
   return JSON.parse(cleanStr);
 }
 
 // This is to support both CommonJS and ES module.
 OpenCC.OpenCC = OpenCC;
+OpenCC._parseJSON = parseJSON;
+
+module.exports = OpenCC;
 
 /**
  * The version of OpenCC library.

--- a/node/opencc.js
+++ b/node/opencc.js
@@ -231,7 +231,7 @@ const OpenCC = module.exports = function (config, options) {
   // patched JSON string directly to the C++ layer via NewFromString.
   const jiebaConfigPath = resolveJiebaConfigPath(config, jiebaInfo);
   if (jiebaConfigPath) {
-    const raw = JSON.parse(fs.readFileSync(jiebaConfigPath, 'utf-8'));
+    const raw = parseJSON(fs.readFileSync(jiebaConfigPath, 'utf-8'));
     filterTofuRiskConversionChain(raw, includeTofuRiskDictionaries);
     patchConfigPaths(raw, jiebaInfo, assetsPath);
     this.handler = new binding.Opencc(
@@ -243,7 +243,7 @@ const OpenCC = module.exports = function (config, options) {
 
   config = getConfigPath(config);
   if (!includeTofuRiskDictionaries) {
-    const raw = JSON.parse(fs.readFileSync(config, 'utf-8'));
+    const raw = parseJSON(fs.readFileSync(config, 'utf-8'));
     filterTofuRiskConversionChain(raw, includeTofuRiskDictionaries);
     const configDir = path.dirname(config);
     if (raw.segmentation && raw.segmentation.dict) {
@@ -262,6 +262,11 @@ const OpenCC = module.exports = function (config, options) {
   }
   this.handler = new binding.Opencc(config);
 };
+
+function parseJSON(str) {
+  const cleanStr = str.replace(/"(?:[^"\\]|\\.)*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+  return JSON.parse(cleanStr);
+}
 
 // This is to support both CommonJS and ES module.
 OpenCC.OpenCC = OpenCC;

--- a/node/test.js
+++ b/node/test.js
@@ -9,10 +9,7 @@ const util = require('util');
 const OpenCC = require('./opencc');
 const { prepareArtifacts } = require('../scripts/prepare-node-prebuild-artifacts');
 
-function parseJSON(str) {
-  const cleanStr = str.replace(/"(?:[^"\\]|\\.)*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
-  return JSON.parse(cleanStr);
-}
+const parseJSON = OpenCC._parseJSON;
 
 const cases = parseJSON(fs.readFileSync('test/testcases/testcases.json', 'utf-8')).cases || [];
 
@@ -78,7 +75,7 @@ describe('API compatibility', function () {
     assert.equal(opencc.convertSync('㑮'), '𫝈');
   });
 
-  it('supports JSONC (JSON with comments) configuration files', function () {
+  it('supports JSONC (JSON with comments and trailing commas) configuration files', function () {
     const tempConfigPath = path.join(os.tmpdir(), 'test_comment_config.json');
     fs.writeFileSync(tempConfigPath, `
       // This is a single line comment
@@ -89,17 +86,17 @@ describe('API compatibility', function () {
           "type": "mmseg",
           "dict": {
             "type": "inline",
-            "entries": {}
-          }
+            "entries": {},
+          },
         },
         "conversion_chain": [{
           "dict": {
             "type": "inline",
             "entries": {
-              "A": "B"
-            }
-          }
-        }]
+              "A": "B",
+            },
+          },
+        }],
       }
     `);
     try {

--- a/node/test.js
+++ b/node/test.js
@@ -9,7 +9,12 @@ const util = require('util');
 const OpenCC = require('./opencc');
 const { prepareArtifacts } = require('../scripts/prepare-node-prebuild-artifacts');
 
-const cases = JSON.parse(fs.readFileSync('test/testcases/testcases.json', 'utf-8')).cases || [];
+function parseJSON(str) {
+  const cleanStr = str.replace(/"(?:[^"\\]|\\.)*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+  return JSON.parse(cleanStr);
+}
+
+const cases = parseJSON(fs.readFileSync('test/testcases/testcases.json', 'utf-8')).cases || [];
 
 function createLocalInstalledShape() {
   const rootDir = path.resolve(__dirname, '..');

--- a/node/test.js
+++ b/node/test.js
@@ -72,6 +72,43 @@ describe('API compatibility', function () {
     const opencc = new OpenCC('t2s.json');
     assert.equal(opencc.convertSync('㑮'), '𫝈');
   });
+
+  it('supports JSONC (JSON with comments) configuration files', function () {
+    const tempConfigPath = path.join(os.tmpdir(), 'test_comment_config.json');
+    fs.writeFileSync(tempConfigPath, `
+      // This is a single line comment
+      {
+        "name": "Test Config", /* This is a multi-line
+        comment */
+        "segmentation": {
+          "type": "mmseg",
+          "dict": {
+            "type": "inline",
+            "entries": {}
+          }
+        },
+        "conversion_chain": [{
+          "dict": {
+            "type": "inline",
+            "entries": {
+              "A": "B"
+            }
+          }
+        }]
+      }
+    `);
+    try {
+      const opencc = new OpenCC(tempConfigPath, { includeTofuRiskDictionaries: false });
+      assert.equal(opencc.convertSync('A'), 'B');
+
+      const openccWithTofu = new OpenCC(tempConfigPath, { includeTofuRiskDictionaries: true });
+      assert.equal(openccWithTofu.convertSync('A'), 'B');
+    } finally {
+      if (fs.existsSync(tempConfigPath)) {
+        fs.unlinkSync(tempConfigPath);
+      }
+    }
+  });
 });
 
 describe('Async API', function () {

--- a/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
+++ b/plugins/jieba/tests/JiebaPluginIntegrationTest.cpp
@@ -362,7 +362,8 @@ protected:
     buffer << ifs.rdbuf();
     rapidjson::Document doc;
     std::string content = buffer.str();
-    doc.Parse(content.c_str());
+    doc.Parse<rapidjson::kParseCommentsFlag |
+              rapidjson::kParseTrailingCommasFlag>(content.c_str());
     if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("cases")) {
       throw std::runtime_error("Invalid testcase format");
     }

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -27,9 +27,9 @@ def test_conversion():
     with open(_testcases_path, 'r', encoding='utf-8') as f:
         content = f.read()
     
-    # Strip comments (single-line // and multi-line /* */)
-    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)')
-    clean_content = pattern.sub(lambda m: "" if m.group(1) else m.group(0), content)
+    # Strip comments and trailing commas
+    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)|(,\s*(?=[\]}]))')
+    clean_content = pattern.sub(lambda m: "" if (m.group(1) or m.group(2)) else m.group(0), content)
     parsed = json.loads(clean_content)
 
     for case in parsed.get('cases', []):

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -22,9 +22,15 @@ def test_init_delete_converter():
 
 def test_conversion():
     import opencc
+    import re
 
     with open(_testcases_path, 'r', encoding='utf-8') as f:
-        parsed = json.load(f)
+        content = f.read()
+    
+    # Strip comments (single-line // and multi-line /* */)
+    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)')
+    clean_content = pattern.sub(lambda m: "" if m.group(1) else m.group(0), content)
+    parsed = json.loads(clean_content)
 
     for case in parsed.get('cases', []):
         input_text = case.get('input')

--- a/scripts/add_testcase.py
+++ b/scripts/add_testcase.py
@@ -118,9 +118,9 @@ def load_testcases(path: Path) -> dict:
     import re
     with path.open(encoding="utf-8") as stream:
         content = stream.read()
-    # Strip comments (single-line // and multi-line /* */)
-    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)')
-    clean_content = pattern.sub(lambda m: "" if m.group(1) else m.group(0), content)
+    # Strip comments and trailing commas
+    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)|(,\s*(?=[\]}]))')
+    clean_content = pattern.sub(lambda m: "" if (m.group(1) or m.group(2)) else m.group(0), content)
     return json.loads(clean_content)
 
 

--- a/scripts/add_testcase.py
+++ b/scripts/add_testcase.py
@@ -115,8 +115,13 @@ def convert(opencc: Path, config: Path, dict_dir: Path, text: str) -> str:
 
 
 def load_testcases(path: Path) -> dict:
+    import re
     with path.open(encoding="utf-8") as stream:
-        return json.load(stream)
+        content = stream.read()
+    # Strip comments (single-line // and multi-line /* */)
+    pattern = re.compile(r'"(?:[^"\\]|\\.)*"|(/\*[\s\S]*?\*/|//.*)')
+    clean_content = pattern.sub(lambda m: "" if m.group(1) else m.group(0), content)
+    return json.loads(clean_content)
 
 
 def write_testcases(path: Path, data: dict) -> None:

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -292,7 +292,8 @@ CasesByConfig LoadCases(const std::string& jsonPath) {
   }
 
   rapidjson::Document doc;
-  doc.Parse(content.c_str());
+  doc.Parse<rapidjson::kParseCommentsFlag |
+            rapidjson::kParseTrailingCommasFlag>(content.c_str());
   if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("cases") ||
       !doc["cases"].IsArray()) {
     throw std::runtime_error("Invalid testcases.json format");


### PR DESCRIPTION
As the test suite grows, test case IDs alone are often insufficient to convey the intent or context behind individual cases. This change adds JSONC support across all test suite parsers (C++, Node.js, and Python) so that contributors can annotate test cases inline — for example, explaining why a particular input/output pair exists, or flagging non-obvious edge cases.

Trailing comma support is included as a minor convenience: when appending a new entry to the cases array, the last existing entry does not need to be modified just to add a comma, keeping diffs minimal and focused.

This is a non-breaking, infrastructure-only change. No existing test case data is modified.