### PR TITLE
Update GitHub Actions runtime versions to remove deprecation warnings

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -20,7 +20,7 @@ jobs:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -31,9 +31,11 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
-      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Configure BuildBuddy
@@ -82,7 +84,7 @@ jobs:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -93,9 +95,11 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
-      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Configure BuildBuddy
@@ -124,7 +128,7 @@ jobs:
         run: bazel test --test_output=all //src/... //data/... //test/... //python/... //plugins/...
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-bazel-${{ matrix.os }}
           path: |

--- a/.github/workflows/check-dictionary-sorted.yml
+++ b/.github/workflows/check-dictionary-sorted.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Sort dictionaries

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -45,7 +45,7 @@ jobs:
           cmake --build build-standalone
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-cmake-${{ matrix.os }}
           path: |

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -20,7 +20,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: msys2/setup-msys2@v2
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -65,7 +65,7 @@ jobs:
           if [ -d install ]; then find install -type f; fi
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-mingw
           path: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,7 +32,7 @@ jobs:
             package_suffix: arm64
             can_run_binaries: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -114,7 +114,7 @@ jobs:
 
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-msvc-${{ matrix.arch }}
           path: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,7 @@ jobs:
           - os: windows-2022
             node-version: 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -40,7 +40,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -59,7 +59,7 @@ jobs:
         run: npm test
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-nodejs-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -32,7 +32,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
         run: pytest python/ --junitxml=pytest.xml
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-python-${{ matrix.python-version }}
           path: |
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Compute version
@@ -82,7 +82,7 @@ jobs:
           echo "Computed version: $VERSION"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-pypi-${{ matrix.os }}-${{ matrix.python-build }}
           path: |

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -153,7 +153,7 @@ jobs:
           )
 
       - name: Upload .deb artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-deb-${{ steps.version.outputs.value }}
           path: |

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
           (cd build/doc/doc && zip -r "../../../dist/opencc-${VERSION}-doc.zip" html)
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-doc-${{ steps.version.outputs.value }}
           path: dist/opencc-${{ steps.version.outputs.value }}-doc.zip

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -45,12 +45,12 @@ jobs:
             library: opencc-jieba.dll
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload package artifact
         if: steps.publish_check.outputs.published != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-opencc-jieba-binary-${{ matrix.target }}
           path: plugins/jieba/node/dist/npm-artifacts/*.tgz
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload npm debug logs
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.upload_npm_debug_logs }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-debug-logs-opencc-jieba-binary-${{ matrix.target }}
           path: npm-debug-logs/*.log
@@ -194,12 +194,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -261,7 +261,7 @@ jobs:
 
       - name: Upload package artifact
         if: steps.publish_check.outputs.published != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-opencc-jieba
           path: plugins/jieba/node/dist/npm-artifacts/*.tgz
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload npm debug logs
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.upload_npm_debug_logs }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-debug-logs-opencc-jieba
           path: npm-debug-logs/*.log
@@ -344,12 +344,12 @@ jobs:
             runner: windows-2025
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -418,7 +418,7 @@ jobs:
 
       - name: Upload package artifact
         if: steps.publish_check.outputs.published != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-opencc-binary-${{ matrix.target }}
           path: dist/npm-artifacts/*.tgz
@@ -472,7 +472,7 @@ jobs:
 
       - name: Upload npm debug logs
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.upload_npm_debug_logs }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-debug-logs-opencc-binary-${{ matrix.target }}
           path: npm-debug-logs/*.log
@@ -487,12 +487,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -555,7 +555,7 @@ jobs:
 
       - name: Upload package artifact
         if: steps.publish_check.outputs.published != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-opencc
           path: dist/npm-artifacts/*.tgz
@@ -609,7 +609,7 @@ jobs:
 
       - name: Upload npm debug logs
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.upload_npm_debug_logs }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-debug-logs-opencc
           path: npm-debug-logs/*.log

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Compute version
@@ -27,7 +27,7 @@ jobs:
         echo "Computed version: $VERSION"
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -170,7 +170,7 @@ jobs:
             -PackageOnly
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencc-winget-release-${{ steps.version.outputs.value }}
           path: |

--- a/.github/workflows/resource-diff.yml
+++ b/.github/workflows/resource-diff.yml
@@ -52,7 +52,7 @@ jobs:
           echo "After: $after_ref"
 
       - name: Checkout before
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: before
           repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
@@ -60,17 +60,19 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout after
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: after
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ steps.refs.outputs.after_ref }}
           fetch-depth: 0
 
-      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Replace archived bazelbuild/setup-bazelisk with bazel-contrib/setup-bazel and enable Bazelisk caching. Upgrade official GitHub actions to Node 24 runtime versions to avoid Node 20 deprecation warnings.