### PR TITLE
Add string_view overloads without breaking C++ ABI

### DIFF
--- a/node/opencc.cc
+++ b/node/opencc.cc
@@ -1,6 +1,7 @@
 #include <napi.h>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "src/Config.hpp"
 #include "src/Converter.hpp"
@@ -110,7 +111,7 @@ public:
 
   ~OpenccBinding() override {}
 
-  std::string Convert(const std::string& input) {
+  std::string Convert(std::string_view input) {
     return converter_->Convert(input);
   }
 
@@ -144,7 +145,7 @@ public:
     const std::string input = ToUtf8String(info[0]);
     std::string output;
     try {
-      output = Convert(input);
+      output = Convert(std::string_view(input));
     } catch (opencc::Exception& e) {
       Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
       return env.Undefined();

--- a/plugins/jieba/include/JiebaSegmentation.hpp
+++ b/plugins/jieba/include/JiebaSegmentation.hpp
@@ -29,6 +29,8 @@ namespace opencc {
 
 class JiebaSegmentation : public Segmentation {
 public:
+  using Segmentation::Segment;
+
   JiebaSegmentation(const std::string& dictPath,
                     const std::string& modelPath,
                     const std::string& userDictPath = "",
@@ -38,6 +40,8 @@ public:
   ~JiebaSegmentation() override;
 
   SegmentsPtr Segment(const std::string& text) const override;
+
+  SegmentsPtr Segment(std::string_view text) const;
 
 private:
   std::unique_ptr<cppjieba::Jieba> jieba_;

--- a/plugins/jieba/src/JiebaSegmentation.cpp
+++ b/plugins/jieba/src/JiebaSegmentation.cpp
@@ -325,3 +325,13 @@ SegmentsPtr JiebaSegmentation::Segment(const std::string& text) const {
   }
   return segments;
 }
+
+SegmentsPtr JiebaSegmentation::Segment(std::string_view text) const {
+  SegmentsPtr segments(new Segments);
+  std::vector<std::string> words;
+  jieba_->Cut(std::string(text), words, true);
+  for (const auto& word : words) {
+    segments->AddSegment(word);
+  }
+  return segments;
+}

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <filesystem>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -229,7 +230,7 @@ protected:
 };
 
 TEST_F(ConfigTest, Convert) {
-  const std::string& converted = converter->Convert(input);
+  const std::string converted = converter->Convert(std::string_view(input));
   EXPECT_EQ(expected, converted);
 }
 
@@ -269,7 +270,7 @@ TEST_F(ConfigTest, DefaultConfigPathFindsAdjacentResources) {
   try {
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(tempDir / "config_test.json"));
-    EXPECT_EQ(expected, tempConverter->Convert(input));
+    EXPECT_EQ(expected, tempConverter->Convert(std::string_view(input)));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -291,7 +292,8 @@ TEST_F(ConfigTest, ExplicitProviderFindsResources) {
         new FilesystemResourceProvider({PathString(resourceDir)}));
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(configDir / "config.json"), provider);
-    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("滑鼠"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -311,7 +313,8 @@ TEST_F(ConfigTest, ExplicitProviderFindsConfigNameAndResources) {
         new FilesystemResourceProvider({PathString(resourceDir)}));
     const ConverterPtr tempConverter =
         config.NewFromFile("provider_config.json", provider);
-    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("滑鼠"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -332,7 +335,8 @@ TEST_F(ConfigTest, ZipProviderFindsConfigNameAndResources) {
         new ZipResourceProvider(PathString(zipPath)));
     const ConverterPtr tempConverter =
         config.NewFromFile("config.json", provider);
-    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("滑鼠"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -374,7 +378,8 @@ TEST_F(ConfigTest, ZipProviderDoesNotOverrideAbsoluteConfigPath) {
         new ZipResourceProvider(PathString(zipPath)));
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(configPath), provider);
-    EXPECT_EQ(utf8("甲"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("甲"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -400,7 +405,8 @@ TEST_F(ConfigTest, ExplicitProviderConfigOverridesInstalledOrCwdConfigName) {
         new FilesystemResourceProvider({PathString(resourceDir)}));
     const ConverterPtr tempConverter =
         config.NewFromFile("config.json", provider);
-    EXPECT_EQ(utf8("乙"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("乙"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
     fs::current_path(originalCwd);
   } catch (...) {
     fs::current_path(originalCwd);
@@ -423,7 +429,8 @@ TEST_F(ConfigTest, RelativeParentDictionaryPathStillWorks) {
   try {
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(configDir / "config.json"));
-    EXPECT_EQ(utf8("滑鼠"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("滑鼠"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -449,7 +456,8 @@ TEST_F(ConfigTest, MultipleSearchPathsUseFirstMatch) {
             {PathString(firstDir), PathString(secondDir)}));
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(configDir / "config.json"), provider);
-    EXPECT_EQ(utf8("第一"), tempConverter->Convert(utf8("鼠标")));
+    EXPECT_EQ(utf8("第一"),
+              tempConverter->Convert(std::string_view(utf8("鼠标"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -518,7 +526,8 @@ TEST_F(ConfigTest, PluginLikeResourcePathSupplementsMainPath) {
             {PathString(mainDir), PathString(pluginDir)}));
     const ConverterPtr tempConverter =
         config.NewFromFile(PathString(configDir / "config.json"), provider);
-    EXPECT_EQ(utf8("伺服器"), tempConverter->Convert(utf8("服务器")));
+    EXPECT_EQ(utf8("伺服器"),
+              tempConverter->Convert(std::string_view(utf8("服务器"))));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;
@@ -540,7 +549,7 @@ TEST_F(ConfigTest, InlineDictBasicConversion) {
 
   const ConverterPtr inlineConverter = config.NewFromString(json, "");
   EXPECT_EQ(utf8("我想吃冰炫風"),
-            inlineConverter->Convert(utf8("我想吃麦旋风")));
+            inlineConverter->Convert(std::string_view(utf8("我想吃麦旋风"))));
 }
 
 TEST_F(ConfigTest, InlineDictInGroupTakesPriorityOverFollowingFileDict) {
@@ -569,7 +578,8 @@ TEST_F(ConfigTest, InlineDictInGroupTakesPriorityOverFollowingFileDict) {
 
   const ConverterPtr inlineConverter =
       config.NewFromString(json, {CONFIG_TEST_DIR_PATH + "/"});
-  EXPECT_EQ(utf8("自訂覆寫"), inlineConverter->Convert(utf8("燕燕于飞")));
+  EXPECT_EQ(utf8("自訂覆寫"),
+            inlineConverter->Convert(std::string_view(utf8("燕燕于飞"))));
 }
 
 TEST_F(ConfigTest, InlineDictOutputStillProcessedByLaterChainStep) {
@@ -607,7 +617,7 @@ TEST_F(ConfigTest, InlineDictOutputStillProcessedByLaterChainStep) {
                   "}\n");
 
   const ConverterPtr inlineConverter = config.NewFromString(json, "");
-  EXPECT_EQ("C", inlineConverter->Convert("A"));
+  EXPECT_EQ("C", inlineConverter->Convert(std::string_view("A")));
 }
 
 TEST_F(ConfigTest, InlineSegmentationDictUsesLongestMatch) {
@@ -639,7 +649,7 @@ TEST_F(ConfigTest, InlineSegmentationDictUsesLongestMatch) {
                   "}\n");
 
   const ConverterPtr inlineConverter = config.NewFromString(json, "");
-  EXPECT_EQ("XD", inlineConverter->Convert("ABCD"));
+  EXPECT_EQ("XD", inlineConverter->Convert(std::string_view("ABCD")));
 }
 
 TEST_F(ConfigTest, InlineDictPreservesExactStringSemantics) {
@@ -656,8 +666,8 @@ TEST_F(ConfigTest, InlineDictPreservesExactStringSemantics) {
       "    }");
 
   const ConverterPtr inlineConverter = config.NewFromString(json, "");
-  EXPECT_EQ("A", inlineConverter->Convert("A"));
-  EXPECT_EQ("B", inlineConverter->Convert(" A "));
+  EXPECT_EQ("A", inlineConverter->Convert(std::string_view("A")));
+  EXPECT_EQ("B", inlineConverter->Convert(std::string_view(" A ")));
 }
 
 TEST_F(ConfigTest, InlineDictValidationErrors) {
@@ -826,7 +836,8 @@ TEST_F(ConfigTest, InlineDictSupportsJsoncCommentsAndTrailingComma) {
                   "}\n");
 
   const ConverterPtr inlineConverter = config.NewFromString(json, "");
-  EXPECT_EQ(utf8("冰炫風"), inlineConverter->Convert(utf8("麦旋风")));
+  EXPECT_EQ(utf8("冰炫風"),
+            inlineConverter->Convert(std::string_view(utf8("麦旋风"))));
 }
 
 TEST_F(ConfigTest, InlineSegmentationAndConversionWorksWithOcd2GroupDicts) {
@@ -873,8 +884,10 @@ TEST_F(ConfigTest, InlineSegmentationAndConversionWorksWithOcd2GroupDicts) {
                   "}\n");
 
   const ConverterPtr inlineConverter = config.NewFromString(json, {ocd2Dir});
-  EXPECT_EQ(utf8("臺灣"), inlineConverter->Convert(utf8("台湾")));
-  EXPECT_EQ(utf8("台灣"), inlineConverter->Convert(utf8("台灣")));
+  EXPECT_EQ(utf8("臺灣"),
+            inlineConverter->Convert(std::string_view(utf8("台湾"))));
+  EXPECT_EQ(utf8("台灣"),
+            inlineConverter->Convert(std::string_view(utf8("台灣"))));
 }
 
 #if defined(_MSC_VER)
@@ -904,7 +917,7 @@ TEST_F(ConfigTest, LoadConfigFromUnicodePath) {
   try {
     const ConverterPtr unicodeConverter =
         config.NewFromFile(tempDir.u8string() + "/config_test.json");
-    EXPECT_EQ(expected, unicodeConverter->Convert(input));
+    EXPECT_EQ(expected, unicodeConverter->Convert(std::string_view(input)));
   } catch (...) {
     fs::remove_all(tempDir);
     throw;

--- a/src/ConversionInspectionTest.cpp
+++ b/src/ConversionInspectionTest.cpp
@@ -22,6 +22,8 @@
 #include "SimpleConverter.hpp"
 #include "TestUtilsUTF8.hpp"
 
+#include <string_view>
+
 namespace opencc {
 
 // ---- Segments::ToVector tests ----
@@ -81,7 +83,7 @@ TEST_F(ConversionInspectionTest, OutputMatchesConvert) {
   const SimpleConverter converter(CONFIG_TEST_JSON_PATH);
   const std::string text = utf8("燕燕于飞差池其羽之子于归远送于野");
   const ConversionInspectionResult result = converter.Inspect(text);
-  const std::string converted = converter.Convert(text);
+  const std::string converted = converter.Convert(std::string_view(text));
   EXPECT_EQ(converted, result.output);
 }
 

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -26,11 +26,21 @@
 
 using namespace opencc;
 
+std::string Converter::Convert(const char* text) const {
+  return Convert(std::string_view(text));
+}
+
 std::string Converter::Convert(const std::string& text) const {
+  return Convert(std::string_view(text));
+}
+
+std::string Converter::Convert(std::string_view text) const {
   std::string converted;
   converted.reserve(text.length() + text.length() / 5);
   if (segmentation == nullptr) {
-    conversionChain->AppendConvertedSegment(text.c_str(), &converted);
+    // AppendConvertedSegment requires null-termination; copy once for this path
+    const std::string owned(text);
+    conversionChain->AppendConvertedSegment(owned.c_str(), &converted);
     return converted;
   }
   const SegmentsPtr& segments = segmentation->Segment(text);
@@ -41,7 +51,7 @@ std::string Converter::Convert(const std::string& text) const {
 }
 
 size_t Converter::Convert(const char* input, char* output) const {
-  const std::string& converted = Convert(input);
+  const std::string converted = Convert(std::string_view(input));
   strcpy(output, converted.c_str());
   return converted.length();
 }

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -136,15 +136,16 @@ std::string ConverterStream::ConvertChunk(const char* input, size_t length) {
     return std::string();
   }
 
-  const std::string output = converter->Convert(
-      std::string(bufferBegin, static_cast<size_t>(keepStart - bufferBegin)));
+  const std::string output = converter->Convert(std::string_view(
+      bufferBegin, static_cast<size_t>(keepStart - bufferBegin)));
   pending.erase(0, static_cast<size_t>(keepStart - bufferBegin));
   return output;
 }
 
 std::string ConverterStream::Finish() {
-  const std::string output = pending.empty() ? std::string()
-                                             : converter->Convert(pending);
+  const std::string output =
+      pending.empty() ? std::string()
+                      : converter->Convert(std::string_view(pending));
   pending.clear();
   return output;
 }

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 #include "Common.hpp"
 #include "ConversionInspection.hpp"
@@ -37,7 +38,11 @@ public:
       : name(_name), segmentation(_segmentation),
         conversionChain(_conversionChain) {}
 
+  std::string Convert(const char* text) const;
+
   std::string Convert(const std::string& text) const;
+
+  std::string Convert(std::string_view text) const;
 
   size_t Convert(const char* input, char* output) const;
 

--- a/src/MaxMatchSegmentation.cpp
+++ b/src/MaxMatchSegmentation.cpp
@@ -23,12 +23,16 @@
 
 using namespace opencc;
 
-MaxMatchSegmentation::MaxMatchSegmentation(const DictPtr _dict)
-    : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
+namespace {
 
-SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
+SegmentsPtr SegmentText(const std::shared_ptr<PrefixMatch>& prefixMatch,
+                        std::string_view text) {
   SegmentsPtr segments(new Segments);
-  const char* segStart = text.c_str();
+  if (text.empty()) {
+    return segments;
+  }
+
+  const char* segStart = text.data();
   size_t segLength = 0;
   auto clearBuffer = [&segments, &segStart, &segLength]() {
     if (segLength > 0) {
@@ -36,8 +40,8 @@ SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
       segLength = 0;
     }
   };
-  const char* textEnd = text.c_str() + text.length();
-  for (const char* pstr = text.c_str(); *pstr != '\0';) {
+  const char* textEnd = text.data() + text.length();
+  for (const char* pstr = text.data(); pstr < textEnd;) {
     size_t remainingLength = textEnd - pstr;
     const PrefixMatch::Match matched =
         prefixMatch->MatchPrefix(pstr, remainingLength);
@@ -64,4 +68,17 @@ SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
   }
   clearBuffer();
   return segments;
+}
+
+} // namespace
+
+MaxMatchSegmentation::MaxMatchSegmentation(const DictPtr _dict)
+    : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
+
+SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
+  return SegmentText(prefixMatch, text);
+}
+
+SegmentsPtr MaxMatchSegmentation::Segment(std::string_view text) const {
+  return SegmentText(prefixMatch, text);
 }

--- a/src/MaxMatchSegmentation.hpp
+++ b/src/MaxMatchSegmentation.hpp
@@ -29,11 +29,15 @@ class PrefixMatch;
  */
 class OPENCC_EXPORT MaxMatchSegmentation : public Segmentation {
 public:
+  using Segmentation::Segment;
+
   MaxMatchSegmentation(const DictPtr _dict);
 
   virtual ~MaxMatchSegmentation() {}
 
   virtual SegmentsPtr Segment(const std::string& text) const;
+
+  SegmentsPtr Segment(std::string_view text) const;
 
   const DictPtr GetDict() const { return dict; }
 

--- a/src/MaxMatchSegmentationTest.cpp
+++ b/src/MaxMatchSegmentationTest.cpp
@@ -48,6 +48,17 @@ TEST_F(MaxMatchSegmentationTest, EmptyString) {
   EXPECT_EQ(0, segments->Length());
 }
 
+TEST_F(MaxMatchSegmentationTest, StringViewSlice) {
+  const std::string text = utf8("x太后的头发干燥y");
+  const std::string_view slice(text.data() + 1, text.size() - 2);
+  const auto& segments = segmenter->Segment(slice);
+  EXPECT_EQ(4, segments->Length());
+  EXPECT_EQ(utf8("太后"), std::string(segments->At(0)));
+  EXPECT_EQ(utf8("的"), std::string(segments->At(1)));
+  EXPECT_EQ(utf8("头发"), std::string(segments->At(2)));
+  EXPECT_EQ(utf8("干燥"), std::string(segments->At(3)));
+}
+
 TEST_F(MaxMatchSegmentationTest, SingleCharacter) {
   const auto& segments = segmenter->Segment(utf8("一"));
   EXPECT_EQ(1, segments->Length());

--- a/src/Segmentation.cpp
+++ b/src/Segmentation.cpp
@@ -15,3 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "Segmentation.hpp"
+
+using namespace opencc;
+
+SegmentsPtr Segmentation::Segment(const char* text) const {
+  return Segment(std::string(text));
+}
+
+SegmentsPtr Segmentation::Segment(std::string_view text) const {
+  return Segment(std::string(text));
+}

--- a/src/Segmentation.hpp
+++ b/src/Segmentation.hpp
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+
 #include "Common.hpp"
 
 namespace opencc {
@@ -29,5 +32,8 @@ class OPENCC_EXPORT Segmentation {
 public:
   virtual ~Segmentation() {}
   virtual SegmentsPtr Segment(const std::string& text) const = 0;
+
+  SegmentsPtr Segment(const char* text) const;
+  SegmentsPtr Segment(std::string_view text) const;
 };
 } // namespace opencc

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -125,6 +125,10 @@ SimpleConverter::SimpleConverter(const std::string& configFileName,
 SimpleConverter::~SimpleConverter() { delete (InternalData*)internalData; }
 
 std::string SimpleConverter::Convert(const std::string& input) const {
+  return Convert(std::string_view(input));
+}
+
+std::string SimpleConverter::Convert(std::string_view input) const {
   try {
     const InternalData* data = (InternalData*)internalData;
     return data->converter->Convert(input);
@@ -134,7 +138,7 @@ std::string SimpleConverter::Convert(const std::string& input) const {
 }
 
 std::string SimpleConverter::Convert(const char* input) const {
-  return Convert(std::string(input));
+  return Convert(std::string_view(input));
 }
 
 std::string SimpleConverter::Convert(const char* input, size_t length) const {

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -19,6 +19,7 @@
 #include "Export.hpp"
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifndef __OPENCC_SIMPLECONVERTER_HPP_
@@ -125,6 +126,14 @@ public:
    * @param input Text to be converted.
    */
   std::string Convert(const std::string& input) const;
+
+  /**
+   * Converts a text without requiring a null-terminated buffer.
+   * New code should prefer this overload when a string_view is already
+   * available.
+   * @param input Text to be converted.
+   */
+  std::string Convert(std::string_view input) const;
 
   /**
    * Converts a text

--- a/src/SimpleConverterTest.cpp
+++ b/src/SimpleConverterTest.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <thread>
+#include <string_view>
 
 #include "ConfigTestBase.hpp"
 #include "SimpleConverter.hpp"
@@ -31,8 +32,8 @@ protected:
 
   void TestConverter(const std::string& config) const {
     const SimpleConverter converter(config);
-    const std::string& converted =
-        converter.Convert(utf8("燕燕于飞差池其羽之子于归远送于野"));
+    const std::string converted = converter.Convert(
+        std::string_view(utf8("燕燕于飞差池其羽之子于归远送于野")));
     EXPECT_EQ(utf8("燕燕于飛差池其羽之子于歸遠送於野"), converted);
   }
 };

--- a/src/benchmark/Performance.cpp
+++ b/src/benchmark/Performance.cpp
@@ -538,7 +538,7 @@ SimpleConverter* Initialize(const BenchmarkConfig& config) {
   return new SimpleConverter(config.path);
 }
 
-void Convert(const SimpleConverter* converter, const std::string& text) {
+void Convert(const SimpleConverter* converter, std::string_view text) {
   converter->Convert(text);
 }
 

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #ifdef _WIN32
 #include <fcntl.h>
@@ -354,7 +355,7 @@ std::string ConvertLineByMode(const std::string& line) {
     // True segmentation-only path: call the segmenter directly without
     // running any conversion stage.
     const SegmentsPtr& segments =
-        converter->GetSegmentation()->Segment(line);
+        converter->GetSegmentation()->Segment(std::string_view(line));
     ConversionInspectionResult result;
     result.input = line;
     result.segments = segments->ToVector();
@@ -363,7 +364,7 @@ std::string ConvertLineByMode(const std::string& line) {
     const ConversionInspectionResult& result = converter->Inspect(line);
     output = SerializeInspectionResultJson(result);
   } else {
-    output = converter->Convert(line);
+    output = converter->Convert(std::string_view(line));
   }
   measurement.convertMs += DurationToMilliseconds(
       std::chrono::steady_clock::now() - convertStart);

--- a/test/BazelOpenccTest.cpp
+++ b/test/BazelOpenccTest.cpp
@@ -19,6 +19,8 @@
 #include "opencc.h"
 #include "gtest/gtest.h"
 
+#include <string_view>
+
 #ifdef BAZEL
 #include "tools/cpp/runfiles/runfiles.h"
 using bazel::tools::cpp::runfiles::Runfiles;
@@ -73,14 +75,14 @@ std::string BazelOpenccTest::dictDir_;
 TEST_F(BazelOpenccTest, SimpleConverter_s2t) {
   SimpleConverter converter(OPENCC_DEFAULT_CONFIG_SIMP_TO_TRAD,
                             {configDir_, dictDir_});
-  EXPECT_EQ(converter.Convert("简化字测试"), "簡化字測試");
+  EXPECT_EQ(converter.Convert(std::string_view("简化字测试")), "簡化字測試");
 }
 
 TEST_F(BazelOpenccTest, SimpleConverter_t2s) {
   SimpleConverter converter(OPENCC_DEFAULT_CONFIG_TRAD_TO_SIMP,
                             {configDir_, dictDir_});
-  EXPECT_EQ(converter.Convert("簡化字測試"), "简化字测试");
-  EXPECT_EQ(converter.Convert("㑮"), "𫝈");
+  EXPECT_EQ(converter.Convert(std::string_view("簡化字測試")), "简化字测试");
+  EXPECT_EQ(converter.Convert(std::string_view("㑮")), "𫝈");
 }
 
 TEST_F(BazelOpenccTest, CInterface_s2t) {


### PR DESCRIPTION
Keep the existing std::string-based Convert and Segmentation entry points as the stable exported C++ ABI, and add std::string_view overloads for new code and internal call sites.

Detailed Changes:
- **ABI compatibility**:
  - Restore the original Segmentation virtual interface and exported Convert overloads as real out-of-line symbols.
  - Add const char* forwarding overloads where needed to avoid ambiguous calls after introducing string_view.
- **New string_view support**:
  - Add string_view overloads for SimpleConverter, Converter, MaxMatchSegmentation, and JiebaSegmentation.
  - Keep plugin segmentation on the std::string ABI boundary while allowing newer callers to use string_view through wrappers.
- **Behavior and tests**:
  - Preserve the MaxMatchSegmentation boundary fix for non-null-terminated slices and guard empty string_view input.
  - Add a MaxMatchSegmentation test covering a string_view slice input.