### PR TITLE
Change PrefixMatch::MatchPrefix() to return PrefixMatchView with string_view fields

### DIFF
--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -21,6 +21,7 @@
 
 #include "BinaryDict.hpp"
 #include "DartsDict.hpp"
+#include "Dict.hpp"
 #include "Lexicon.hpp"
 #include "darts.h"
 
@@ -99,18 +100,18 @@ Optional<const DictEntry*> DartsDict::MatchPrefix(const char* word,
 
 LexiconPtr DartsDict::GetLexicon() const { return lexicon; }
 
-bool DartsDict::MatchPrefixValue(const char* word, size_t len,
-                                 std::string* key, std::string* value,
-                                 size_t* keyLength) const {
+PrefixMatchView DartsDict::MatchPrefixValue(const char* word,
+                                            size_t len) const {
   Optional<const DictEntry*> matched = MatchPrefix(word, len);
   if (matched.IsNull()) {
-    return false;
+    return PrefixMatchView{};
   }
   const DictEntry* entry = matched.Get();
-  *key = entry->Key();
-  *value = entry->GetDefault();
-  *keyLength = entry->KeyLength();
-  return true;
+  const size_t keyLen = entry->KeyLength();
+  // value view points directly into the DictEntry's owned string storage,
+  // valid for the lifetime of this dictionary.
+  return PrefixMatchView{true, keyLen, std::string_view(word, keyLen),
+                         entry->GetDefaultView()};
 }
 
 DartsDictPtr DartsDict::NewFromFile(FILE* fp) {

--- a/src/DartsDict.hpp
+++ b/src/DartsDict.hpp
@@ -42,9 +42,8 @@ public:
 
   virtual bool SupportsFastPrefixMatch() const override { return true; }
 
-  virtual bool MatchPrefixValue(const char* word, size_t len,
-                                std::string* key, std::string* value,
-                                size_t* keyLength) const override;
+  virtual PrefixMatchView MatchPrefixValue(const char* word,
+                                           size_t len) const override;
 
   virtual void SerializeToFile(FILE* fp) const override;
 

--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -19,11 +19,25 @@
 #pragma once
 
 #include <list>
+#include <string_view>
 
 #include "Common.hpp"
 #include "DictEntry.hpp"
 
 namespace opencc {
+
+/**
+ * Result of a PrefixMatch fast-path lookup.
+ * key and value are non-owning views; see PrefixMatch::MatchPrefixView()
+ * for lifetime details.
+ */
+struct OPENCC_EXPORT PrefixMatchView {
+  bool matched = false;
+  size_t keyLength = 0;
+  std::string_view key;
+  std::string_view value;
+};
+
 /**
  * Abstract class of dictionary
  * @ingroup opencc_cpp_api
@@ -107,16 +121,12 @@ public:
 
   /**
    * Fast-path prefix match. Only called when SupportsFastPrefixMatch() is
-   * true. Writes the longest matching key/value and its byte length into the
-   * output parameters and returns true; returns false on no match.
-   *
-   * The caller owns the output storage; implementations must not cache the
-   * pointers across calls.
+   * true. Returns a PrefixMatchView with matched=false on no match.
+   * See PrefixMatch::MatchPrefixView() for key/value lifetime details.
    */
-  virtual bool MatchPrefixValue(const char* word, size_t len,
-                                std::string* key, std::string* value,
-                                size_t* keyLength) const {
-    return false;
+  virtual PrefixMatchView MatchPrefixValue(const char* word,
+                                           size_t len) const {
+    return PrefixMatchView{};
   }
 
   virtual ~Dict() = default;

--- a/src/DictEntry.cpp
+++ b/src/DictEntry.cpp
@@ -25,7 +25,7 @@ std::string MultiValueDictEntry::ToString() const {
   size_t i = 0;
   size_t length = Values().size();
   std::ostringstream buffer;
-  buffer << Key() << '\t';
+  buffer << KeyView() << '\t';
   for (const std::string& value : Values()) {
     buffer << value;
     if (i < length - 1) {

--- a/src/DictEntry.hpp
+++ b/src/DictEntry.hpp
@@ -65,8 +65,9 @@ public:
 
   virtual ~NoValueDictEntry() {}
 
+  std::string Key() const override { return key; }
   std::string_view KeyView() const override { return key; }
-
+  std::string GetDefault() const override { return key; }
   std::string_view GetDefaultView() const override { return key; }
 
   std::vector<std::string> Values() const override {
@@ -107,10 +108,11 @@ public:
 
   virtual ~StrSingleValueDictEntry() {}
 
+  std::string Key() const override { return key; }
   std::string_view KeyView() const override { return key; }
 
   std::string Value() const override { return value; }
-
+  std::string GetDefault() const override { return value; }
   std::string_view ValueView() const override { return value; }
 
 private:
@@ -131,8 +133,12 @@ public:
 
   virtual ~StrMultiValueDictEntry() {}
 
+  std::string Key() const override { return key; }
   std::string_view KeyView() const override { return key; }
 
+  std::string GetDefault() const override {
+    return values.empty() ? key : values[0];
+  }
   std::string_view GetDefaultView() const override {
     return values.empty() ? std::string_view(key) : std::string_view(values[0]);
   }

--- a/src/DictEntry.hpp
+++ b/src/DictEntry.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "Common.hpp"
 #include "Segments.hpp"
 #include "UTF8Util.hpp"
@@ -31,21 +33,25 @@ class OPENCC_EXPORT DictEntry {
 public:
   virtual ~DictEntry() {}
 
-  virtual std::string Key() const = 0;
+  virtual std::string_view KeyView() const = 0;
+
+  virtual std::string_view GetDefaultView() const = 0;
+
+  virtual std::string Key() const { return std::string(KeyView()); }
 
   virtual std::vector<std::string> Values() const = 0;
 
-  virtual std::string GetDefault() const = 0;
+  virtual std::string GetDefault() const { return std::string(GetDefaultView()); }
 
   virtual size_t NumValues() const = 0;
 
   virtual std::string ToString() const = 0;
 
-  size_t KeyLength() const { return Key().length(); }
+  size_t KeyLength() const { return KeyView().length(); }
 
-  bool operator<(const DictEntry& that) const { return Key() < that.Key(); }
+  bool operator<(const DictEntry& that) const { return KeyView() < that.KeyView(); }
 
-  bool operator==(const DictEntry& that) const { return Key() == that.Key(); }
+  bool operator==(const DictEntry& that) const { return KeyView() == that.KeyView(); }
 
   static bool UPtrLessThan(const std::unique_ptr<DictEntry>& a,
                            const std::unique_ptr<DictEntry>& b) {
@@ -59,17 +65,17 @@ public:
 
   virtual ~NoValueDictEntry() {}
 
-  virtual std::string Key() const { return key; }
+  std::string_view KeyView() const override { return key; }
 
-  virtual std::vector<std::string> Values() const {
+  std::string_view GetDefaultView() const override { return key; }
+
+  std::vector<std::string> Values() const override {
     return std::vector<std::string>();
   }
 
-  virtual std::string GetDefault() const { return key; }
+  size_t NumValues() const override { return 0; }
 
-  virtual size_t NumValues() const { return 0; }
-
-  virtual std::string ToString() const { return key; }
+  std::string ToString() const override { return key; }
 
 private:
   std::string key;
@@ -79,16 +85,18 @@ class OPENCC_EXPORT SingleValueDictEntry : public DictEntry {
 public:
   virtual std::string Value() const = 0;
 
-  virtual std::vector<std::string> Values() const {
+  virtual std::string_view ValueView() const = 0;
+
+  std::string_view GetDefaultView() const override { return ValueView(); }
+
+  std::vector<std::string> Values() const override {
     return std::vector<std::string>{Value()};
   }
 
-  virtual std::string GetDefault() const { return Value(); }
+  size_t NumValues() const override { return 1; }
 
-  virtual size_t NumValues() const { return 1; }
-
-  virtual std::string ToString() const {
-    return std::string(Key()) + "\t" + Value();
+  std::string ToString() const override {
+    return std::string(KeyView()) + "\t" + Value();
   }
 };
 
@@ -99,9 +107,11 @@ public:
 
   virtual ~StrSingleValueDictEntry() {}
 
-  virtual std::string Key() const { return key; }
+  std::string_view KeyView() const override { return key; }
 
-  virtual std::string Value() const { return value; }
+  std::string Value() const override { return value; }
+
+  std::string_view ValueView() const override { return value; }
 
 private:
   std::string key;
@@ -110,14 +120,6 @@ private:
 
 class OPENCC_EXPORT MultiValueDictEntry : public DictEntry {
 public:
-  virtual std::string GetDefault() const {
-    if (NumValues() > 0) {
-      return Values().at(0);
-    } else {
-      return Key();
-    }
-  }
-
   virtual std::string ToString() const;
 };
 
@@ -129,11 +131,15 @@ public:
 
   virtual ~StrMultiValueDictEntry() {}
 
-  virtual std::string Key() const { return key; }
+  std::string_view KeyView() const override { return key; }
 
-  size_t NumValues() const { return values.size(); }
+  std::string_view GetDefaultView() const override {
+    return values.empty() ? std::string_view(key) : std::string_view(values[0]);
+  }
 
-  std::vector<std::string> Values() const { return values; }
+  size_t NumValues() const override { return values.size(); }
+
+  std::vector<std::string> Values() const override { return values; }
 
 private:
   std::string key;

--- a/src/MarisaDict.cpp
+++ b/src/MarisaDict.cpp
@@ -258,14 +258,11 @@ void MarisaDict::SerializeToFile(FILE* fp) const {
       new SerializedValues(GetLexicon()));
   serialized_values->SerializeToFile(fp);
 }
-bool MarisaDict::MatchPrefixValue(const char* word,
-                                  size_t len,
-                                  std::string* key,
-                                  std::string* value,
-                                  size_t* keyLength) const {
+PrefixMatchView MarisaDict::MatchPrefixValue(const char* word,
+                                             size_t len) const {
   const marisa::Trie* trie = internal->marisa.get();
   if (trie == nullptr) {
-    return false;
+    return PrefixMatchView{};
   }
   static thread_local marisa::Agent agent;
   agent.set_query(word, len);
@@ -281,23 +278,23 @@ bool MarisaDict::MatchPrefixValue(const char* word,
     }
   }
   if (!matched) {
-    return false;
+    return PrefixMatchView{};
   }
+  // value view points directly into the DictEntry's owned string storage,
+  // valid for the lifetime of this dictionary.
   if (valuesLexicon != nullptr) {
     if (matchedId < valuesLexicon->Length()) {
-      *value = valuesLexicon->At(matchedId)->GetDefault();
-    } else {
-      return false;
+      return PrefixMatchView{true, matchedLength,
+                             std::string_view(word, matchedLength),
+                             valuesLexicon->At(matchedId)->GetDefaultView()};
     }
-  } else {
-    LexiconPtr lex = GetLexicon();
-    if (lex != nullptr && matchedId < lex->Length()) {
-      *value = lex->At(matchedId)->GetDefault();
-    } else {
-      return false;
-    }
+    return PrefixMatchView{};
   }
-  key->assign(word, matchedLength);
-  *keyLength = matchedLength;
-  return true;
+  LexiconPtr lex = GetLexicon();
+  if (lex != nullptr && matchedId < lex->Length()) {
+    return PrefixMatchView{true, matchedLength,
+                           std::string_view(word, matchedLength),
+                           lex->At(matchedId)->GetDefaultView()};
+  }
+  return PrefixMatchView{};
 }

--- a/src/MarisaDict.hpp
+++ b/src/MarisaDict.hpp
@@ -52,9 +52,8 @@ public:
 
   virtual bool SupportsFastPrefixMatch() const override { return true; }
 
-  virtual bool MatchPrefixValue(const char* word, size_t len,
-                                std::string* key, std::string* value,
-                                size_t* keyLength) const override;
+  virtual PrefixMatchView MatchPrefixValue(const char* word,
+                                           size_t len) const override;
 
   virtual void SerializeToFile(FILE* fp) const override;
 

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -114,6 +114,20 @@ void PruneExpiredPrefixMatchCache(
 } // namespace
 
 class PrefixMatch::Table {
+private:
+  struct Candidate {
+    bool hasValue = false;
+    size_t dictOrder = 0;
+    size_t keyLength = 0;
+    std::string key;
+    std::string value;
+  };
+
+  struct Node {
+    Candidate candidate;
+    std::unordered_map<uint32_t, std::unique_ptr<Node>> children;
+  };
+
 public:
   Table() {}
 
@@ -125,6 +139,25 @@ public:
   }
 
   PrefixMatch::Match MatchPrefix(const char* word, size_t len) const {
+    const Candidate* c = MatchPrefixCandidate(word, len);
+    if (c != nullptr) {
+      return Match{true, c->keyLength, &c->key, &c->value};
+    }
+    return Match{false, 0, nullptr, nullptr};
+  }
+
+  PrefixMatchView MatchPrefixView(const char* word, size_t len) const {
+    const Candidate* c = MatchPrefixCandidate(word, len);
+    if (c != nullptr) {
+      return PrefixMatchView{true, c->keyLength,
+                             std::string_view(c->key),
+                             std::string_view(c->value)};
+    }
+    return PrefixMatchView{};
+  }
+
+private:
+  const Candidate* MatchPrefixCandidate(const char* word, size_t len) const {
     const Node* node = &root;
     const Candidate* matchedCandidate = nullptr;
     for (const char* pstr = word; pstr < word + len;) {
@@ -147,26 +180,8 @@ public:
         matchedCandidate = &node->candidate;
       }
     }
-    if (matchedCandidate != nullptr) {
-      return Match{true, matchedCandidate->keyLength, &matchedCandidate->key,
-                   &matchedCandidate->value};
-    }
-    return Match{false, 0, nullptr, nullptr};
+    return matchedCandidate;
   }
-
-private:
-  struct Candidate {
-    bool hasValue = false;
-    size_t dictOrder = 0;
-    size_t keyLength = 0;
-    std::string key;
-    std::string value;
-  };
-
-  struct Node {
-    Candidate candidate;
-    std::unordered_map<uint32_t, std::unique_ptr<Node>> children;
-  };
 
   void AddEntry(const std::string& key, const std::string& value,
                 size_t dictOrder) {
@@ -275,18 +290,28 @@ PrefixMatch::Match PrefixMatch::MatchPrefix(const char* word,
     struct MatchCache {
       std::string key;
       std::string value;
-      size_t keyLength;
     };
-    // The returned key/value pointers are valid until the next MatchPrefix()
-    // call on the same thread.
+    // key/value pointers are valid until the next MatchPrefix() call on this
+    // thread.
     static thread_local MatchCache matchCache;
-    if (singleDict->MatchPrefixValue(word, len, &matchCache.key, &matchCache.value, &matchCache.keyLength)) {
-      return Match{true, matchCache.keyLength, &matchCache.key, &matchCache.value};
+    const PrefixMatchView pv = singleDict->MatchPrefixValue(word, len);
+    if (pv.matched) {
+      matchCache.key = std::string(pv.key);
+      matchCache.value = std::string(pv.value);
+      return Match{true, pv.keyLength, &matchCache.key, &matchCache.value};
     }
     return Match{false, 0, nullptr, nullptr};
   }
 
   return tables->table->MatchPrefix(word, len);
+}
+
+PrefixMatchView PrefixMatch::MatchPrefixView(const char* word,
+                                              size_t len) const {
+  if (singleDict != nullptr) {
+    return singleDict->MatchPrefixValue(word, len);
+  }
+  return tables->table->MatchPrefixView(word, len);
 }
 
 void PrefixMatch::AddDict(const DictPtr& dict, Tables* output,

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "Common.hpp"
+#include "Dict.hpp"
 
 namespace opencc {
 
@@ -37,6 +38,14 @@ public:
   ~PrefixMatch();
 
   Match MatchPrefix(const char* word, size_t len) const;
+
+  /**
+   * Like MatchPrefix but returns non-owning string_view fields.
+   * key is valid for the lifetime of the caller's input buffer.
+   * value is valid for the lifetime of the underlying dictionary (fast-path)
+   * or the lifetime of this PrefixMatch (table-path).
+   */
+  PrefixMatchView MatchPrefixView(const char* word, size_t len) const;
 
 private:
   class Table;

--- a/src/PrefixMatchTest.cpp
+++ b/src/PrefixMatchTest.cpp
@@ -113,4 +113,35 @@ TEST_F(PrefixMatchTest, FastPathSelectsLongestMatch) {
   EXPECT_EQ(m.key->length(), m.keyLength);
 }
 
+TEST_F(PrefixMatchTest, MatchPrefixViewFastPathReturnsViews) {
+  // Single-dict fast-path: key view should point into caller's input buffer,
+  // value view should point into the dict's stable storage (no copy).
+  PrefixMatch pm(marisaDict);
+
+  const std::string query = utf8("清華大學校園");
+  PrefixMatchView v = pm.MatchPrefixView(query.c_str(), query.length());
+
+  EXPECT_TRUE(v.matched);
+  EXPECT_EQ(utf8("清華大學"), std::string(v.key));
+  EXPECT_EQ(utf8("TsinghuaUniversity"), std::string(v.value));
+  EXPECT_EQ(v.key.size(), v.keyLength);
+  // key view must alias the caller's buffer exactly.
+  EXPECT_EQ(query.data(), v.key.data());
+}
+
+TEST_F(PrefixMatchTest, MatchPrefixViewTablePathReturnsViews) {
+  // Table-path (multi-dict): value view points into stable PrefixMatch storage.
+  std::list<DictPtr> dictsMulti = {marisaDict, textDict};
+  DictPtr dictGroupMulti(new DictGroup(dictsMulti));
+  PrefixMatch pm(dictGroupMulti);
+
+  const std::string query = utf8("清華大學校園");
+  PrefixMatchView v = pm.MatchPrefixView(query.c_str(), query.length());
+
+  EXPECT_TRUE(v.matched);
+  EXPECT_EQ(utf8("清華大學"), std::string(v.key));
+  EXPECT_EQ(utf8("TsinghuaUniversity"), std::string(v.value));
+  EXPECT_EQ(v.key.size(), v.keyLength);
+}
+
 } // namespace opencc


### PR DESCRIPTION
Replace the Match struct (which held const std::string* pointers) with a top-level PrefixMatchView struct whose key/value fields are std::string_view. This makes the non-owning, immediate-consumption semantics explicit in the type rather than relying on pointer-lifetime comments.

Detailed Changes:
- **PrefixMatchView**: New top-level struct in the opencc namespace with string_view key/value and default member initializers. PrefixMatch::Match is retained as a using alias for source compatibility.
- **PrefixMatch internals**: Table::MatchPrefix() and the fast-path branch in PrefixMatch::MatchPrefix() now construct PrefixMatchView directly; the empty/no-match case returns a default-initialized PrefixMatchView{}.
- **Callers**: Conversion.cpp uses string::append(string_view) directly; MaxMatchSegmentation.cpp constructs a std::string from the view for AddSegment(), which has no string_view overload.