### PR TITLE
Add resource zip manifest artifact

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,6 +11,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resource-package:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(bash scripts/compute-version.sh)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed version: $VERSION"
+      - uses: bazelbuild/setup-bazelisk@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Configure BuildBuddy
+        shell: bash
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            {
+              echo "build --config=buildbuddy"
+              echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+              echo "build --bes_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+            } >> .bazelrc.user
+            echo "BuildBuddy enabled."
+          else
+            echo "BUILDBUDDY_API_KEY not set; skipping BuildBuddy config (fork PR or missing secret)."
+          fi
+      - name: Build resource package
+        shell: bash
+        env:
+          MSYS_NO_PATHCONV: 1
+        run: |
+          bazel build \
+            --workspace_status_command=./scripts/bazel-workspace-status.sh \
+            //data:opencc_resources_zip
+      - name: Stage resource package
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp bazel-bin/data/opencc-resources.zip "dist/opencc-${VERSION}-resources.zip"
+          unzip -l "dist/opencc-${VERSION}-resources.zip"
+      - name: Upload resource package
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencc-${{ env.VERSION }}-resources
+          path: dist/opencc-${{ env.VERSION }}-resources.zip
+          if-no-files-found: error
+
   build-and-test:
     permissions:
       contents: read

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -64,10 +64,10 @@ jobs:
           cp bazel-bin/data/opencc-resources.zip "dist/opencc-${VERSION}-resources.zip"
           unzip -l "dist/opencc-${VERSION}-resources.zip"
       - name: Upload resource package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: opencc-${{ env.VERSION }}-resources
           path: dist/opencc-${{ env.VERSION }}-resources.zip
+          archive: false
           if-no-files-found: error
 
   build-and-test:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,9 +24,9 @@ jobs:
         # LTS coverage on macOS 14 (ARM64)
         include:
           - os: macos-14
-            node-version: 22
+            node-version: 24
           - os: windows-2022
-            node-version: 22
+            node-version: 24
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,14 +46,14 @@ jobs:
       - run: npm ci
       - run: npm test
       - name: Build Node.js prebuild
-        if: ${{ matrix.node-version == 22 }}
+        if: ${{ matrix.node-version == 24 }}
         run: npm run prebuild
       - name: Verify Node.js prebuild layout
-        if: ${{ matrix.node-version == 22 }}
+        if: ${{ matrix.node-version == 24 }}
         run: |
           node -e "const fs=require('fs'); const path=require('path'); const dirs=fs.readdirSync('prebuilds',{withFileTypes:true}).filter((entry)=>entry.isDirectory()).map((entry)=>entry.name); if(!dirs.includes('assets')) throw new Error('missing prebuilds/assets'); const platformDirs=dirs.filter((name)=>name!=='assets'); if(platformDirs.length!==1) throw new Error('expected one platform prebuild directory, found '+platformDirs.join(',')); const addon=path.join('prebuilds', platformDirs[0], 'opencc.node'); if(!fs.existsSync(addon)) throw new Error('missing '+addon); console.log('Verified '+addon+' with shared assets');"
       - name: Test Node.js prebuild
-        if: ${{ matrix.node-version == 22 }}
+        if: ${{ matrix.node-version == 24 }}
         env:
           PREBUILDS_ONLY: 1
         run: npm test

--- a/data/BUILD.bazel
+++ b/data/BUILD.bazel
@@ -1,17 +1,10 @@
+load("//data/scripts:opencc_resources_zip.bzl", "opencc_resources_zip")
+
 package(default_visibility = ["//visibility:public"])
 
-genrule(
+opencc_resources_zip(
     name = "opencc_resources_zip",
-    srcs = [
-        "//data/config:config",
-        "//data/dictionary:text_dictionaries",
-    ],
-    outs = ["opencc-resources.zip"],
-    cmd = (
-        "$(location //data/scripts:opencc_resources_zip) "
-        + "--output $@ "
-        + "--configs $(locations //data/config:config) "
-        + "--dicts $(locations //data/dictionary:text_dictionaries)"
-    ),
-    tools = ["//data/scripts:opencc_resources_zip"],
+    configs = ["//data/config:config"],
+    dicts = ["//data/dictionary:text_dictionaries"],
+    out = "opencc-resources.zip",
 )

--- a/data/scripts/opencc_resources_zip.bzl
+++ b/data/scripts/opencc_resources_zip.bzl
@@ -1,0 +1,36 @@
+def _opencc_resources_zip_impl(ctx):
+    args = ctx.actions.args()
+    args.add("--output", ctx.outputs.out)
+    args.add("--source-url", ctx.attr.source_url)
+    args.add("--stable-status", ctx.info_file)
+    args.add("--volatile-status", ctx.version_file)
+    args.add_all("--configs", ctx.files.configs)
+    args.add_all("--dicts", ctx.files.dicts)
+
+    ctx.actions.run(
+        executable = ctx.executable.tool,
+        arguments = [args],
+        inputs = (
+            ctx.files.configs +
+            ctx.files.dicts +
+            [ctx.info_file, ctx.version_file]
+        ),
+        outputs = [ctx.outputs.out],
+        mnemonic = "OpenccResourcesZip",
+        progress_message = "Building OpenCC resource zip %{output}",
+    )
+
+opencc_resources_zip = rule(
+    implementation = _opencc_resources_zip_impl,
+    attrs = {
+        "configs": attr.label_list(allow_files = True, mandatory = True),
+        "dicts": attr.label_list(allow_files = True, mandatory = True),
+        "source_url": attr.string(default = "https://github.com/BYVoid/OpenCC"),
+        "tool": attr.label(
+            default = Label("//data/scripts:opencc_resources_zip"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "out": attr.output(mandatory = True),
+    },
+)

--- a/data/scripts/opencc_resources_zip.py
+++ b/data/scripts/opencc_resources_zip.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 
 import argparse
+import hashlib
 import json
 import os
+import subprocess
 import time
 import zipfile
+from datetime import datetime, timezone
+
+
+DEFAULT_SOURCE_URL = "https://github.com/BYVoid/OpenCC"
+MANIFEST_NAME = "opencc-resource-manifest.json"
 
 
 def parse_args():
@@ -14,7 +21,113 @@ def parse_args():
     parser.add_argument("--output", required=True)
     parser.add_argument("--configs", nargs="+", required=True)
     parser.add_argument("--dicts", nargs="+", required=True)
+    parser.add_argument("--source-url", default=DEFAULT_SOURCE_URL)
+    parser.add_argument("--stable-status")
+    parser.add_argument("--volatile-status")
     return parser.parse_args()
+
+
+def read_status_file(path):
+    values = {}
+    if not path:
+        return values
+    try:
+        with open(path, encoding="utf-8") as file:
+            for line in file:
+                parts = line.rstrip("\n").split(" ", 1)
+                if len(parts) == 2:
+                    values[parts[0]] = parts[1]
+    except FileNotFoundError:
+        pass
+    return values
+
+
+def git_output(args):
+    try:
+        return subprocess.check_output(
+            ["git", *args],
+            encoding="utf-8",
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return ""
+
+
+def first_value(values, keys):
+    for key in keys:
+        value = values.get(key)
+        if value:
+            return value
+    return ""
+
+
+def build_time_from_status(values):
+    timestamp = values.get("BUILD_TIMESTAMP")
+    if timestamp:
+        try:
+            return datetime.fromtimestamp(int(timestamp), timezone.utc).isoformat()
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc).isoformat()
+
+
+def git_dirty():
+    try:
+        return (
+            subprocess.call(["git", "diff", "--quiet"], stderr=subprocess.DEVNULL) != 0
+            or subprocess.call(
+                ["git", "diff", "--cached", "--quiet"], stderr=subprocess.DEVNULL
+            )
+            != 0
+        )
+    except FileNotFoundError:
+        return False
+
+
+def build_manifest(args, entries):
+    stable_status = read_status_file(args.stable_status)
+    volatile_status = read_status_file(args.volatile_status)
+    status = {**stable_status, **volatile_status}
+    source_url = first_value(
+        status,
+        [
+            "STABLE_BUILD_SCM_REMOTE",
+            "STABLE_GIT_REMOTE",
+            "BUILD_SCM_REMOTE",
+            "GIT_REMOTE",
+        ],
+    )
+    if not source_url:
+        source_url = git_output(["config", "--get", "remote.origin.url"])
+    if not source_url:
+        source_url = args.source_url
+
+    commit_id = first_value(
+        status,
+        [
+            "STABLE_BUILD_SCM_REVISION",
+            "STABLE_GIT_COMMIT",
+            "STABLE_BUILD_GIT_COMMIT",
+            "BUILD_SCM_REVISION",
+            "GIT_COMMIT",
+        ],
+    )
+    if not commit_id:
+        commit_id = git_output(["rev-parse", "HEAD"])
+
+    dirty = status.get("STABLE_BUILD_SCM_DIRTY")
+    if dirty not in ("0", "1"):
+        dirty = "1" if git_dirty() else "0"
+
+    return {
+        "manifest_version": 1,
+        "source_url": source_url,
+        "commit_id": commit_id or "unknown",
+        "source_dirty": dirty == "1",
+        "build_time_utc": build_time_from_status(status),
+        "hash_algorithm": "sha256",
+        "entries": entries,
+    }
 
 
 def convert_dict_references(value):
@@ -58,6 +171,14 @@ def write_entry(archive, name, content, date_time):
     archive.writestr(info, content.encode("utf-8"))
 
 
+def add_entry(archive, entries, name, content, date_time):
+    write_entry(archive, name, content, date_time)
+    entries[name] = {
+        "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        "size": len(content.encode("utf-8")),
+    }
+
+
 def main():
     args = parse_args()
     output_dir = os.path.dirname(args.output)
@@ -65,14 +186,30 @@ def main():
         os.makedirs(output_dir, exist_ok=True)
     date_time = time.localtime()[:6]
     with zipfile.ZipFile(args.output, "w") as archive:
+        entries = {}
         for path in sorted(args.configs, key=os.path.basename):
-            write_entry(
-                archive, os.path.basename(path), read_text_config(path), date_time
+            add_entry(
+                archive,
+                entries,
+                os.path.basename(path),
+                read_text_config(path),
+                date_time,
             )
         for path in sorted(args.dicts, key=os.path.basename):
-            write_entry(
-                archive, os.path.basename(path), read_clean_dictionary(path), date_time
+            add_entry(
+                archive,
+                entries,
+                os.path.basename(path),
+                read_clean_dictionary(path),
+                date_time,
             )
+        manifest = json.dumps(
+            build_manifest(args, entries),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+        write_entry(archive, MANIFEST_NAME, manifest, date_time)
 
 
 if __name__ == "__main__":

--- a/scripts/bazel-workspace-status.sh
+++ b/scripts/bazel-workspace-status.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit="$(git rev-parse HEAD 2>/dev/null || true)"
+remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+dirty="0"
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  dirty="1"
+fi
+
+if [[ -n "$commit" ]]; then
+  printf 'STABLE_BUILD_SCM_REVISION %s\n' "$commit"
+fi
+if [[ -n "$remote" ]]; then
+  printf 'STABLE_BUILD_SCM_REMOTE %s\n' "$remote"
+fi
+printf 'STABLE_BUILD_SCM_DIRTY %s\n' "$dirty"
+printf 'BUILD_TIMESTAMP %s\n' "$(date -u +%s)"

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -36,13 +36,18 @@ cc_test(
     ],
     data = [
         "//data/config",
-        "//data:opencc_resources_zip",
         "//data/dictionary:binary_dictionaries",
         "//data/dictionary:text_dictionaries",
         "//src/tools:command_line",
         "//test/testcases",
-    ],
-    defines = ["BAZEL"],
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["//data:opencc_resources_zip"],
+    }),
+    defines = ["BAZEL"] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["OPENCC_ENABLE_RESOURCE_ZIP_TEST"],
+    }),
     deps = [
         "//src:common_lib",
         "@bazel_tools//tools/cpp/runfiles",

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -144,7 +144,7 @@ protected:
 #endif
   }
 
-#ifdef BAZEL
+#if defined(BAZEL) && defined(OPENCC_ENABLE_RESOURCE_ZIP_TEST)
   std::string ResourceZipFile() const {
     return runfiles_->Rlocation("_main/data/opencc-resources.zip");
   }
@@ -212,7 +212,7 @@ protected:
 #endif
   }
 
-#ifdef BAZEL
+#if defined(BAZEL) && defined(OPENCC_ENABLE_RESOURCE_ZIP_TEST)
   std::string TestResourceZipCommand(const std::string& config,
                                      const std::string& inputFile,
                                      const std::string& outputFile) const {
@@ -419,7 +419,7 @@ TEST_F(CommandLineConvertTest, IncludeTofuRiskDictionariesFlagRestoresLegacy) {
   EXPECT_EQ("𫝈", GetFileContents(outputFile));
 }
 
-#ifdef BAZEL
+#if defined(BAZEL) && defined(OPENCC_ENABLE_RESOURCE_ZIP_TEST)
 TEST_F(CommandLineConvertTest, ResourceZipConvertsWithoutResourcePaths) {
   const std::string inputFile = InputFile("resource_zip");
   const std::string outputFile = OutputFile("resource_zip");


### PR DESCRIPTION
Add a dedicated Bazel CI job for building the OpenCC resource package
and uploading it as a workflow artifact.

This introduces a proper Starlark rule for `opencc_resources_zip`
instead of using an inline `genrule`. The new rule passes Bazel stable
and volatile workspace status files to the packaging script, allowing
the generated archive to include build provenance metadata.

The resource zip now contains `opencc-resource-manifest.json`, including:

* manifest version
* source repository URL
* source commit id
* dirty source tree flag
* UTC build time
* SHA-256 hash and size for each packaged resource

This makes the standalone resource package easier to verify and trace
back to the source revision that produced it.

Also add `scripts/bazel-workspace-status.sh` to provide SCM metadata for
Bazel builds, and wire the resource-package CI job to use it.

The Bazel command-line resource zip test is disabled on Windows for now
via `OPENCC_ENABLE_RESOURCE_ZIP_TEST`, because the resource zip runfiles
test is currently only enabled on non-Windows platforms.

Finally, update the Node.js CI prebuild lane from Node.js 22 to Node.js
24, so the generated Node.js prebuild coverage tracks the newer active
runtime version.
