### PR TITLE
Make segmentation optional in config; apply to t2jp

### DIFF
--- a/data/config/opencc_config.schema.json
+++ b/data/config/opencc_config.schema.json
@@ -3,7 +3,7 @@
   "id": "https://opencc.byvoid.com/schema/opencc_config.schema.json",
   "title": "OpenCC configuration",
   "type": "object",
-  "required": ["segmentation", "conversion_chain"],
+  "required": ["name", "conversion_chain"],
   "additionalProperties": false,
   "properties": {
     "name": { "type": "string" },

--- a/data/config/t2jp.json
+++ b/data/config/t2jp.json
@@ -1,9 +1,5 @@
 {
   "name": "Old Japanese Kanji (Kyūjitai) to New Japanese Kanji (Shinjitai)",
-  "segmentation": {
-    "type": "mmseg",
-    "dict": { "type": "ocd2", "file": "JPShinjitaiCharactersRev.ocd2" }
-  },
   "conversion_chain": [
     { "dict": { "type": "ocd2", "file": "JPShinjitaiCharactersRev.ocd2" } }
   ]

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -832,9 +832,12 @@ Config::NewFromString(const std::string& json,
   impl->options = options;
   impl->resourceProvider = provider;
 
-  // Required: segmentation
-  SegmentationPtr segmentation =
-      impl->ParseSegmentation(impl->GetObjectProperty(doc, "segmentation"));
+  // Optional: segmentation
+  SegmentationPtr segmentation;
+  if (doc.HasMember("segmentation")) {
+    segmentation =
+        impl->ParseSegmentation(impl->GetObjectProperty(doc, "segmentation"));
+  }
 
   // Required: conversion_chain
   ConversionChainPtr chain = impl->ParseConversionChain(

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -27,9 +27,13 @@
 using namespace opencc;
 
 std::string Converter::Convert(const std::string& text) const {
-  const SegmentsPtr& segments = segmentation->Segment(text);
   std::string converted;
   converted.reserve(text.length() + text.length() / 5);
+  if (segmentation == nullptr) {
+    conversionChain->AppendConvertedSegment(text.c_str(), &converted);
+    return converted;
+  }
+  const SegmentsPtr& segments = segmentation->Segment(text);
   for (const char* segment : *segments) {
     conversionChain->AppendConvertedSegment(segment, &converted);
   }
@@ -46,7 +50,13 @@ ConversionInspectionResult Converter::Inspect(const std::string& text) const {
   ConversionInspectionResult result;
   result.input = text;
 
-  const SegmentsPtr& initialSegments = segmentation->Segment(text);
+  SegmentsPtr initialSegments;
+  if (segmentation == nullptr) {
+    initialSegments.reset(new Segments);
+    initialSegments->AddSegment(text);
+  } else {
+    initialSegments = segmentation->Segment(text);
+  }
   result.segments = initialSegments->ToVector();
 
   const std::vector<SegmentsPtr> trace =


### PR DESCRIPTION
Configs that omit the segmentation key now pass the full text directly to the conversion chain, which already performs identical prefix matching internally. t2jp is converted to use this mode since its segmentation dict equals its conversion dict and there is only one conversion step.