### PR TITLE
Simplify Converter API in preparation for further API changes

### DIFF
--- a/node/opencc.cc
+++ b/node/opencc.cc
@@ -216,10 +216,10 @@ public:
       std::string output;
       if (info[0].IsBuffer()) {
         Napi::Buffer<char> input = info[0].As<Napi::Buffer<char>>();
-        output = stream_->ConvertChunk(input.Data(), input.Length());
+        output = stream_->ConvertChunk({input.Data(), input.Length()});
       } else {
         const std::string input = ToUtf8String(info[0]);
-        output = stream_->ConvertChunk(input.data(), input.size());
+        output = stream_->ConvertChunk(input);
       }
       return Napi::String::New(env, output);
     } catch (opencc::Exception& e) {
@@ -239,12 +239,11 @@ public:
       if (info.Length() >= 1 && info[0].IsBuffer()) {
         Napi::Buffer<char> input = info[0].As<Napi::Buffer<char>>();
         return Napi::String::New(
-            env, stream_->Finish(input.Data(), input.Length()));
+            env, stream_->Finish({input.Data(), input.Length()}));
       }
       if (info.Length() >= 1) {
         const std::string input = ToUtf8String(info[0]);
-        return Napi::String::New(env,
-                                 stream_->Finish(input.data(), input.size()));
+        return Napi::String::New(env, stream_->Finish(input));
       }
       return Napi::String::New(env, stream_->Finish());
     } catch (opencc::Exception& e) {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -897,7 +897,7 @@ Config::NewFromString(const std::string& json,
   // Required: conversion_chain
   ConversionChainPtr chain = impl->ParseConversionChain(
       impl->GetArrayProperty(doc, "conversion_chain"));
-  return ConverterPtr(new Converter(name, segmentation, chain));
+  return ConverterPtr(new SingleStageConverter(segmentation, chain));
 }
 
 }; // namespace opencc

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -234,11 +234,10 @@ TEST_F(ConfigTest, Convert) {
   EXPECT_EQ(expected, converted);
 }
 
