### PR TITLE
Add AppVeyor-based Python smoke test for CLI and API

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,13 +19,16 @@ environment:
     # Build plain C++
     - nodejs_version: none
 
+    # Build Python package from source and smoke-test the installed wheel.
+    - nodejs_version: python
+
 platform:
   - x64
 
 for:
 - matrix:
-    except:
-      - nodejs_version: none
+    only:
+      - nodejs_version: stable
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform
     - npm -g i npm@latest
@@ -130,3 +133,45 @@ for:
     name: OpenCCWinGetManifests
   - path: opencc-smoke-output.zip
     name: OpenCCSmokeOutput
+
+- matrix:
+    only:
+      - nodejs_version: python
+  install:
+    - py -3 --version
+    - py -3 -m pip install --upgrade pip setuptools wheel
+  build_script:
+    - py -3 -m pip wheel --no-deps --wheel-dir python-smoke-dist .
+    - for %%F in (python-smoke-dist\*.whl) do set OPENCC_PY_WHL=%%~fF
+    - py -3 -m venv python-smoke-venv
+    - python-smoke-venv\Scripts\python.exe -m pip install "%OPENCC_PY_WHL%"
+  test_script:
+    - chcp 65001
+    - python-smoke-venv\Scripts\opencc.exe --version
+    - python-smoke-venv\Scripts\opencc.exe --help >nul
+    - mkdir python-smoke\測試
+    - echo 打印机和鼠标 > python-smoke\測試\簡體輸入.txt
+    - echo 開放中文轉換 > python-smoke\測試\繁體輸入.txt
+    - echo [opencc python smoke] s2twp input
+    - type python-smoke\測試\簡體輸入.txt
+    - python-smoke-venv\Scripts\opencc.exe -i python-smoke\測試\簡體輸入.txt -o python-smoke\測試\輸出.s2twp.txt -c s2twp
+    - echo [opencc python smoke] s2twp file output
+    - type python-smoke\測試\輸出.s2twp.txt
+    - type python-smoke\測試\簡體輸入.txt | python-smoke-venv\Scripts\opencc.exe -c s2twp > python-smoke\測試\管線.s2twp.txt
+    - echo [opencc python smoke] s2twp pipe output
+    - type python-smoke\測試\管線.s2twp.txt
+    - echo [opencc python smoke] t2s input
+    - type python-smoke\測試\繁體輸入.txt
+    - python-smoke-venv\Scripts\opencc.exe -i python-smoke\測試\繁體輸入.txt -o python-smoke\測試\輸出.t2s.txt -c t2s
+    - echo [opencc python smoke] t2s file output
+    - type python-smoke\測試\輸出.t2s.txt
+    - type python-smoke\測試\繁體輸入.txt | python-smoke-venv\Scripts\opencc.exe -c t2s > python-smoke\測試\管線.t2s.txt
+    - echo [opencc python smoke] t2s pipe output
+    - type python-smoke\測試\管線.t2s.txt
+    - python-smoke-venv\Scripts\python.exe python\tests\pypi_smoke.py
+    - 7z a opencc-python-smoke-output.zip python-smoke\測試\*.txt
+  artifacts:
+  - path: python-smoke-dist\*.whl
+    name: OpenCCPythonWheel
+  - path: opencc-python-smoke-output.zip
+    name: OpenCCPythonSmokeOutput

--- a/python/opencc/__init__.py
+++ b/python/opencc/__init__.py
@@ -1,4 +1,5 @@
 import importlib.util
+import ntpath
 import os
 from typing import Optional
 
@@ -73,7 +74,10 @@ __version__ = opencc_clib.__version__
 
 
 def _normalize_config_name(config: str) -> str:
-    if config.endswith('.json'):
+    basename = ntpath.basename(os.path.basename(config))
+    if basename != config:
+        return config
+    if '.' in basename:
         return config
     if config in _CONFIG_STEMS:
         return config + '.json'

