### PR TITLE
Fix Python Bazel test entrypoints on Windows

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -138,16 +138,17 @@ jobs:
           set +e
           bazel test --show_timestamps --test_output=all //src/... //data/... //test/... //python/... //plugins/...
           status=$?
+          bash scripts/collect_bazel_testlogs.sh bazel-testlogs-artifact
           if [ "$status" -ne 0 ]; then
             echo "Bazel test failed with exit code ${status}."
             testlogs_dir="$(bazel info bazel-testlogs 2>/dev/null)"
             echo "Bazel testlogs dir: ${testlogs_dir}"
             echo "Failing test logs:"
             find "${testlogs_dir}" -name test.log -print
-            if [ -f "${testlogs_dir}/python/tests/test_opencc/test.log" ]; then
-              echo "===== //python/tests:test_opencc test.log ====="
-              sed -n '1,240p' "${testlogs_dir}/python/tests/test_opencc/test.log"
-            fi
+            while IFS= read -r log; do
+              echo "===== ${log#"${testlogs_dir}/"} ====="
+              sed -n '1,240p' "${log}"
+            done < <(find "${testlogs_dir}" -name test.log -print | sort)
           fi
           exit "$status"
       - name: upload artifacts
@@ -156,5 +157,4 @@ jobs:
         with:
           name: opencc-${{ env.VERSION }}-bazel-${{ matrix.os }}
           path: |
