### PR TITLE
Bind DictGroup to short-circuit match policy

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -422,6 +422,7 @@ cc_library(
     hdrs = ["PrefixMatch.hpp"],
     deps = [
         ":common_lib",
+        ":dict_group_lib",
         ":dict_lib",
         ":lexicon_lib",
         ":utf8_util_lib",

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -317,6 +317,21 @@ public:
     return doc[name].GetBool();
   }
 
+  DictGroupMatchPolicy GetOptionalDictGroupMatchPolicy(const JSONValue& doc) {
+    if (!doc.HasMember("match_policy")) {
+      return DictGroupMatchPolicy::ShortCircuit;
+    }
+    if (!doc["match_policy"].IsString()) {
+      throw InvalidFormat("Property must be a std::string: match_policy");
+    }
+    const std::string matchPolicy = doc["match_policy"].GetString();
+    if (matchPolicy == "short_circuit") {
+      return DictGroupMatchPolicy::ShortCircuit;
+    }
+    throw InvalidFormat("Unknown dictionary group match_policy: " +
+                        matchPolicy);
+  }
+
   template <typename DICT>
   DictPtr LoadDictWithResourceProvider(const std::string& cachePrefix,
                                        const std::string& fileName) {
@@ -496,6 +511,8 @@ public:
     }
 
     if (type == "group") {
+      const DictGroupMatchPolicy matchPolicy =
+          GetOptionalDictGroupMatchPolicy(doc);
       std::list<DictPtr> dicts;
       const JSONValue& docs = GetArrayProperty(doc, "dicts");
       for (rapidjson::SizeType i = 0; i < docs.Size(); i++) {
@@ -511,7 +528,7 @@ public:
       if (dicts.empty()) {
         return DictPtr();
       }
-      return DictGroupPtr(new DictGroup(dicts));
+      return DictGroupPtr(new DictGroup(dicts, matchPolicy));
     } else {
       std::string fileName = GetStringProperty(doc, "file");
       DictPtr dict = LoadDictFromFile(type, fileName);

--- a/src/Dict.hpp
+++ b/src/Dict.hpp
@@ -27,6 +27,19 @@
 namespace opencc {
 
 /**
+ * Defines how a dictionary group resolves matches across child dictionaries.
+ */
+enum class DictGroupMatchPolicy {
+  /**
+   * Preserve legacy DictGroup behavior: query child dictionaries in order and
+   * return the first dictionary that has a match. For prefix lookup, this means
+   * a shorter prefix from an earlier dictionary can win over a longer prefix
+   * from a later dictionary.
+   */
+  ShortCircuit,
+};
+
+/**
  * Result of a PrefixMatch fast-path lookup.
  * key and value are non-owning views; see PrefixMatch::MatchPrefixView()
  * for lifetime details.
@@ -110,6 +123,15 @@ public:
    */
   virtual const std::list<DictPtr>* GetDictGroupItems() const {
     return nullptr;
+  }
+
+  /**
+   * Returns the match policy when this dictionary is a group. Non-group
+   * dictionaries return ShortCircuit because the value is ignored unless
+   * GetDictGroupItems() returns children.
+   */
+  virtual DictGroupMatchPolicy GetMatchPolicy() const {
+    return DictGroupMatchPolicy::ShortCircuit;
   }
 
   /**

--- a/src/DictGroup.cpp
+++ b/src/DictGroup.cpp
@@ -38,7 +38,12 @@ size_t GetKeyMaxLength(const std::list<DictPtr>& dicts) {
 } // namespace
 
 DictGroup::DictGroup(const std::list<DictPtr>& _dicts)
-    : keyMaxLength(GetKeyMaxLength(_dicts)), dicts(_dicts) {}
+    : DictGroup(_dicts, DictGroupMatchPolicy::ShortCircuit) {}
+
+DictGroup::DictGroup(const std::list<DictPtr>& _dicts,
+                     DictGroupMatchPolicy _matchPolicy)
+    : keyMaxLength(GetKeyMaxLength(_dicts)), dicts(_dicts),
+      matchPolicy(_matchPolicy) {}
 
 DictGroup::~DictGroup() {}
 

--- a/src/DictGroup.hpp
+++ b/src/DictGroup.hpp
@@ -24,11 +24,13 @@
 #include "Dict.hpp"
 
 namespace opencc {
+
 /**
  * Group of dictionaries.
  *
- * DictGroup preserves dictionary order. Exact lookup returns the first match
- * from the first child dictionary that contains the key.
+ * DictGroup preserves dictionary order. With the current ShortCircuit match
+ * policy, exact lookup returns the first match from the first child dictionary
+ * that contains the key.
  *
  * OpenCC's built-in conversion and mmseg segmentation paths do not call
  * DictGroup::MatchPrefix() or DictGroup::MatchAllPrefixes() directly. They
@@ -41,7 +43,9 @@ namespace opencc {
  */
 class OPENCC_EXPORT DictGroup : public Dict {
 public:
-  DictGroup(const std::list<DictPtr>& dicts);
+  explicit DictGroup(const std::list<DictPtr>& dicts);
+
+  DictGroup(const std::list<DictPtr>& dicts, DictGroupMatchPolicy matchPolicy);
 
   static DictGroupPtr NewFromDict(const Dict& dict);
 
@@ -104,8 +108,14 @@ public:
    */
   const std::list<DictPtr> GetDicts() const { return dicts; }
 
+  /**
+   * Returns how this group resolves matches across child dictionaries.
+   */
+  virtual DictGroupMatchPolicy GetMatchPolicy() const { return matchPolicy; }
+
 private:
   const size_t keyMaxLength;
   const std::list<DictPtr> dicts;
+  const DictGroupMatchPolicy matchPolicy;
 };
 } // namespace opencc

--- a/src/DictGroupTest.cpp
+++ b/src/DictGroupTest.cpp
@@ -32,6 +32,20 @@ TEST_F(DictGroupTest, KeyMaxLength) {
   EXPECT_EQ(3, dictGroup->GetDicts().back()->KeyMaxLength());
 }
 
+TEST_F(DictGroupTest, MatchPolicyDefaultsToShortCircuit) {
+  const DictGroupPtr& dictGroup = CreateDictGroupForConversion();
+  EXPECT_EQ(DictGroupMatchPolicy::ShortCircuit, dictGroup->GetMatchPolicy());
+}
+
+TEST_F(DictGroupTest, ExplicitMatchPolicy) {
+  const DictPtr phrasesDict = CreateDictForPhrases();
+  const DictPtr charactersDict = CreateDictForCharacters();
+  const DictGroupPtr dictGroup(new DictGroup(
+      std::list<DictPtr>{phrasesDict, charactersDict},
+      DictGroupMatchPolicy::ShortCircuit));
+  EXPECT_EQ(DictGroupMatchPolicy::ShortCircuit, dictGroup->GetMatchPolicy());
+}
+
 TEST_F(DictGroupTest, SimpleGroupTest) {
   const DictGroupPtr& dictGroup = CreateDictGroupForConversion();
   {

--- a/src/PrefixMatch.cpp
+++ b/src/PrefixMatch.cpp
@@ -18,6 +18,7 @@
 
 #include "PrefixMatch.hpp"
 #include "Dict.hpp"
+#include "DictGroup.hpp"
 #include "Lexicon.hpp"
 #include "UTF8Util.hpp"
 
@@ -111,6 +112,14 @@ void PruneExpiredPrefixMatchCache(
   }
 }
 
+void Unreachable() {
+#if defined(_MSC_VER)
+  __assume(false);
+#elif defined(__GNUC__) || defined(__clang__)
+  __builtin_unreachable();
+#endif
+}
+
 } // namespace
 
 class PrefixMatch::Table {
@@ -129,7 +138,8 @@ private:
   };
 
 public:
-  Table() {}
+  explicit Table(DictGroupMatchPolicy _matchPolicy)
+      : matchPolicy(_matchPolicy) {}
 
   void AddDict(const DictPtr& dict, size_t dictOrder) {
     const LexiconPtr lexicon = dict->GetLexicon();
@@ -172,15 +182,29 @@ private:
       }
       pstr += charLength;
       node = child->second.get();
-      if (node->candidate.hasValue &&
-          (matchedCandidate == nullptr ||
-           node->candidate.dictOrder < matchedCandidate->dictOrder ||
-           (node->candidate.dictOrder == matchedCandidate->dictOrder &&
-            node->candidate.keyLength > matchedCandidate->keyLength))) {
+      if (IsBetterMatch(node->candidate, matchedCandidate)) {
         matchedCandidate = &node->candidate;
       }
     }
     return matchedCandidate;
+  }
+
+  bool IsBetterMatch(const Candidate& candidate,
+                     const Candidate* matchedCandidate) const {
+    if (!candidate.hasValue) {
+      return false;
+    }
+    if (matchedCandidate == nullptr) {
+      return true;
+    }
+    switch (matchPolicy) {
+    case DictGroupMatchPolicy::ShortCircuit:
+      return candidate.dictOrder < matchedCandidate->dictOrder ||
+             (candidate.dictOrder == matchedCandidate->dictOrder &&
+              candidate.keyLength > matchedCandidate->keyLength);
+    }
+    Unreachable();
+    return false;
   }
 
   void AddEntry(const std::string& key, const std::string& value,
@@ -210,6 +234,7 @@ private:
   }
 
   Node root;
+  const DictGroupMatchPolicy matchPolicy;
 };
 
 PrefixMatch::PrefixMatch(const DictPtr& dict) {
@@ -254,7 +279,7 @@ PrefixMatch::PrefixMatch(const DictPtr& dict) {
   }
 
   std::shared_ptr<Tables> built(new Tables);
-  built->table.reset(new Table);
+  built->table.reset(new Table(dict->GetMatchPolicy()));
   size_t dictOrder = 0;
   AddDict(dict, built.get(), &dictOrder);
 
@@ -331,6 +356,12 @@ void PrefixMatch::AppendCacheKey(const DictPtr& dict, std::string* output) {
   const std::list<DictPtr>* dictGroupItems = dict->GetDictGroupItems();
   if (dictGroupItems != nullptr) {
     output->push_back('[');
+    const DictGroupMatchPolicy matchPolicy = dict->GetMatchPolicy();
+    switch (matchPolicy) {
+    case DictGroupMatchPolicy::ShortCircuit:
+      output->append("short_circuit:");
+      break;
+    }
     for (const DictPtr& child : *dictGroupItems) {
       AppendCacheKey(child, output);
     }

--- a/src/PrefixMatchTest.cpp
+++ b/src/PrefixMatchTest.cpp
@@ -144,4 +144,28 @@ TEST_F(PrefixMatchTest, MatchPrefixViewTablePathReturnsViews) {
   EXPECT_EQ(v.key.size(), v.keyLength);
 }
 
+TEST_F(PrefixMatchTest, ShortCircuitGroupPrefersEarlierShorterMatch) {
+  LexiconPtr firstLexicon(new Lexicon);
+  firstLexicon->Add(DictEntryFactory::New(utf8("意"), "first"));
+  firstLexicon->Sort();
+  DictPtr firstDict(new TextDict(firstLexicon));
+
+  LexiconPtr secondLexicon(new Lexicon);
+  secondLexicon->Add(DictEntryFactory::New(utf8("意大利面"), "second"));
+  secondLexicon->Sort();
+  DictPtr secondDict(new TextDict(secondLexicon));
+
+  DictPtr dictGroup(new DictGroup(
+      std::list<DictPtr>{firstDict, secondDict},
+      DictGroupMatchPolicy::ShortCircuit));
+  PrefixMatch pm(dictGroup);
+
+  const std::string query = utf8("意大利面");
+  PrefixMatch::Match m = pm.MatchPrefix(query.c_str(), query.length());
+
+  EXPECT_TRUE(m.matched);
+  EXPECT_EQ(utf8("意"), *m.key);
+  EXPECT_EQ("first", *m.value);
+}
+
 } // namespace opencc


### PR DESCRIPTION
Make the current DictGroup behavior explicit by storing and parsing a ShortCircuit match policy, and route PrefixMatch table selection through that policy without changing conversion semantics.