-TEST_F(ConfigTest, ConvertBuffer) {
-  char output[1024];
-  const size_t length = converter->Convert(input.c_str(), output);
-  EXPECT_EQ(expected.length(), length);
-  EXPECT_EQ(expected, output);
+TEST_F(ConfigTest, ConvertLength) {
+  const std::string result = converter->Convert(std::string_view(input));
+  EXPECT_EQ(expected.length(), result.length());
+  EXPECT_EQ(expected, result);
 }
 
 TEST_F(ConfigTest, NonexistingPath) {

--- a/src/ConversionChainTest.cpp
+++ b/src/ConversionChainTest.cpp
@@ -70,7 +70,7 @@ TEST_F(ConversionChainTest, StreamKeepsIncompleteIdeographicDescriptionSequence)
   ConversionPtr componentConversion(new Conversion(componentDict));
   ConversionChainPtr chain(
       new ConversionChain(std::list<ConversionPtr>{componentConversion}));
-  ConverterPtr converter(new Converter("test", segmentation, chain));
+  ConverterPtr converter(new SingleStageConverter(segmentation, chain));
   ConverterStream stream(converter, 1);
 
   const std::string firstChunk = utf8("prefix⿰钅");
@@ -93,7 +93,7 @@ TEST_F(ConversionChainTest,
   ConversionPtr componentConversion(new Conversion(componentDict));
   ConversionChainPtr chain(
       new ConversionChain(std::list<ConversionPtr>{componentConversion}));
-  ConverterPtr converter(new Converter("test", segmentation, chain));
+  ConverterPtr converter(new SingleStageConverter(segmentation, chain));
   ConverterStream stream(converter, 16);
 
   std::string nestedPrefix = utf8("prefix");

--- a/src/ConversionChainTest.cpp
+++ b/src/ConversionChainTest.cpp
@@ -76,8 +76,8 @@ TEST_F(ConversionChainTest, StreamKeepsIncompleteIdeographicDescriptionSequence)
   const std::string firstChunk = utf8("prefix⿰钅");
   const std::string secondChunk = utf8("只只");
   std::string output;
-  output += stream.ConvertChunk(firstChunk.c_str(), firstChunk.length());
-  output += stream.Finish(secondChunk.c_str(), secondChunk.length());
+  output += stream.ConvertChunk(firstChunk);
+  output += stream.Finish(secondChunk);
 
   EXPECT_EQ(utf8("prefix⿰钅只隻"), output);
 }
@@ -110,8 +110,8 @@ TEST_F(ConversionChainTest,
 
   const std::string secondChunk = utf8("只只");
   std::string output;
-  output += stream.ConvertChunk(nestedPrefix.c_str(), nestedPrefix.length());
-  output += stream.Finish(secondChunk.c_str(), secondChunk.length());
+  output += stream.ConvertChunk(nestedPrefix);
+  output += stream.Finish(secondChunk);
 
   EXPECT_EQ(expected, output);
 }

--- a/src/ConversionChainTest.cpp
+++ b/src/ConversionChainTest.cpp
@@ -116,4 +116,62 @@ TEST_F(ConversionChainTest,
   EXPECT_EQ(expected, output);
 }
 
+class PipelineConverterTest : public TextDictTestBase {
+protected:
+  // stage1: 钅 → 釒   stage2: 釒 → 金
+  void SetUp() override {
+    LexiconPtr lex1(new Lexicon);
+    lex1->Add(DictEntryFactory::New(utf8("钅"), utf8("釒")));
+    lex1->Sort();
+    DictPtr dict1(new TextDict(lex1));
+    stage1 = ConverterPtr(new SingleStageConverter(
+        SegmentationPtr(new MaxMatchSegmentation(dict1)),
+        ConversionChainPtr(
+            new ConversionChain({ConversionPtr(new Conversion(dict1))}))));
+    seg1 = stage1->GetSegmentation();
+
+    LexiconPtr lex2(new Lexicon);
+    lex2->Add(DictEntryFactory::New(utf8("釒"), utf8("金")));
+    lex2->Sort();
+    DictPtr dict2(new TextDict(lex2));
+    stage2 = ConverterPtr(new SingleStageConverter(
+        SegmentationPtr(new MaxMatchSegmentation(dict2)),
+        ConversionChainPtr(
+            new ConversionChain({ConversionPtr(new Conversion(dict2))}))));
+    seg2 = stage2->GetSegmentation();
+  }
+
+  ConverterPtr stage1, stage2;
+  SegmentationPtr seg1, seg2;
+};
+
+TEST_F(PipelineConverterTest, ConvertChainsStagesInOrder) {
+  PipelineConverter pipeline({stage1, stage2});
+  EXPECT_EQ(utf8("金"), pipeline.Convert(utf8("钅")));
+}
+
+TEST_F(PipelineConverterTest, ConvertEmptyPipelineIsIdentity) {
+  PipelineConverter pipeline({});
+  EXPECT_EQ(utf8("钅"), pipeline.Convert(utf8("钅")));
+}
+
+TEST_F(PipelineConverterTest, GetSegmentationReturnsLastStage) {
+  PipelineConverter pipeline({stage1, stage2});
+  EXPECT_EQ(seg2, pipeline.GetSegmentation());
+}
+
+TEST_F(PipelineConverterTest, GetSegmentationEmptyPipelineReturnsNullptr) {
+  PipelineConverter pipeline({});
+  EXPECT_EQ(nullptr, pipeline.GetSegmentation());
+}
+
+TEST_F(PipelineConverterTest, InspectReturnsInputOutputWithNoStageDetail) {
+  PipelineConverter pipeline({stage1, stage2});
+  const ConversionInspectionResult result = pipeline.Inspect(utf8("钅"));
+  EXPECT_EQ(utf8("钅"), result.input);
+  EXPECT_EQ(utf8("金"), result.output);
+  EXPECT_TRUE(result.segments.empty());
+  EXPECT_TRUE(result.stages.empty());
+}
+
 } // namespace opencc

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -73,6 +73,26 @@ ConversionInspectionResult SingleStageConverter::Inspect(const std::string& text
   return result;
 }
 
+std::string PipelineConverter::Convert(std::string_view text) const {
+  std::string result(text);
+  for (const ConverterPtr& stage : stages) {
+    result = stage->Convert(result);
+  }
+  return result;
+}
+
+ConversionInspectionResult
+PipelineConverter::Inspect(const std::string& text) const {
+  ConversionInspectionResult result;
+  result.input = text;
+  result.output = Convert(text);
+  return result;
+}
+
+SegmentationPtr PipelineConverter::GetSegmentation() const {
+  return stages.empty() ? nullptr : stages.back()->GetSegmentation();
+}
+
 std::string ConverterStream::ConvertChunk(std::string_view input) {
   if (!input.empty()) {
     pending.append(input);

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -24,7 +24,7 @@
 
 using namespace opencc;
 
-std::string Converter::Convert(std::string_view text) const {
+std::string SingleStageConverter::Convert(std::string_view text) const {
   std::string converted;
   converted.reserve(text.length() + text.length() / 5);
   if (segmentation == nullptr) {
@@ -40,7 +40,7 @@ std::string Converter::Convert(std::string_view text) const {
   return converted;
 }
 
-ConversionInspectionResult Converter::Inspect(const std::string& text) const {
+ConversionInspectionResult SingleStageConverter::Inspect(const std::string& text) const {
   ConversionInspectionResult result;
   result.input = text;
 

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-#include <cstring>
-
 #include "ConversionChain.hpp"
 #include "ConversionInspection.hpp"
 #include "Converter.hpp"
@@ -25,14 +23,6 @@
 #include "UTF8Util.hpp"
 
 using namespace opencc;
-
-std::string Converter::Convert(const char* text) const {
-  return Convert(std::string_view(text));
-}
-
-std::string Converter::Convert(const std::string& text) const {
-  return Convert(std::string_view(text));
-}
 
 std::string Converter::Convert(std::string_view text) const {
   std::string converted;
@@ -48,12 +38,6 @@ std::string Converter::Convert(std::string_view text) const {
     conversionChain->AppendConvertedSegment(segment, &converted);
   }
   return converted;
-}
-
-size_t Converter::Convert(const char* input, char* output) const {
-  const std::string converted = Convert(std::string_view(input));
-  strcpy(output, converted.c_str());
-  return converted.length();
 }
 
 ConversionInspectionResult Converter::Inspect(const std::string& text) const {
@@ -89,9 +73,9 @@ ConversionInspectionResult Converter::Inspect(const std::string& text) const {
   return result;
 }
 
-std::string ConverterStream::ConvertChunk(const char* input, size_t length) {
-  if (length > 0) {
-    pending.append(input, length);
+std::string ConverterStream::ConvertChunk(std::string_view input) {
+  if (!input.empty()) {
+    pending.append(input);
   }
   if (pending.empty()) {
     return std::string();
@@ -142,6 +126,13 @@ std::string ConverterStream::ConvertChunk(const char* input, size_t length) {
   return output;
 }
 
+std::string ConverterStream::Finish(std::string_view input) {
+  if (!input.empty()) {
+    pending.append(input);
+  }
+  return Finish();
+}
+
 std::string ConverterStream::Finish() {
   const std::string output =
       pending.empty() ? std::string()
@@ -150,9 +141,3 @@ std::string ConverterStream::Finish() {
   return output;
 }
 
-std::string ConverterStream::Finish(const char* input, size_t length) {
-  if (length > 0) {
-    pending.append(input, length);
-  }
-  return Finish();
-}

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -28,28 +28,44 @@
 
 namespace opencc {
 /**
- * Controller of segmentation and conversion
+ * Abstract base for all converters.
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT Converter {
 public:
-  Converter(const std::string& _name, SegmentationPtr _segmentation,
-            ConversionChainPtr _conversionChain)
-      : name(_name), segmentation(_segmentation),
-        conversionChain(_conversionChain) {}
+  virtual ~Converter() = default;
 
-  std::string Convert(std::string_view text) const;
+  virtual std::string Convert(std::string_view text) const = 0;
 
-  ConversionInspectionResult Inspect(const std::string& text) const;
+  virtual ConversionInspectionResult Inspect(const std::string& text) const = 0;
 
-  const SegmentationPtr GetSegmentation() const { return segmentation; }
+  virtual SegmentationPtr GetSegmentation() const = 0;
 
-  const ConversionChainPtr GetConversionChain() const {
+  virtual ConversionChainPtr GetConversionChain() const = 0;
+};
+
+/**
+ * Single-stage converter: one segmentation pass followed by one conversion
+ * chain.
+ * @ingroup opencc_cpp_api
+ */
+class OPENCC_EXPORT SingleStageConverter : public Converter {
+public:
+  SingleStageConverter(SegmentationPtr segmentation,
+                       ConversionChainPtr conversionChain)
+      : segmentation(segmentation), conversionChain(conversionChain) {}
+
+  std::string Convert(std::string_view text) const override;
+
+  ConversionInspectionResult Inspect(const std::string& text) const override;
+
+  SegmentationPtr GetSegmentation() const override { return segmentation; }
+
+  ConversionChainPtr GetConversionChain() const override {
     return conversionChain;
   }
 
 private:
-  const std::string name;
   const SegmentationPtr segmentation;
   const ConversionChainPtr conversionChain;
 };

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -21,6 +21,8 @@
 #include <cstddef>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "Common.hpp"
 #include "ConversionInspection.hpp"
@@ -68,6 +70,30 @@ public:
 private:
   const SegmentationPtr segmentation;
   const ConversionChainPtr conversionChain;
+};
+
+/**
+ * Pipeline converter: passes text through a sequence of converters in order.
+ * @ingroup opencc_cpp_api
+ */
+class OPENCC_EXPORT PipelineConverter : public Converter {
+public:
+  explicit PipelineConverter(std::vector<ConverterPtr> stages)
+      : stages(std::move(stages)) {}
+
+  std::string Convert(std::string_view text) const override;
+
+  /** Returns an object with input/output filled and no stage detail. */
+  ConversionInspectionResult Inspect(const std::string& text) const override;
+
+  /** Returns the last stage's segmentation, or nullptr for an empty pipeline. */
+  SegmentationPtr GetSegmentation() const override;
+
+  /** Returns nullptr; a pipeline has no single conversion chain. */
+  ConversionChainPtr GetConversionChain() const override { return nullptr; }
+
+private:
+  const std::vector<ConverterPtr> stages;
 };
 
 class OPENCC_EXPORT ConverterStream {

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -38,13 +38,7 @@ public:
       : name(_name), segmentation(_segmentation),
         conversionChain(_conversionChain) {}
 
-  std::string Convert(const char* text) const;
-
-  std::string Convert(const std::string& text) const;
-
   std::string Convert(std::string_view text) const;
-
-  size_t Convert(const char* input, char* output) const;
 
   ConversionInspectionResult Inspect(const std::string& text) const;
 
@@ -65,11 +59,24 @@ public:
   explicit ConverterStream(ConverterPtr _converter, size_t _maxKeepChars = 16)
       : converter(_converter), maxKeepChars(_maxKeepChars) {}
 
-  std::string ConvertChunk(const char* input, size_t length);
+  /**
+   * Appends @p input to pending, then emits everything up to the last
+   * @c maxKeepChars code points (extended if an incomplete IDS is detected).
+   * The kept tail remains in pending so that a phrase or IDS spanning two
+   * consecutive calls is not split across separate Convert() invocations.
+   */
+  std::string ConvertChunk(std::string_view input);
+
+  /**
+   * Appends @p input to pending and flushes everything at once.
+   * @note Not equivalent to ConvertChunk(@p input) + Finish(): ConvertChunk
+   *   applies the keepStart window and issues two Convert() calls, which
+   *   breaks phrase or IDS matches that span the boundary.
+   *   Use this overload for the final chunk when no more data is coming.
+   */
+  std::string Finish(std::string_view input);
 
   std::string Finish();
-
-  std::string Finish(const char* input, size_t length);
 
 private:
   ConverterPtr converter;

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include "Config.hpp"
 #include "Converter.hpp"
 #include "UTF8Util.hpp"
@@ -152,7 +154,9 @@ std::string SimpleConverter::Convert(const char* input, size_t length) const {
 size_t SimpleConverter::Convert(const char* input, char* output) const {
   try {
     const InternalData* data = (InternalData*)internalData;
-    return data->converter->Convert(input, output);
+    const std::string converted = data->converter->Convert(input);
+    strcpy(output, converted.c_str());
+    return converted.length();
   } catch (Exception& ex) {
     throw std::runtime_error(ex.what());
   }

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -386,9 +386,9 @@ void ConvertStream(FILE* fin, FILE* fout) {
 
     const auto convertStart = std::chrono::steady_clock::now();
     const bool isFinalChunk = length < buffer.size() && feof(fin);
-    const std::string& converted =
-        isFinalChunk ? stream.Finish(buffer.data(), length)
-                     : stream.ConvertChunk(buffer.data(), length);
+    const std::string converted =
+        isFinalChunk ? stream.Finish({buffer.data(), length})
+                     : stream.ConvertChunk({buffer.data(), length});
     measurement.convertMs += DurationToMilliseconds(
         std::chrono::steady_clock::now() - convertStart);
     measurement.outputBytes += converted.size();


### PR DESCRIPTION
Drop Convert(const char*), Convert(const std::string&), and the unsafe size_t Convert(const char*, char*) from Converter, leaving only the string_view overload. ConverterStream is narrowed to three methods: ConvertChunk(string_view), Finish(string_view), and Finish(). The string_view Finish overload preserves the original Finish(ptr, len) semantics — appending data then flushing all at once without applying the keepStart window — which is semantically distinct from ConvertChunk+Finish.

This is the first of several planned ABI-breaking changes; all consumers must recompile against the updated header.