-            bazel-testlogs/**/*.log
-            bazel-testlogs/**
+            bazel-testlogs-artifact/**

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Build and install
         run: python -m pip install .
       - name: Test with pytest
-        run: pytest python/ --junitxml=pytest.xml
+        run: python python/tests/run_pytest_with_artifacts.py python --artifact-dir python-test-artifacts/unit-test --artifact-prefix pytest
       - name: upload artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: opencc-${{ env.VERSION }}-python-${{ matrix.python-version }}
           path: |
-            pytest.xml
+            python-test-artifacts/unit-test/**
 
   test-pypi:
     permissions:
@@ -94,7 +94,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "pytest {project}/python/tests"
+          CIBW_TEST_COMMAND: "python {project}/python/tests/run_pytest_with_artifacts.py {project}/python/tests --artifact-dir {project}/python-test-artifacts/cibuildwheel --artifact-prefix pytest"
 
       - name: upload artifacts
         if: ${{ always() }}
@@ -103,3 +103,4 @@ jobs:
           name: opencc-${{ env.VERSION }}-pypi-${{ matrix.os }}-${{ matrix.python-build }}
           path: |
             wheelhouse/*.whl
+            python-test-artifacts/cibuildwheel/**

--- a/python/opencc/__init__.py
+++ b/python/opencc/__init__.py
@@ -1,14 +1,9 @@
+import importlib.util
 import os
 from typing import Optional
 
-try:
-    import opencc_clib
-except ImportError:
-    from opencc.clib import opencc_clib
-
 __all__ = ['CONFIGS', 'OpenCC', '__version__']
 
-__version__ = opencc_clib.__version__
 _this_dir = os.path.dirname(os.path.abspath(__file__))
 _opencc_share_dir = os.path.join(_this_dir, 'clib', 'share', 'opencc')
 _opencc_rootdir = os.path.abspath(os.path.join(_this_dir, '..', '..'))
@@ -30,8 +25,51 @@ def _append_path_to_env(name: str, path: str) -> None:
     if value == '':
         value = path
     else:
-        value += f':{path}'
+        value += f'{os.pathsep}{path}'
     os.environ[name] = value
+
+
+def _load_opencc_clib_from_runfiles():
+    candidate_dirs = [
+        os.path.join(_opencc_rootdir, 'src', 'pyd'),
+        os.path.join(_opencc_rootdir, 'src'),
+    ]
+    candidate_names = [
+        'opencc_clib.pyd',
+        'opencc_clib.so',
+    ]
+    for directory in candidate_dirs:
+        if not os.path.isdir(directory):
+            continue
+        for entry in os.listdir(directory):
+            if entry == 'opencc_clib.pyd' or entry.startswith('opencc_clib.') or entry.startswith('opencc_clib.cpython-'):
+                candidate_names.append(entry)
+    candidate_paths = []
+    for directory in candidate_dirs:
+        for name in candidate_names:
+            candidate_paths.append(os.path.join(directory, name))
+    for candidate in candidate_paths:
+        if not os.path.isfile(candidate):
+            continue
+        spec = importlib.util.spec_from_file_location('opencc_clib', candidate)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    raise ImportError('opencc_clib not found in Bazel runfiles')
+
+
+try:
+    import opencc_clib
+except ImportError:
+    try:
+        from opencc.clib import opencc_clib
+    except ImportError:
+        opencc_clib = _load_opencc_clib_from_runfiles()
+
+
+__version__ = opencc_clib.__version__
 
 
 def _normalize_config_name(config: str) -> str:

--- a/python/tests/run_pytest_with_artifacts.py
+++ b/python/tests/run_pytest_with_artifacts.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Run pytest and capture both JUnit XML and console output.',
+    )
+    parser.add_argument(
+        'paths',
+        nargs='*',
+        default=['python/tests'],
+        help='Test paths passed to pytest.',
+    )
+    parser.add_argument(
+        '--artifact-dir',
+        default='python-test-artifacts',
+        help='Directory for generated pytest artifacts.',
+    )
+    parser.add_argument(
+        '--artifact-prefix',
+        default='pytest',
+        help='Filename prefix for generated pytest artifacts.',
+    )
+    args, passthrough = parser.parse_known_args()
+
+    artifact_dir = os.path.abspath(args.artifact_dir)
+    os.makedirs(artifact_dir, exist_ok=True)
+
+    junit_path = os.path.join(artifact_dir, f'{args.artifact_prefix}.xml')
+    log_path = os.path.join(artifact_dir, f'{args.artifact_prefix}.log')
+
+    command = [
+        sys.executable,
+        '-m',
+        'pytest',
+        *args.paths,
+        f'--junitxml={junit_path}',
+        *passthrough,
+    ]
+
+    print(f'Running: {" ".join(command)}')
+    print(f'Writing JUnit XML to: {junit_path}')
+    print(f'Writing console log to: {log_path}')
+
+    with open(log_path, 'w', encoding='utf-8', newline='') as log_file:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            sys.stdout.write(line)
+            log_file.write(line)
+        return process.wait()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -221,4 +221,4 @@ def test_cli_custom_config_path_without_json_extension(tmp_path, monkeypatch):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv[1:]))
+    sys.exit(pytest.main([os.path.abspath(__file__), *sys.argv[1:]]))

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -130,4 +130,4 @@ def test_custom_config_path_without_json_extension_is_preserved():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv[1:]))
+    sys.exit(pytest.main([os.path.abspath(__file__), *sys.argv[1:]]))

--- a/scripts/collect_bazel_testlogs.sh
+++ b/scripts/collect_bazel_testlogs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_dir="${1:-bazel-testlogs-artifact}"
+
+testlogs_dir="$(bazel info bazel-testlogs 2>/dev/null || true)"
+if [ -z "${testlogs_dir}" ] || [ ! -d "${testlogs_dir}" ]; then
+  echo "No Bazel testlogs directory found."
+  exit 0
+fi
+
+rm -rf "${artifact_dir}"
+mkdir -p "${artifact_dir}"
+
+while IFS= read -r -d '' file; do
+  relative_path="${file#"${testlogs_dir}/"}"
+  destination="${artifact_dir}/${relative_path}"
+  mkdir -p "$(dirname "${destination}")"
+  cp "${file}" "${destination}"
+done < <(
+  find "${testlogs_dir}" \
+    \( -name test.log -o -name test.xml -o -name outputs.zip -o -name test.outputs_manifest \) \
+    -type f -print0
+)
+
+echo "Collected Bazel test logs into ${artifact_dir}"


### PR DESCRIPTION
Load the Python extension module from Bazel runfiles when package-style imports are unavailable, and constrain direct pytest entrypoints to the current test file. This avoids Windows runfiles import failures and accidental collection of dictionary artifacts as tests.