--- a/python/tests/pypi_smoke.py
+++ b/python/tests/pypi_smoke.py
@@ -1,0 +1,43 @@
+import opencc
+
+
+def _check(actual, expected):
+    if actual != expected:
+        raise AssertionError('expected {!r}, got {!r}'.format(expected, actual))
+
+
+def main():
+    print('opencc module:', opencc.__file__)
+    print('opencc version:', opencc.__version__)
+    assert opencc.__version__, '__version__ must be non-empty'
+
+    # Verify that key built-in configs are present in the installed package
+    for config in ('s2t', 's2tw', 's2twp', 's2hk', 's2hkp', 't2s', 't2tw', 't2hk'):
+        config_file = config + '.json'
+        assert (
+            config in opencc.CONFIGS or config_file in opencc.CONFIGS
+        ), '{} or {} not in opencc.CONFIGS'.format(config, config_file)
+
+    # Simplified → Traditional
+    _check(opencc.OpenCC('s2t').convert('汉字'), '漢字')
+
+    # Simplified → Taiwan (with phrase replacement)
+    _check(opencc.OpenCC('s2twp').convert('打印机和鼠标'), '印表機和滑鼠')
+
+    # Simplified → Hong Kong
+    _check(opencc.OpenCC('s2hk').convert('鼠标'), '鼠標')
+
+    # Traditional → Simplified
+    _check(opencc.OpenCC('t2s').convert('開放中文轉換'), '开放中文转换')
+
+    # Taiwan → Simplified (reverse direction)
+    _check(opencc.OpenCC('tw2s').convert('滑鼠'), '鼠标')
+
+    # Config stem without .json suffix resolves correctly
+    _check(opencc.OpenCC('s2t').convert('汉字'), '漢字')
+
+    print('All checks passed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/python/tests/pypi_smoke.py
+++ b/python/tests/pypi_smoke.py
@@ -30,8 +30,11 @@ def main():
     # Traditional → Simplified
     _check(opencc.OpenCC('t2s').convert('開放中文轉換'), '开放中文转换')
 
-    # Taiwan → Simplified (reverse direction)
-    _check(opencc.OpenCC('tw2s').convert('滑鼠'), '鼠标')
+    # Taiwan → Simplified: character-variant conversion only (no vocabulary replacement)
+    _check(opencc.OpenCC('tw2s').convert('台灣'), '台湾')
+
+    # Taiwan → Simplified: with Mainland vocabulary replacement (tw2sp)
+    _check(opencc.OpenCC('tw2sp').convert('滑鼠'), '鼠标')
 
     # Config stem without .json suffix resolves correctly
     _check(opencc.OpenCC('s2t').convert('汉字'), '漢字')

--- a/python/tests/test_opencc.py
+++ b/python/tests/test_opencc.py
@@ -127,6 +127,10 @@ def test_custom_config_path_without_json_extension_is_preserved():
     import opencc
 
     assert opencc._normalize_config_name('custom-config') == 'custom-config'
+    assert opencc._normalize_config_name('custom-config.jsonc') == 'custom-config.jsonc'
+    assert opencc._normalize_config_name('./s2t') == './s2t'
+    assert opencc._normalize_config_name('configs/s2t') == 'configs/s2t'
+    assert opencc._normalize_config_name(r'configs\s2t') == r'configs\s2t'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a Windows AppVeyor smoke job that builds the Python wheel from source, installs it into a virtualenv, and validates both CLI and Python API usage.

Detailed Changes:
- **AppVeyor Smoke Test**:
  - Build the source wheel on Windows and install it into a fresh virtualenv.
  - Exercise opencc.exe with version/help output, file conversion, and pipe conversion in both Simplified-Traditional directions.
- **Python Config Resolution**:
  - Limit .json stem expansion to built-in bare config names so custom paths and explicit extensions remain unchanged.
  - Cover custom extensions and POSIX/Windows path-like config values in Python tests.
- **PyPI Package Smoke**:
  - Add python/tests/pypi_smoke.py to validate package metadata, installed configs, config stem resolution, and representative conversions.
  - Accept both stem and .json config names in the installed CONFIGS listing.