### PR TITLE
Implement single-dictionary lookup fast-path for PrefixMatch

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -403,8 +403,6 @@ cc_library(
         ":dict_lib",
         ":lexicon_lib",
         ":utf8_util_lib",
-        ":marisa_dict_lib",
-        ":darts_dict_lib",
     ],
 )
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -403,6 +403,22 @@ cc_library(
         ":dict_lib",
         ":lexicon_lib",
         ":utf8_util_lib",
+        ":marisa_dict_lib",
+        ":darts_dict_lib",
+    ],
+)
+
+cc_test(
+    name = "prefix_match_test",
+    size = "small",
+    srcs = ["PrefixMatchTest.cpp"],
+    deps = [
+        ":prefix_match_lib",
+        ":dict_group_lib",
+        ":marisa_dict_lib",
+        ":test_utils_utf8_lib",
+        ":text_dict_test_base_lib",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(UNITTESTS
   MarisaDictTest
   MaxMatchSegmentationTest
   PhraseExtractTest
+  PrefixMatchTest
   SerializedValuesTest
   SimpleConverterTest
   TextDictTest

--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -99,6 +99,20 @@ Optional<const DictEntry*> DartsDict::MatchPrefix(const char* word,
 
 LexiconPtr DartsDict::GetLexicon() const { return lexicon; }
 
+bool DartsDict::MatchPrefixValue(const char* word, size_t len,
+                                 std::string* key, std::string* value,
+                                 size_t* keyLength) const {
+  Optional<const DictEntry*> matched = MatchPrefix(word, len);
+  if (matched.IsNull()) {
+    return false;
+  }
+  const DictEntry* entry = matched.Get();
+  *key = entry->Key();
+  *value = entry->GetDefault();
+  *keyLength = entry->KeyLength();
+  return true;
+}
+
 DartsDictPtr DartsDict::NewFromFile(FILE* fp) {
   DartsDictPtr dict(new DartsDict());
 

--- a/src/DartsDict.hpp
+++ b/src/DartsDict.hpp
@@ -28,18 +28,25 @@ namespace opencc {
  */
 class OPENCC_EXPORT DartsDict : public Dict, public SerializableDict {
 public:
-  virtual ~DartsDict();
+  virtual ~DartsDict() override;
 
-  virtual size_t KeyMaxLength() const;
+  virtual size_t KeyMaxLength() const override;
 
-  virtual Optional<const DictEntry*> Match(const char* word, size_t len) const;
+  virtual Optional<const DictEntry*> Match(const char* word,
+                                           size_t len) const override;
 
   virtual Optional<const DictEntry*> MatchPrefix(const char* word,
-                                                 size_t len) const;
+                                                 size_t len) const override;
 
-  virtual LexiconPtr GetLexicon() const;
+  virtual LexiconPtr GetLexicon() const override;
 
-  virtual void SerializeToFile(FILE* fp) const;
+  virtual bool SupportsFastPrefixMatch() const override { return true; }
+
+  virtual bool MatchPrefixValue(const char* word, size_t len,
+                                std::string* key, std::string* value,
+                                size_t* keyLength) const override;
+
+  virtual void SerializeToFile(FILE* fp) const override;
 
   /**
    * Constructs a DartsDict from another dictionary.

--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -98,6 +98,27 @@ public:
     return nullptr;
   }
 
+  /**
+   * Returns true if this dict can handle prefix queries directly without
+   * PrefixMatch building a lookup table. Subclasses that override
+   * MatchPrefixValue() must also override this to return true.
+   */
+  virtual bool SupportsFastPrefixMatch() const { return false; }
+
+  /**
+   * Fast-path prefix match. Only called when SupportsFastPrefixMatch() is
+   * true. Writes the longest matching key/value and its byte length into the
+   * output parameters and returns true; returns false on no match.
+   *
+   * The caller owns the output storage; implementations must not cache the
+   * pointers across calls.
+   */
+  virtual bool MatchPrefixValue(const char* word, size_t len,
+                                std::string* key, std::string* value,
+                                size_t* keyLength) const {
+    return false;
+  }
+
   virtual ~Dict() = default;
 };
 } // namespace opencc

--- a/src/MarisaDict.cpp
+++ b/src/MarisaDict.cpp
@@ -258,3 +258,46 @@ void MarisaDict::SerializeToFile(FILE* fp) const {
       new SerializedValues(GetLexicon()));
   serialized_values->SerializeToFile(fp);
 }
+bool MarisaDict::MatchPrefixValue(const char* word,
+                                  size_t len,
+                                  std::string* key,
+                                  std::string* value,
+                                  size_t* keyLength) const {
+  const marisa::Trie* trie = internal->marisa.get();
+  if (trie == nullptr) {
+    return false;
+  }
+  static thread_local marisa::Agent agent;
+  agent.set_query(word, len);
+  bool matched = false;
+  size_t matchedId = 0;
+  size_t matchedLength = 0;
+  while (trie->common_prefix_search(agent)) {
+    const size_t currentLength = agent.key().length();
+    if (!matched || currentLength > matchedLength) {
+      matched = true;
+      matchedId = agent.key().id();
+      matchedLength = currentLength;
+    }
+  }
+  if (!matched) {
+    return false;
+  }
+  if (valuesLexicon != nullptr) {
+    if (matchedId < valuesLexicon->Length()) {
+      *value = valuesLexicon->At(matchedId)->GetDefault();
+    } else {
+      return false;
+    }
+  } else {
+    LexiconPtr lex = GetLexicon();
+    if (lex != nullptr && matchedId < lex->Length()) {
+      *value = lex->At(matchedId)->GetDefault();
+    } else {
+      return false;
+    }
+  }
+  key->assign(word, matchedLength);
+  *keyLength = matchedLength;
+  return true;
+}

--- a/src/MarisaDict.hpp
+++ b/src/MarisaDict.hpp
@@ -35,21 +35,28 @@ namespace opencc {
  */
 class OPENCC_EXPORT MarisaDict : public Dict, public SerializableDict {
 public:
-  virtual ~MarisaDict();
+  virtual ~MarisaDict() override;
 
-  virtual size_t KeyMaxLength() const;
+  virtual size_t KeyMaxLength() const override;
 
-  virtual Optional<const DictEntry*> Match(const char* word, size_t len) const;
+  virtual Optional<const DictEntry*> Match(const char* word,
+                                           size_t len) const override;
 
   virtual Optional<const DictEntry*> MatchPrefix(const char* word,
-                                                 size_t len) const;
+                                                 size_t len) const override;
 
-  virtual std::vector<const DictEntry*> MatchAllPrefixes(const char* word,
-                                                         size_t len) const;
+  virtual std::vector<const DictEntry*> MatchAllPrefixes(
+      const char* word, size_t len) const override;
 
-  virtual LexiconPtr GetLexicon() const;
+  virtual LexiconPtr GetLexicon() const override;
 
-  virtual void SerializeToFile(FILE* fp) const;
+  virtual bool SupportsFastPrefixMatch() const override { return true; }
+
+  virtual bool MatchPrefixValue(const char* word, size_t len,
+                                std::string* key, std::string* value,
+                                size_t* keyLength) const override;
+
+  virtual void SerializeToFile(FILE* fp) const override;
 
   /**
    * Constructs a MarisaDict from another dictionary.
@@ -59,6 +66,10 @@ public:
   static MarisaDictPtr NewFromFile(FILE* fp);
 
   static MarisaDictPtr NewFromBuffer(const char* data, size_t size);
+
+  bool IsLexiconReconstructed() const {
+    return lexiconReconstructed.load(std::memory_order_acquire);
+  }
 
 private:
   MarisaDict();
@@ -74,6 +85,5 @@ private:
 
   class MarisaInternal;
   std::unique_ptr<MarisaInternal> internal;
-
 };
 } // namespace opencc

--- a/src/MarisaDict.hpp
+++ b/src/MarisaDict.hpp
@@ -67,6 +67,7 @@ public:
 
   static MarisaDictPtr NewFromBuffer(const char* data, size_t size);
 
+  // Exposed for testing only.
   bool IsLexiconReconstructed() const {
     return lexiconReconstructed.load(std::memory_order_acquire);
   }

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -198,6 +198,22 @@ private:
 };
 
 PrefixMatch::PrefixMatch(const DictPtr& dict) {
+  // Try to unwrap single dict group
+  DictPtr actualDict = dict;
+  while (actualDict) {
+    const std::list<DictPtr>* items = actualDict->GetDictGroupItems();
+    if (items != nullptr && items->size() == 1) {
+      actualDict = items->front();
+    } else {
+      break;
+    }
+  }
+
+  if (actualDict && actualDict->SupportsFastPrefixMatch()) {
+    singleDict = actualDict;
+    return;
+  }
+
   static std::mutex cacheMutex;
   static std::unordered_map<std::string, std::vector<CacheEntry>> cache;
 
@@ -255,6 +271,21 @@ PrefixMatch::~PrefixMatch() {}
 
 PrefixMatch::Match PrefixMatch::MatchPrefix(const char* word,
                                             size_t len) const {
+  if (singleDict != nullptr) {
+    struct MatchCache {
+      std::string key;
+      std::string value;
+      size_t keyLength;
+    };
+    // The returned key/value pointers are valid until the next MatchPrefix()
+    // call on the same thread.
+    static thread_local MatchCache matchCache;
+    if (singleDict->MatchPrefixValue(word, len, &matchCache.key, &matchCache.value, &matchCache.keyLength)) {
+      return Match{true, matchCache.keyLength, &matchCache.key, &matchCache.value};
+    }
+    return Match{false, 0, nullptr, nullptr};
+  }
+
   return tables->table->MatchPrefix(word, len);
 }
 

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -22,7 +22,7 @@
 
 namespace opencc {
 
-class PrefixMatch {
+class OPENCC_EXPORT PrefixMatch {
 public:
   class Tables;
 
@@ -47,6 +47,7 @@ private:
                                std::vector<std::weak_ptr<const Dict>>* output);
 
   std::shared_ptr<const Tables> tables;
+  DictPtr singleDict;
 };
 
 } // namespace opencc

--- a/src/PrefixMatchTest.cpp
+++ b/src/PrefixMatchTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Open Chinese Convert
+ *
+ * Copyright 2020-2026 Carbo Kuo and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstring>
+#include <list>
+#include <string>
+#include <vector>
+
+#include "PrefixMatch.hpp"
+#include "DictGroup.hpp"
+#include "MarisaDict.hpp"
+#include "TestUtilsUTF8.hpp"
+#include "TextDictTestBase.hpp"
+
+namespace opencc {
+
+class PrefixMatchTest : public TextDictTestBase {
+protected:
+  PrefixMatchTest()
+      : marisaDict(MarisaDict::NewFromDict(*textDict)), fileName("dict.ocd2") {
+    marisaDict->opencc::SerializableDict::SerializeToFile(fileName);
+  }
+
+  virtual ~PrefixMatchTest() {
+    std::remove(fileName.c_str());
+  }
+
+  const MarisaDictPtr marisaDict;
+  const std::string fileName;
+};
+
+TEST_F(PrefixMatchTest, SingleDictFastPathMatchesTablePath) {
+  // 1. Create a single-element DictGroup wrapper around marisaDict
+  std::list<DictPtr> dicts = { marisaDict };
+  DictPtr dictGroup(new DictGroup(dicts));
+
+  // 2. Create two PrefixMatch instances:
+  // - pmFast uses the single dict fast-path (unwrapped group -> marisaDict)
+  PrefixMatch pmFast(dictGroup);
+
+  // - pmTable uses the standard table path because we pass a group of two dicts
+  std::list<DictPtr> dictsMulti = { marisaDict, textDict };
+  DictPtr dictGroupMulti(new DictGroup(dictsMulti));
+  PrefixMatch pmTable(dictGroupMulti);
+
+  // Compare queries
+  const std::vector<std::string> testQueries = {
+    "清華", "清華大", "清華大學", "清", "積羽沉舟", "nowhere"
+  };
+
+  for (const std::string& query : testQueries) {
+    PrefixMatch::Match mFast = pmFast.MatchPrefix(query.c_str(), query.length());
+    PrefixMatch::Match mTable = pmTable.MatchPrefix(query.c_str(), query.length());
+
+    EXPECT_EQ(mFast.matched, mTable.matched);
+    if (mFast.matched) {
+      EXPECT_EQ(mFast.keyLength, mTable.keyLength);
+      EXPECT_EQ(*mFast.key, *mTable.key);
+      EXPECT_EQ(*mFast.value, *mTable.value);
+    }
+  }
+}
+
+TEST_F(PrefixMatchTest, MarisaLazyLoadFastPathDoesNotReconstruct) {
+  // 1. Load MarisaDict from the serialized ocd2 file (lazy load)
+  MarisaDictPtr lazyDict = SerializableDict::NewFromFile<MarisaDict>(fileName);
+  
+  // Verify it is not reconstructed initially
+  EXPECT_FALSE(lazyDict->IsLexiconReconstructed());
+
+  // 2. Create PrefixMatch single-dict fast-path on it
+  PrefixMatch pm(lazyDict);
+
+  // 3. Query a prefix that should hit
+  PrefixMatch::Match m = pm.MatchPrefix("清華", 6);
+  EXPECT_TRUE(m.matched);
+  EXPECT_EQ(6, m.keyLength); // "清華" length is 6 bytes in UTF-8
+  EXPECT_EQ("清華", *m.key);
+  EXPECT_EQ(utf8("Tsinghua"), *m.value);
+
+  // 4. Verify that the lexicon was NOT reconstructed during the query!
+  EXPECT_FALSE(lazyDict->IsLexiconReconstructed());
+}
+
+TEST_F(PrefixMatchTest, FastPathSelectsLongestMatch) {
+  // Dictionary has "清"→Tsing, "清華"→Tsinghua, "清華大學"→TsinghuaUniversity.
+  // A query with a longer input must match the longest key, not the first
+  // prefix returned by common_prefix_search().
+  PrefixMatch pm(marisaDict);
+
+  const std::string query = utf8("清華大學校園");
+  PrefixMatch::Match m = pm.MatchPrefix(query.c_str(), query.length());
+
+  EXPECT_TRUE(m.matched);
+  EXPECT_EQ(utf8("清華大學"), *m.key);
+  EXPECT_EQ(utf8("TsinghuaUniversity"), *m.value);
+  EXPECT_EQ(m.key->length(), m.keyLength);
+}
+
+} // namespace opencc


### PR DESCRIPTION
Optimize PrefixMatch to skip table construction and caching overhead when
initialized with a single-dictionary configuration (such as s2t_flatten).
Queries delegate directly to the underlying dict via virtual dispatch,
avoiding the custom prefix-search table entirely.

Detailed Changes:
- **Dict Interface**:
  - Add SupportsFastPrefixMatch() virtual hook for dicts to opt into
    fast-path dispatch without exposing concrete type information.
  - Add MatchPrefixValue() virtual hook that writes the longest matching
    key/value and its byte length into caller-owned output parameters.
    Returned pointers from PrefixMatch are valid until the next
    MatchPrefix() call on the same thread.
- **PrefixMatch Single-Dict Fast-Path**:
  - Recursively unwrap single-element DictGroup wrappers in the constructor.
  - If the leaf dict reports SupportsFastPrefixMatch(), retain a direct
    pointer and skip PrefixMatch::Table construction.
  - MatchPrefix() collapses to a single virtual call with one thread_local
    cache; no longer includes MarisaDict.hpp or DartsDict.hpp.
  - Add OPENCC_EXPORT to fix Windows DLL linker errors in tests that
    instantiate PrefixMatch directly.
- **MarisaDict Direct Query**:
  - MatchPrefixValue() queries the marisa::Trie directly using a
    thread_local Agent, explicitly tracking the longest match rather than
    relying on common_prefix_search() iteration order.
  - Reads values from valuesLexicon when available to avoid triggering
    lazy lexicon reconstruction.
- **DartsDict Direct Query**:
  - MatchPrefixValue() delegates to the existing MatchPrefix() and copies
    key/value into the caller's output storage.
- **Build & Test Integration**:
  - Register prefix_match_test in BUILD.bazel and CMakeLists.txt.
  - Add PrefixMatchTest covering fast-path/table-path output consistency,
    lazy-loaded MarisaDict not triggering lexicon reconstruction, and
    explicit longest-match selection (querying "清華大學校園" against a
    dict containing "清", "清華", "清華大學").
  - Add override to all virtual overrides in MarisaDict and DartsDict.