### PR TITLE
Diagnose Windows test failure: disable BuildBuddy and fix startup symlink flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,12 @@
+# Enable Windows runfiles symlinks. Bazel does not support startup:windows, so
+# this must be a plain startup option; non-Windows Bazel ignores it with a
+# warning-free no-op.
+startup --windows_enable_symlinks
+
 # Automatically apply platform-specific config sections (e.g. build:windows)
 common --enable_platform_specific_config
 
 # Enable C++17 for MSVC on Windows
-startup:windows --windows_enable_symlinks
 build:windows --cxxopt=/std:c++17
 build:windows --host_cxxopt=/std:c++17
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Configure BuildBuddy
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && runner.os != 'Windows'
         shell: bash
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}


### PR DESCRIPTION
Disable BuildBuddy remote cache on Windows CI runners to determine whether the golden_convert_test failure is caused by remote cache hits not materialising command_line.exe on the local disk.

Fix startup:windows --windows_enable_symlinks, which is not valid Bazel rcfile syntax and was silently ignored; use plain startup --windows_enable_symlinks so the flag is applied on all platforms (non-Windows ignores it with no warning).