### PR TITLE
Replace merged ST phrase dictionary with union group across configs

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -32,7 +32,6 @@ set(
   DICTS_GENERATED
   TSCharactersExt
   STPhrases_GeneratedFromRegionalPhrases
-  STPhrases_WithGeneratedFromRegionalPhrases
   TWVariantsRev
   HKVariantsRev
   JPShinjitaiCharactersRev
@@ -83,28 +82,6 @@ set(
     --input ${DICT_DIR}/HKPhrases.txt
     --input ${DICT_DIR}/TWPhrases.txt
     --output STPhrases_GeneratedFromRegionalPhrases.txt
-    --opencc $<TARGET_FILE:${OPENCC_BIN}>
-    --config ${CMAKE_CURRENT_SOURCE_DIR}/config/t2s.json
-    --dict-dir ${DICT_GENERATED_DIR}
-)
-
-set(
-  DICT_STPhrases_WithGeneratedFromRegionalPhrases_GENERATING_INPUT
-  ${DICT_DIR}/HKPhrases.txt
-  ${DICT_DIR}/TWPhrases.txt
-  ${DICT_DIR}/STPhrases.txt
-  ${DICT_GENERATED_DIR}/TSCharacters.ocd2
-  ${DICT_GENERATED_DIR}/TSCharactersExt.ocd2
-  ${DICT_GENERATED_DIR}/TSPhrases.ocd2
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/t2s.json
-)
-set(
-  DICT_STPhrases_WithGeneratedFromRegionalPhrases_GENERATING_COMMAND
-  ${DICT_GENERATE_ST_PHRASES_BIN}
-    --input ${DICT_DIR}/HKPhrases.txt
-    --input ${DICT_DIR}/TWPhrases.txt
-    --append-to ${DICT_DIR}/STPhrases.txt
-    --output STPhrases_WithGeneratedFromRegionalPhrases.txt
     --opencc $<TARGET_FILE:${OPENCC_BIN}>
     --config ${CMAKE_CURRENT_SOURCE_DIR}/config/t2s.json
     --dict-dir ${DICT_GENERATED_DIR}

--- a/data/config/s2hk.json
+++ b/data/config/s2hk.json
@@ -3,8 +3,12 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+      "type": "group",
+      "match_policy": "union",
+      "dicts": [
+        { "type": "ocd2", "file": "STPhrases.ocd2" },
+        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+      ]
     }
   },
   "conversion_chain": [
@@ -13,7 +17,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/data/config/s2hkp.json
+++ b/data/config/s2hkp.json
@@ -3,8 +3,12 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+      "type": "group",
+      "match_policy": "union",
+      "dicts": [
+        { "type": "ocd2", "file": "STPhrases.ocd2" },
+        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+      ]
     }
   },
   "conversion_chain": [
@@ -14,8 +18,12 @@
         "match_policy": "short_circuit",
         "dicts": [
           {
-            "type": "ocd2",
-            "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
           },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]

--- a/data/config/s2t.json
+++ b/data/config/s2t.json
@@ -3,8 +3,12 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+      "type": "group",
+      "match_policy": "union",
+      "dicts": [
+        { "type": "ocd2", "file": "STPhrases.ocd2" },
+        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+      ]
     }
   },
   "conversion_chain": [
@@ -13,7 +17,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/data/config/s2tw.json
+++ b/data/config/s2tw.json
@@ -3,8 +3,12 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+      "type": "group",
+      "match_policy": "union",
+      "dicts": [
+        { "type": "ocd2", "file": "STPhrases.ocd2" },
+        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+      ]
     }
   },
   "conversion_chain": [
@@ -13,7 +17,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/data/config/s2twp.json
+++ b/data/config/s2twp.json
@@ -3,8 +3,12 @@
   "segmentation": {
     "type": "mmseg",
     "dict": {
-      "type": "ocd2",
-      "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+      "type": "group",
+      "match_policy": "union",
+      "dicts": [
+        { "type": "ocd2", "file": "STPhrases.ocd2" },
+        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+      ]
     }
   },
   "conversion_chain": [
@@ -14,8 +18,12 @@
         "match_policy": "short_circuit",
         "dicts": [
           {
-            "type": "ocd2",
-            "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
           },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]

--- a/data/dictionary/BUILD.bazel
+++ b/data/dictionary/BUILD.bazel
@@ -30,7 +30,6 @@ TEXT_DICTS = glob(
     exclude = ["CJK_Compatibility_Ideographs.txt"],
 ) + [
     "STPhrases_GeneratedFromRegionalPhrases.txt",
-    "STPhrases_WithGeneratedFromRegionalPhrases.txt",
     "TSCharactersExt.txt",
     "TWVariantsRev.txt",
     "HKVariantsRev.txt",
@@ -76,32 +75,6 @@ genrule(
     cmd = "$(location //data/scripts:generate_st_phrases_from_regional_phrases) " +
           "--input $(location HKPhrases.txt) " +
           "--input $(location TWPhrases.txt) " +
-          "--output $@ " +
-          "--opencc $(location //src/tools:command_line) " +
-          "--config $(location //data/config:t2s.json) " +
-          "--dict-dir $$(dirname $(location TSPhrases.ocd2))",
-    tools = [
-        "//data/scripts:generate_st_phrases_from_regional_phrases",
-        "//src/tools:command_line",
-    ],
-)
-
-genrule(
-    name = "generate_STPhrases_WithGeneratedFromRegionalPhrases",
-    srcs = [
-        "HKPhrases.txt",
-        "TWPhrases.txt",
-        "STPhrases.txt",
-        "TSCharacters.ocd2",
-        "TSCharactersExt.ocd2",
-        "TSPhrases.ocd2",
-        "//data/config:t2s.json",
-    ],
-    outs = ["STPhrases_WithGeneratedFromRegionalPhrases.txt"],
-    cmd = "$(location //data/scripts:generate_st_phrases_from_regional_phrases) " +
-          "--input $(location HKPhrases.txt) " +
-          "--input $(location TWPhrases.txt) " +
-          "--append-to $(location STPhrases.txt) " +
           "--output $@ " +
           "--opencc $(location //src/tools:command_line) " +
           "--config $(location //data/config:t2s.json) " +

--- a/data/dictionary/DictionaryNonBmpTest.cpp
+++ b/data/dictionary/DictionaryNonBmpTest.cpp
@@ -38,7 +38,6 @@ constexpr NonBmpException kAllowedNonBmpCharacters[] = {
     {"STPhrases", "\xF0\xA3\xB2\x98"}, // U+23C98, 𣲘
     {"TSPhrases", "\xF0\xAB\xAB\x87"}, // U+2BAC7, 𫫇
     {"STPhrases_GeneratedFromRegionalPhrases", "\xF0\xAB\xAB\x87"}, // U+2BAC7, 𫫇
-    {"STPhrases_WithGeneratedFromRegionalPhrases", "\xF0\xAB\xAB\x87"}, // U+2BAC7, 𫫇
 };
 
 uint32_t DecodeUtf8CodePoint(const char* str, size_t length) {
@@ -72,9 +71,6 @@ bool IsAllowedNonBmpCharacter(const std::string& dictionary,
     if (dictionary == exception.dictionary && character == exception.character) {
       return true;
     }
-  }
-  if (dictionary == "STPhrases_WithGeneratedFromRegionalPhrases") {
-    return IsAllowedNonBmpCharacter("STPhrases", character);
   }
   return false;
 }

--- a/node/dicts.gypi
+++ b/node/dicts.gypi
@@ -107,46 +107,6 @@
       "outputs": ["<(output_prefix)STPhrases_GeneratedFromRegionalPhrases.ocd2"],
       "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
     }, {
-      "action_name": "STPhrases_WithGeneratedFromRegionalPhrases.txt",
-      "inputs": [
-        "<(dict_generate_st_phrases)",
-        "<(input_prefix)HKPhrases.txt",
-        "<(input_prefix)TWPhrases.txt",
-        "<(input_prefix)STPhrases.txt",
-        "<(module_root_dir)/data/config/t2s.json",
-        "<(output_prefix)TSCharacters.ocd2",
-        "<(output_prefix)TSCharactersExt.ocd2",
-        "<(output_prefix)TSPhrases.ocd2",
-        "<(output_prefix)opencc.node"
-      ],
-      "outputs": ["<(output_prefix)STPhrases_WithGeneratedFromRegionalPhrases.txt"],
-      "action": [
-        "<(python_cmd)",
-        "<(dict_generate_st_phrases)",
-        "--input",
-        "<(input_prefix)HKPhrases.txt",
-        "--input",
-        "<(input_prefix)TWPhrases.txt",
-        "--append-to",
-        "<(input_prefix)STPhrases.txt",
-        "--output",
-        "<@(_outputs)",
-        "--node-binding",
-        "<(output_prefix)opencc.node",
-        "--config",
-        "<(module_root_dir)/data/config/t2s.json",
-        "--dict-dir",
-        "<(PRODUCT_DIR)"
-      ]
-    }, {
-      "action_name": "STPhrases_WithGeneratedFromRegionalPhrases",
-      "variables": {
-        "input": "<(output_prefix)STPhrases_WithGeneratedFromRegionalPhrases.txt",
-      },
-      "inputs": ["<(input)"],
-      "outputs": ["<(output_prefix)STPhrases_WithGeneratedFromRegionalPhrases.ocd2"],
-      "action": ["node", "<(cmd)", "<(input)", "<@(_outputs)"]
-    }, {
       "action_name": "TWVariantsPhrases",
       "variables": {
         "input": "<(input_prefix)TWVariantsPhrases.txt",

--- a/node/test.js
+++ b/node/test.js
@@ -278,7 +278,8 @@ describe('npm CLI', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencc-node-cli-config-'));
     const assetsPath = getAssetsPath();
     fs.copyFileSync(path.join(assetsPath, 's2t.json'), path.join(dir, 'custom-s2t.json'));
-    fs.copyFileSync(path.join(assetsPath, 'STPhrases_WithGeneratedFromRegionalPhrases.ocd2'), path.join(dir, 'STPhrases_WithGeneratedFromRegionalPhrases.ocd2'));
+    fs.copyFileSync(path.join(assetsPath, 'STPhrases.ocd2'), path.join(dir, 'STPhrases.ocd2'));
+    fs.copyFileSync(path.join(assetsPath, 'STPhrases_GeneratedFromRegionalPhrases.ocd2'), path.join(dir, 'STPhrases_GeneratedFromRegionalPhrases.ocd2'));
     fs.copyFileSync(path.join(assetsPath, 'STCharacters.ocd2'), path.join(dir, 'STCharacters.ocd2'));
 
     const result = childProcess.spawnSync(process.execPath, [cli, '-c', './custom-s2t.json'], {

--- a/plugins/jieba/data/config/s2hk_jieba.json
+++ b/plugins/jieba/data/config/s2hk_jieba.json
@@ -13,7 +13,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/plugins/jieba/data/config/s2hkp_jieba.json
+++ b/plugins/jieba/data/config/s2hkp_jieba.json
@@ -14,8 +14,12 @@
         "match_policy": "short_circuit",
         "dicts": [
           {
-            "type": "ocd2",
-            "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
           },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]

--- a/plugins/jieba/data/config/s2t_jieba.json
+++ b/plugins/jieba/data/config/s2t_jieba.json
@@ -13,7 +13,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/plugins/jieba/data/config/s2tw_jieba.json
+++ b/plugins/jieba/data/config/s2tw_jieba.json
@@ -13,7 +13,14 @@
         "type": "group",
         "match_policy": "short_circuit",
         "dicts": [
-          { "type": "ocd2", "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2" },
+          {
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
+          },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]
       }

--- a/plugins/jieba/data/config/s2twp_jieba.json
+++ b/plugins/jieba/data/config/s2twp_jieba.json
@@ -14,8 +14,12 @@
         "match_policy": "short_circuit",
         "dicts": [
           {
-            "type": "ocd2",
-            "file": "STPhrases_WithGeneratedFromRegionalPhrases.ocd2"
+            "type": "group",
+            "match_policy": "union",
+            "dicts": [
+              { "type": "ocd2", "file": "STPhrases.ocd2" },
+              { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
+            ]
           },
           { "type": "ocd2", "file": "STCharacters.ocd2" }
         ]


### PR DESCRIPTION
Remove the statically-merged STPhrases_WithGeneratedFromRegionalPhrases artifact and instead express the same semantics as a union group of STPhrases and STPhrases_GeneratedFromRegionalPhrases in all five s2* configs and their jieba counterparts.  The union match policy introduced in the previous commit makes this equivalent at runtime: longest prefix wins, with STPhrases taking priority on same-length ties, which is exactly what the merged dict enforced.

Detailed Changes:
- **Config updates (s2t, s2tw, s2hk, s2twp, s2hkp and jieba variants)**:
  - Replace single-file segmentation dict with union group [STPhrases, STPhrases_Generated].
  - Replace merged dict in conversion stage 1 with union group nested inside the existing short_circuit group alongside STCharacters.
- **Build system**:
  - Remove generate_STPhrases_WithGeneratedFromRegionalPhrases genrule from BUILD.bazel.
  - Remove corresponding entry and generation commands from data/CMakeLists.txt.
  - Remove two node-gyp actions from node/dicts.gypi.
- **Tests**:
  - Remove STPhrases_WithGeneratedFromRegionalPhrases allowlist entries from DictionaryNonBmpTest.cpp (no longer a separate dict to audit).
  - Update node/test.js CLI resolution test to copy the two source dicts instead of the former merged artifact.

Reverts #1349
Fixes #1350 