### PR TITLE
Add CLI entry point for the Python opencc package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ This document compiles the Open Chinese Convert (OpenCC) project information to 
 - Tools `opencc_dict`, `opencc_phrase_extract` (`src/tools/`) help developers convert dictionary formats and extract phrases.
 - Node.js tests live in `node/test.js`; npm prebuild packaging uses `npm run prebuild` and related scripts in `scripts/`.
 
+### CLI Consistency Follow-up
+- There is ongoing work to align user-facing behavior across the native CLI, npm CLI, and Python CLI. Treat CLI behavior differences as intentional only when they are documented in `README.md` and covered by tests.
+- Known area to unify: `-c/--config` values that omit `.json`. Current target behavior is the npm CLI rule:
+  - Built-in config stems such as `s2t` and `t2s` should resolve to `s2t.json` / `t2s.json`.
+  - Custom config paths should be preserved as given; do not auto-append `.json` for arbitrary filenames.
+- Before changing config resolution rules in one CLI, check the corresponding implementations in `src/tools/CommandLineMain.cpp`, `node/cli.js`, and `python/opencc/__init__.py`, then update tests for all affected surfaces.
+- When possible, add both direct tests and subprocess/integration-style tests so packaging entry points and standalone CLI invocation are covered, not just in-process helper calls.
+
 ## Ecosystem Bindings
 - Python module is located in `python/`, providing the `OpenCC` class through the C API.
 - Node.js extension is in the `node/` directory, using N-API/Node-API to call the core library. The optional `opencc-jieba` npm package lives in `plugins/jieba/node/` and supplies plugin configs, dictionaries, and platform-specific plugin binaries.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Discussion (Telegram): https://t.me/open_chinese_convert
     * 使用 `npm install -g opencc` 命令可安裝 OpenCC Node.js CLI
     * 使用 `npm install -g opencc opencc-jieba` 命令可同時安裝 OpenCC Node.js CLI 及 Jieba 分詞插件
 * [Python](https://pypi.org/project/OpenCC/)
+    * 使用 `pip install opencc` 命令可安裝 Python API 及 Python CLI
 * [More (Repology)](https://repology.org/project/opencc/versions)
 
 ### Prebuilt binaries 預編譯二進位檔
@@ -103,6 +104,17 @@ import opencc
 converter = opencc.OpenCC('s2t.json')
 converter.convert('汉字')  # 漢字
 ```
+
+The Python package also installs a basic CLI:
+
+```sh
+pip install opencc
+opencc -c s2t.json -i input.txt -o output.txt
+```
+
+The Python CLI supports basic text conversion, `--include-tofu-risk-dictionaries`,
+and `--resource-zip`. Diagnostic modes such as `--inspect` and `--segmentation`
+still require the native OpenCC CLI.
 
 ### C++
 
@@ -165,6 +177,11 @@ int main() {
 [Full Document 完整文檔](https://opencc.byvoid.com/docs/)
 
 ### Command Line
+
+Unless otherwise noted, this section describes the native OpenCC CLI built from
+the C++ toolchain. The Python and npm CLIs support basic file/stdin conversion
+only, plus `--include-tofu-risk-dictionaries`; the Python CLI also supports
+`--resource-zip`.
 
 * `opencc --help`
 * `opencc_dict --help`

--- a/python/opencc/BUILD.bazel
+++ b/python/opencc/BUILD.bazel
@@ -4,7 +4,10 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "opencc",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "cli.py",
+    ],
     data = [
         "//data/config",
         "//data/dictionary:binary_dictionaries",

--- a/python/opencc/__init__.py
+++ b/python/opencc/__init__.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 try:
     import opencc_clib
@@ -19,6 +20,7 @@ elif os.path.isdir(_opencc_configdir):
     CONFIGS = [f for f in os.listdir(_opencc_configdir) if f.endswith('.json')]
 else:
     CONFIGS = []
+_CONFIG_STEMS = {config[:-5] for config in CONFIGS}
 
 
 def _append_path_to_env(name: str, path: str) -> None:
@@ -32,16 +34,26 @@ def _append_path_to_env(name: str, path: str) -> None:
     os.environ[name] = value
 
 
+def _normalize_config_name(config: str) -> str:
+    if config.endswith('.json'):
+        return config
+    if config in _CONFIG_STEMS:
+        return config + '.json'
+    return config
+
+
 class OpenCC(opencc_clib._OpenCC):
 
-    def __init__(self, config: str = 't2s') -> None:
-        if not config.endswith('.json'):
-            config += '.json'
-        if not os.path.isfile(config):
+    def __init__(self,
+                 config: str = 't2s',
+                 include_tofu_risk_dictionaries: bool = True,
+                 resource_zip: Optional[str] = None) -> None:
+        config = _normalize_config_name(config)
+        if resource_zip is None and not os.path.isfile(config):
             config_under_share_dir = os.path.join(_opencc_share_dir, config)
             if os.path.isfile(config_under_share_dir):
                 config = config_under_share_dir
-        super().__init__(config)
+        super().__init__(config, include_tofu_risk_dictionaries, resource_zip)
         self.config = config
 
     def convert(self, text: str):

--- a/python/opencc/cli.py
+++ b/python/opencc/cli.py
@@ -1,0 +1,85 @@
+import argparse
+import os
+import sys
+
+import opencc
+
+
+def _build_parser():
+    config_list = '\n'.join(f'  {c}' for c in sorted(opencc.CONFIGS)) or '  (none found)'
+    parser = argparse.ArgumentParser(
+        prog='opencc',
+        description='Open Chinese Convert (OpenCC) Command Line Tool',
+        epilog=f'Built-in configurations:\n{config_list}',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        '-c', '--config',
+        default='s2t.json',
+        metavar='<file>',
+        help='Configuration file (default: s2t.json)',
+    )
+    parser.add_argument(
+        '-i', '--input',
+        metavar='<file>',
+        help='Input file (default: stdin)',
+    )
+    parser.add_argument(
+        '-o', '--output',
+        metavar='<file>',
+        help='Output file (default: stdout)',
+    )
+    parser.add_argument(
+        '--resource-zip',
+        metavar='<file>',
+        help='Load config and dictionaries from a resource zip file',
+    )
+    parser.add_argument(
+        '--include-tofu-risk-dictionaries',
+        action='store_true',
+        default=False,
+        help='Include dictionaries that may output tofu characters',
+    )
+    parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version=f'OpenCC {opencc.__version__}',
+    )
+    return parser
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.input and args.output:
+        try:
+            if os.path.samefile(args.input, args.output):
+                print('opencc: error: input and output refer to the same file', file=sys.stderr)
+                sys.exit(1)
+        except FileNotFoundError:
+            pass
+
+    converter = opencc.OpenCC(
+        args.config,
+        include_tofu_risk_dictionaries=args.include_tofu_risk_dictionaries,
+        resource_zip=args.resource_zip,
+    )
+
+    if args.input:
+        with open(args.input, 'rb') as f:
+            text = f.read().decode('utf-8')
+    else:
+        text = sys.stdin.buffer.read().decode('utf-8')
+
+    result = converter.convert(text)
+
+    if args.output:
+        with open(args.output, 'wb') as f:
+            f.write(result.encode('utf-8'))
+    else:
+        sys.stdout.buffer.write(result.encode('utf-8'))
+
+
+if __name__ == '__main__':
+    main()

--- a/python/tests/BUILD.bazel
+++ b/python/tests/BUILD.bazel
@@ -16,3 +16,16 @@ py_test(
         requirement("exceptiongroup"),
     ],
 )
+
+py_test(
+    name = "test_cli",
+    size = "small",
+    srcs = ["test_cli.py"],
+    imports = [".."],
+    deps = [
+        "//python/opencc",
+        requirement("pytest"),
+        requirement("pygments"),
+        requirement("exceptiongroup"),
+    ],
+)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,224 @@
+import os
+import pathlib
+import pytest
+import subprocess
+import sys
+import zipfile
+
+import opencc.cli
+
+_TEXT_ZIP_CONFIG = """{
+  "name": "Python CLI Resource Zip Test",
+  "segmentation": {
+    "type": "mmseg",
+    "dict": {
+      "type": "text",
+      "file": "STPhrases.txt"
+    }
+  },
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          {
+            "type": "text",
+            "file": "STPhrases.txt"
+          },
+          {
+            "type": "text",
+            "file": "STCharacters.txt"
+          }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "text",
+        "file": "TWPhrases.txt"
+      }
+    }
+  ]
+}
+"""
+
+
+def _write_resource_zip(path: pathlib.Path) -> None:
+    with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr('s2twp.json', _TEXT_ZIP_CONFIG)
+        archive.writestr('STPhrases.txt', "打印机\t印表機\n")
+        archive.writestr('STCharacters.txt', "鼠\t鼠\n标\t標\n")
+        archive.writestr('TWPhrases.txt', "鼠標\t滑鼠\n")
+
+
+def _write_custom_config(config_path: pathlib.Path, dict_path: pathlib.Path) -> None:
+    config_path.write_text(
+        '{\n'
+        '  "name": "Python CLI Custom Config Test",\n'
+        '  "segmentation": {\n'
+        '    "type": "mmseg",\n'
+        '    "dict": {\n'
+        '      "type": "text",\n'
+        f'      "file": "{dict_path.name}"\n'
+        '    }\n'
+        '  },\n'
+        '  "conversion_chain": [\n'
+        '    {\n'
+        '      "dict": {\n'
+        '        "type": "text",\n'
+        f'        "file": "{dict_path.name}"\n'
+        '      }\n'
+        '    }\n'
+        '  ]\n'
+        '}\n',
+        encoding='utf-8',
+    )
+    dict_path.write_text('鼠标\t滑鼠\n', encoding='utf-8')
+
+
+def _run_cli(monkeypatch, *args):
+    monkeypatch.setattr(sys, 'argv', ['opencc', *args])
+    opencc.cli.main()
+
+
+def _subprocess_env():
+    env = os.environ.copy()
+    pythonpath_entries = [p for p in sys.path if p]
+    if env.get('PYTHONPATH'):
+        pythonpath_entries.append(env['PYTHONPATH'])
+    env['PYTHONPATH'] = os.pathsep.join(pythonpath_entries)
+    return env
+
+
+def test_cli_skips_tofu_risk_dictionaries_by_default(tmp_path, monkeypatch):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    input_path.write_text('㑮', encoding='utf-8')
+
+    _run_cli(
+        monkeypatch,
+        '-c', 't2s.json',
+        '-i', str(input_path),
+        '-o', str(output_path),
+    )
+
+    assert output_path.read_text(encoding='utf-8') == '㑮'
+
+
+def test_cli_include_tofu_risk_dictionaries_flag(tmp_path, monkeypatch):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    input_path.write_text('㑮', encoding='utf-8')
+
+    _run_cli(
+        monkeypatch,
+        '-c', 't2s.json',
+        '-i', str(input_path),
+        '-o', str(output_path),
+        '--include-tofu-risk-dictionaries',
+    )
+
+    assert output_path.read_text(encoding='utf-8') == '𫝈'
+
+
+def test_cli_rejects_same_input_and_output_file(tmp_path, monkeypatch, capsys):
+    input_path = tmp_path / 'same.txt'
+    input_path.write_text('汉字', encoding='utf-8')
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_cli(
+            monkeypatch,
+            '-c', 's2t.json',
+            '-i', str(input_path),
+            '-o', str(pathlib.Path(input_path)),
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert 'input and output refer to the same file' in captured.err
+
+
+def test_cli_resource_zip_support(tmp_path, monkeypatch):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    resource_zip = tmp_path / 'opencc-resources.zip'
+    input_path.write_text('打印机和鼠标', encoding='utf-8')
+    _write_resource_zip(resource_zip)
+
+    _run_cli(
+        monkeypatch,
+        '-c', 's2twp.json',
+        '-i', str(input_path),
+        '-o', str(output_path),
+        '--resource-zip', str(resource_zip),
+    )
+
+    assert output_path.read_text(encoding='utf-8') == '印表機和滑鼠'
+
+
+def test_cli_subprocess_integration(tmp_path):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    resource_zip = tmp_path / 'opencc-resources.zip'
+    input_path.write_text('打印机和鼠标', encoding='utf-8')
+    _write_resource_zip(resource_zip)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-m',
+            'opencc.cli',
+            '-c',
+            's2twp.json',
+            '-i',
+            str(input_path),
+            '-o',
+            str(output_path),
+            '--resource-zip',
+            str(resource_zip),
+        ],
+        capture_output=True,
+        text=True,
+        env=_subprocess_env(),
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.read_text(encoding='utf-8') == '印表機和滑鼠'
+
+
+def test_cli_builtin_config_stem_supports_omitting_json(tmp_path, monkeypatch):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    input_path.write_text('汉字', encoding='utf-8')
+
+    _run_cli(
+        monkeypatch,
+        '-c', 's2t',
+        '-i', str(input_path),
+        '-o', str(output_path),
+    )
+
+    assert output_path.read_text(encoding='utf-8') == '漢字'
+
+
+def test_cli_custom_config_path_without_json_extension(tmp_path, monkeypatch):
+    input_path = tmp_path / 'input.txt'
+    output_path = tmp_path / 'output.txt'
+    config_path = tmp_path / 'custom-config'
+    dict_path = tmp_path / 'custom-dict.txt'
+    input_path.write_text('鼠标', encoding='utf-8')
+    _write_custom_config(config_path, dict_path)
+
+    _run_cli(
+        monkeypatch,
+        '-c', str(config_path),
+        '-i', str(input_path),
+        '-o', str(output_path),
+    )
+
+    assert output_path.read_text(encoding='utf-8') == '滑鼠'
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv[1:]))

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -52,32 +52,6 @@ def _write_resource_zip(path: str) -> None:
         archive.writestr('TWPhrases.txt', "鼠標\t滑鼠\n")
 
 
-def _write_custom_config(config_path: str, dict_path: str) -> None:
-    with open(config_path, 'w', encoding='utf-8') as config_file:
-        config_file.write(
-            '{\n'
-            '  "name": "Python Custom Config Test",\n'
-            '  "segmentation": {\n'
-            '    "type": "mmseg",\n'
-            '    "dict": {\n'
-            '      "type": "text",\n'
-            f'      "file": "{os.path.basename(dict_path)}"\n'
-            '    }\n'
-            '  },\n'
-            '  "conversion_chain": [\n'
-            '    {\n'
-            '      "dict": {\n'
-            '        "type": "text",\n'
-            f'        "file": "{os.path.basename(dict_path)}"\n'
-            '      }\n'
-            '    }\n'
-            '  ]\n'
-            '}\n'
-        )
-    with open(dict_path, 'w', encoding='utf-8') as dict_file:
-        dict_file.write('鼠标\t滑鼠\n')
-
-
 def test_import():
     import opencc  # noqa
 
@@ -149,15 +123,10 @@ def test_builtin_config_stem_is_normalized():
     assert opencc.OpenCC('s2t').convert('汉字') == '漢字'
 
 
-def test_custom_config_path_without_json_extension_is_preserved(tmp_path):
+def test_custom_config_path_without_json_extension_is_preserved():
     import opencc
 
-    config_path = tmp_path / 'custom-config'
-    dict_path = tmp_path / 'custom-dict.txt'
-    _write_custom_config(str(config_path), str(dict_path))
-
-    converter = opencc.OpenCC(str(config_path))
-    assert converter.convert('鼠标') == '滑鼠'
+    assert opencc._normalize_config_name('custom-config') == 'custom-config'
 
 
 if __name__ == "__main__":

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -2,10 +2,80 @@ import json
 import os
 import pytest
 import sys
+import zipfile
 
 _this_dir = os.path.dirname(os.path.abspath(__file__))
 _opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
 _testcases_path = os.path.join(_opencc_rootdir, 'test', 'testcases', 'testcases.json')
+
+_TEXT_ZIP_CONFIG = """{
+  "name": "Python Resource Zip Test",
+  "segmentation": {
+    "type": "mmseg",
+    "dict": {
+      "type": "text",
+      "file": "STPhrases.txt"
+    }
+  },
+  "conversion_chain": [
+    {
+      "dict": {
+        "type": "group",
+        "dicts": [
+          {
+            "type": "text",
+            "file": "STPhrases.txt"
+          },
+          {
+            "type": "text",
+            "file": "STCharacters.txt"
+          }
+        ]
+      }
+    },
+    {
+      "dict": {
+        "type": "text",
+        "file": "TWPhrases.txt"
+      }
+    }
+  ]
+}
+"""
+
+
+def _write_resource_zip(path: str) -> None:
+    with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr('s2twp.json', _TEXT_ZIP_CONFIG)
+        archive.writestr('STPhrases.txt', "打印机\t印表機\n")
+        archive.writestr('STCharacters.txt', "鼠\t鼠\n标\t標\n")
+        archive.writestr('TWPhrases.txt', "鼠標\t滑鼠\n")
+
+
+def _write_custom_config(config_path: str, dict_path: str) -> None:
+    with open(config_path, 'w', encoding='utf-8') as config_file:
+        config_file.write(
+            '{\n'
+            '  "name": "Python Custom Config Test",\n'
+            '  "segmentation": {\n'
+            '    "type": "mmseg",\n'
+            '    "dict": {\n'
+            '      "type": "text",\n'
+            f'      "file": "{os.path.basename(dict_path)}"\n'
+            '    }\n'
+            '  },\n'
+            '  "conversion_chain": [\n'
+            '    {\n'
+            '      "dict": {\n'
+            '        "type": "text",\n'
+            f'        "file": "{os.path.basename(dict_path)}"\n'
+            '      }\n'
+            '    }\n'
+            '  ]\n'
+            '}\n'
+        )
+    with open(dict_path, 'w', encoding='utf-8') as dict_file:
+        dict_file.write('鼠标\t滑鼠\n')
 
 
 def test_import():
@@ -49,6 +119,45 @@ def test_conversion():
         for input_text, ans in cases:
             assert converter.convert(input_text) == ans, \
                 'Failed to convert {} for {} -> {}'.format(cfg, input_text, ans)
+
+
+def test_include_tofu_risk_dictionaries_option():
+    import opencc
+
+    assert opencc.OpenCC('t2s.json').convert('㑮') == '𫝈'
+    assert opencc.OpenCC(
+        't2s.json',
+        include_tofu_risk_dictionaries=False,
+    ).convert('㑮') == '㑮'
+
+
+def test_resource_zip_text_dictionary_support(tmp_path):
+    import opencc
+
+    resource_zip = tmp_path / 'opencc-resources.zip'
+    _write_resource_zip(str(resource_zip))
+    converter = opencc.OpenCC(
+        's2twp.json',
+        resource_zip=str(resource_zip),
+    )
+    assert converter.convert('打印机和鼠标') == '印表機和滑鼠'
+
+
+def test_builtin_config_stem_is_normalized():
+    import opencc
+
+    assert opencc.OpenCC('s2t').convert('汉字') == '漢字'
+
+
+def test_custom_config_path_without_json_extension_is_preserved(tmp_path):
+    import opencc
+
+    config_path = tmp_path / 'custom-config'
+    dict_path = tmp_path / 'custom-dict.txt'
+    _write_custom_config(str(config_path), str(dict_path))
+
+    converter = opencc.OpenCC(str(config_path))
+    assert converter.convert('鼠标') == '滑鼠'
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,11 @@ setuptools.setup(
         'bdist_wheel': BDistWheelCommand,
     },
     setup_requires=setup_requires,
+    entry_points={
+        'console_scripts': [
+            'opencc=opencc.cli:main',
+        ],
+    },
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -37,7 +37,8 @@ struct InternalData {
 
   static InternalData* NewInternalData(const std::string& configFileName,
                                        const std::vector<std::string>& paths,
-                                       const char* argv0) {
+                                       const char* argv0,
+                                       const ConfigLoadOptions& options) {
     try {
       Config config;
 #ifdef BAZEL
@@ -55,10 +56,12 @@ struct InternalData {
         paths_with_runfiles.push_back(
             bazel_runfiles->Rlocation("_main/data/dictionary"));
         return new InternalData(
-            config.NewFromFile(configFileName, paths_with_runfiles, argv0));
+            config.NewFromFile(configFileName, paths_with_runfiles, argv0,
+                               options));
       }
 #endif
-      return new InternalData(config.NewFromFile(configFileName, paths, argv0));
+      return new InternalData(
+          config.NewFromFile(configFileName, paths, argv0, options));
     } catch (Exception& ex) {
       throw std::runtime_error(ex.what());
     }
@@ -66,10 +69,12 @@ struct InternalData {
 
   static InternalData* NewInternalData(
       const std::string& configFileName,
-      const std::shared_ptr<ResourceProvider>& provider) {
+      const std::shared_ptr<ResourceProvider>& provider,
+      const ConfigLoadOptions& options) {
     try {
       Config config;
-      return new InternalData(config.NewFromFile(configFileName, provider));
+      return new InternalData(
+          config.NewFromFile(configFileName, provider, options));
     } catch (Exception& ex) {
       throw std::runtime_error(ex.what());
     }
@@ -79,21 +84,43 @@ struct InternalData {
 } // namespace
 
 SimpleConverter::SimpleConverter(const std::string& configFileName)
-    : SimpleConverter(configFileName, std::vector<std::string>()) {}
+    : SimpleConverter(configFileName, ConfigLoadOptions()) {}
+
+SimpleConverter::SimpleConverter(const std::string& configFileName,
+                                 const ConfigLoadOptions& options)
+    : SimpleConverter(configFileName, std::vector<std::string>(), options) {}
 
 SimpleConverter::SimpleConverter(const std::string& configFileName,
                                  const std::vector<std::string>& paths)
-    : SimpleConverter(configFileName, paths, nullptr) {}
+    : SimpleConverter(configFileName, paths, ConfigLoadOptions()) {}
+
+SimpleConverter::SimpleConverter(const std::string& configFileName,
+                                 const std::vector<std::string>& paths,
+                                 const ConfigLoadOptions& options)
+    : SimpleConverter(configFileName, paths, nullptr, options) {}
 
 SimpleConverter::SimpleConverter(const std::string& configFileName,
                                  const std::vector<std::string>& paths,
                                  const char* argv0)
+    : SimpleConverter(configFileName, paths, argv0, ConfigLoadOptions()) {}
+
+SimpleConverter::SimpleConverter(const std::string& configFileName,
+                                 const std::vector<std::string>& paths,
+                                 const char* argv0,
+                                 const ConfigLoadOptions& options)
     : internalData(
-          InternalData::NewInternalData(configFileName, paths, argv0)) {}
+          InternalData::NewInternalData(configFileName, paths, argv0,
+                                        options)) {}
 
 SimpleConverter::SimpleConverter(const std::string& configFileName,
                                  std::shared_ptr<ResourceProvider> provider)
-    : internalData(InternalData::NewInternalData(configFileName, provider)) {}
+    : SimpleConverter(configFileName, provider, ConfigLoadOptions()) {}
+
+SimpleConverter::SimpleConverter(const std::string& configFileName,
+                                 std::shared_ptr<ResourceProvider> provider,
+                                 const ConfigLoadOptions& options)
+    : internalData(
+          InternalData::NewInternalData(configFileName, provider, options)) {}
 
 SimpleConverter::~SimpleConverter() { delete (InternalData*)internalData; }
 

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -35,6 +35,8 @@
 
 namespace opencc {
 
+struct ConfigLoadOptions;
+
 /**
  * A high level converter
  * This interface does not require C++11 to compile.
@@ -51,10 +53,28 @@ public:
   /**
    * Constructor of SimpleConverter
    * @param configFileName File name of configuration.
+   * @param options Configuration loading options.
+   */
+  SimpleConverter(const std::string& configFileName,
+                  const ConfigLoadOptions& options);
+
+  /**
+   * Constructor of SimpleConverter
+   * @param configFileName File name of configuration.
    * @param paths Additional paths to locate configuration and dictionary files.
    */
   SimpleConverter(const std::string& configFileName,
                   const std::vector<std::string>& paths);
+
+  /**
+   * Constructor of SimpleConverter
+   * @param configFileName File name of configuration.
+   * @param paths Additional paths to locate configuration and dictionary files.
+   * @param options Configuration loading options.
+   */
+  SimpleConverter(const std::string& configFileName,
+                  const std::vector<std::string>& paths,
+                  const ConfigLoadOptions& options);
 
   /**
    * Constructor of SimpleConverter
@@ -69,11 +89,34 @@ public:
   /**
    * Constructor of SimpleConverter
    * @param configFileName File name of configuration.
+   * @param paths Additional paths to locate configuration and dictionary files.
+   * @param argv0 Path of the executable (argv[0]), in addition to additional
+   * paths.
+   * @param options Configuration loading options.
+   */
+  SimpleConverter(const std::string& configFileName,
+                  const std::vector<std::string>& paths, const char* argv0,
+                  const ConfigLoadOptions& options);
+
+  /**
+   * Constructor of SimpleConverter
+   * @param configFileName File name of configuration.
    * @param provider Provider used to locate dictionary/resource files
    * referenced by the configuration.
    */
   SimpleConverter(const std::string& configFileName,
                   std::shared_ptr<ResourceProvider> provider);
+
+  /**
+   * Constructor of SimpleConverter
+   * @param configFileName File name of configuration.
+   * @param provider Provider used to locate dictionary/resource files
+   * referenced by the configuration.
+   * @param options Configuration loading options.
+   */
+  SimpleConverter(const std::string& configFileName,
+                  std::shared_ptr<ResourceProvider> provider,
+                  const ConfigLoadOptions& options);
 
   ~SimpleConverter();
 

--- a/src/py_opencc.cpp
+++ b/src/py_opencc.cpp
@@ -16,14 +16,33 @@
  * limitations under the License.
  */
 
+#include "Config.hpp"
+#include "ResourceProvider.hpp"
 #include "opencc.h"
+#include <memory>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(opencc_clib, m) {
   py::class_<opencc::SimpleConverter>(m, "_OpenCC")
-      .def(py::init<const std::string&>())
+      .def(py::init([](const std::string& configFileName,
+                       bool includeTofuRiskDictionaries,
+                       py::object resourceZip) {
+             opencc::ConfigLoadOptions options;
+             options.includeTofuRiskDictionaries = includeTofuRiskDictionaries;
+             if (!resourceZip.is_none()) {
+               std::shared_ptr<opencc::ResourceProvider> provider(
+                   new opencc::ZipResourceProvider(
+                       resourceZip.cast<std::string>()));
+               return new opencc::SimpleConverter(configFileName, provider,
+                                                  options);
+             }
+             return new opencc::SimpleConverter(configFileName, options);
+           }),
+           py::arg("config"),
+           py::arg("include_tofu_risk_dictionaries") = true,
+           py::arg("resource_zip") = py::none())
       .def("convert", py::overload_cast<const char*, size_t>(
                           &opencc::SimpleConverter::Convert, py::const_));
 


### PR DESCRIPTION
Add the Python opencc console entry point, support tofu-risk filtering and resource zip loading, and align built-in config stem handling with the npm CLI.

Detailed Changes:
- **Python CLI and bindings**:
  - Wire setup.py, pybind bindings, and python/opencc wrappers to expose the CLI and resource zip support.
  - Keep built-in config stems like s2t consistent with the npm CLI while preserving custom config paths as given.
- **Tests and documentation**:
  - Add direct and subprocess-style Python CLI tests, and make resource-zip tests self-contained for plain pytest and Bazel.
  - Document the Python CLI in README.md and record the remaining cross-CLI consistency follow-up in AGENTS.md.