### PR TITLE
Place Python extension in Bazel package runfiles

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -136,7 +136,7 @@ jobs:
           MSYS_NO_PATHCONV: 1
         run: |
           set +e
-          bazel test --show_timestamps --test_output=all //src/... //data/... //test/... //python/... //plugins/...
+          bazel test --show_timestamps --test_output=all --nocache_test_results //src/... //data/... //test/... //python/... //plugins/...
           status=$?
           bash scripts/collect_bazel_testlogs.sh bazel-testlogs-artifact
           if [ "$status" -ne 0 ]; then

--- a/python/opencc/.gitignore
+++ b/python/opencc/.gitignore
@@ -1,3 +1,4 @@
 version.py
-clib/
+clib/*
 !clib/__init__.py
+!clib/BUILD.bazel

--- a/python/opencc/BUILD.bazel
+++ b/python/opencc/BUILD.bazel
@@ -12,7 +12,10 @@ py_library(
         "//data/config",
         "//data/dictionary:binary_dictionaries",
         "//data/dictionary:text_dictionaries",
-    ],
+    ] + select({
+        "@platforms//os:windows": ["//python/opencc/clib:opencc_clib_pyd"],
+        "//conditions:default": [],
+    }),
     imports = [".."],
     deps = ["//src:py_opencc"],
 )

--- a/python/opencc/clib/BUILD.bazel
+++ b/python/opencc/clib/BUILD.bazel
@@ -1,6 +1,8 @@
 package(default_visibility = ["//python/opencc:__pkg__"])
 
-alias(
+genrule(
     name = "opencc_clib_pyd",
-    actual = "//src/pyd:opencc_clib_pyd_copy",
+    srcs = ["//src/pyd:opencc_clib_pyd_copy"],
+    outs = ["opencc_clib.pyd"],
+    cmd = "cp $< $@",
 )

--- a/python/opencc/clib/BUILD.bazel
+++ b/python/opencc/clib/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//python/opencc:__pkg__"])
+
+alias(
+    name = "opencc_clib_pyd",
+    actual = "//src/pyd:opencc_clib_pyd_copy",
+)

--- a/src/pyd/BUILD.bazel
+++ b/src/pyd/BUILD.bazel
@@ -6,5 +6,8 @@ genrule(
     srcs = ["//src:opencc_clib"],
     outs = ["opencc_clib.pyd"],
     cmd = "cp $< $@",
-    visibility = ["//src:__pkg__"],
+    visibility = [
+        "//python/opencc/clib:__pkg__",
+        "//src:__pkg__",
+    ],
 )


### PR DESCRIPTION
Add the Windows pybind extension to the opencc.clib package path used by the Python package. This lets Bazel py_test targets import opencc.clib.opencc_clib consistently with the wheel layout.

Allow the opencc.clib Bazel package to depend on the copied Windows pybind extension.