### PR TITLE
Unify Segmentation/Conversion/Converter/Inspect interfaces to std::string_view; add Doxygen docs

### DIFF
--- a/plugins/jieba/include/JiebaSegmentation.hpp
+++ b/plugins/jieba/include/JiebaSegmentation.hpp
@@ -39,9 +39,7 @@ public:
 
   ~JiebaSegmentation() override;
 
-  SegmentsPtr Segment(const std::string& text) const override;
-
-  SegmentsPtr Segment(std::string_view text) const;
+  SegmentsPtr Segment(std::string_view text) const override;
 
 private:
   std::unique_ptr<cppjieba::Jieba> jieba_;

--- a/plugins/jieba/src/JiebaSegmentation.cpp
+++ b/plugins/jieba/src/JiebaSegmentation.cpp
@@ -316,16 +316,6 @@ JiebaSegmentation::JiebaSegmentation(const std::string& dictPath,
 
 JiebaSegmentation::~JiebaSegmentation() = default;
 
-SegmentsPtr JiebaSegmentation::Segment(const std::string& text) const {
-  SegmentsPtr segments(new Segments);
-  std::vector<std::string> words;
-  jieba_->Cut(text, words, true);
-  for (const auto& word : words) {
-    segments->AddSegment(word);
-  }
-  return segments;
-}
-
 SegmentsPtr JiebaSegmentation::Segment(std::string_view text) const {
   SegmentsPtr segments(new Segments);
   std::vector<std::string> words;

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -27,12 +27,16 @@ Conversion::Conversion(DictPtr _dict)
     : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
 std::string Conversion::Convert(std::string_view phrase) const {
+  if (phrase.empty()) {
+    return std::string();
+  }
   std::string buffer;
   const size_t phraseLength = phrase.size();
   buffer.reserve(phraseLength + phraseLength / 5);
 
-  const char* phraseEnd = phrase.data() + phraseLength;
-  for (const char* pstr = phrase.data(); pstr < phraseEnd;) {
+  const char* phraseData = phrase.data();
+  const char* phraseEnd = phraseData + phraseLength;
+  for (const char* pstr = phraseData; pstr < phraseEnd;) {
     size_t remainingLength = phraseEnd - pstr;
     const PrefixMatch::Match matched =
         prefixMatch->MatchPrefix(pstr, remainingLength);

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -26,10 +26,42 @@ using namespace opencc;
 Conversion::Conversion(DictPtr _dict)
     : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
-std::string Conversion::Convert(const char* phrase) const {
+std::string Conversion::Convert(std::string_view phrase) const {
   std::string buffer;
-  AppendConverted(phrase, &buffer);
+  const size_t phraseLength = phrase.size();
+  buffer.reserve(phraseLength + phraseLength / 5);
+
+  const char* phraseEnd = phrase.data() + phraseLength;
+  for (const char* pstr = phrase.data(); pstr < phraseEnd;) {
+    size_t remainingLength = phraseEnd - pstr;
+    const PrefixMatch::Match matched =
+        prefixMatch->MatchPrefix(pstr, remainingLength);
+    size_t matchedLength;
+    if (!matched.matched) {
+      matchedLength =
+          UTF8Util::NextIdeographicDescriptionSequenceLength(pstr,
+                                                             remainingLength);
+      if (matchedLength == 0) {
+        matchedLength = UTF8Util::NextCharLength(pstr);
+      }
+      if (matchedLength > remainingLength) {
+        matchedLength = remainingLength;
+      }
+      buffer.append(pstr, matchedLength);
+    } else {
+      matchedLength = matched.keyLength;
+      if (matchedLength > remainingLength) {
+        matchedLength = remainingLength;
+      }
+      buffer.append(*matched.value);
+    }
+    pstr += matchedLength;
+  }
   return buffer;
+}
+
+std::string Conversion::Convert(const char* phrase) const {
+  return Convert(std::string_view(phrase));
 }
 
 void Conversion::AppendConverted(const char* phrase, std::string* output) const {
@@ -69,10 +101,6 @@ void Conversion::AppendConverted(const char* phrase, std::string* output) const 
     }
     pstr += matchedLength;
   }
-}
-
-std::string Conversion::Convert(const std::string& phrase) const {
-  return Convert(phrase.c_str());
 }
 
 SegmentsPtr Conversion::Convert(const SegmentsPtr& input) const {

--- a/src/Conversion.hpp
+++ b/src/Conversion.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "Common.hpp"
 #include "Segmentation.hpp"
 
@@ -25,25 +27,51 @@ namespace opencc {
 class PrefixMatch;
 
 /**
- * Conversion interface
+ * Single-dictionary phrase conversion.
+ *
+ * Applies prefix-match replacement using one dictionary (@c DictPtr) to an
+ * already-segmented piece of text.  This is the lowest-level conversion
+ * primitive: it knows nothing about segmentation and operates on a single
+ * segment or a pre-built @c Segments object.
+ *
+ * Multiple @c Conversion objects are composed in a @c ConversionChain to
+ * apply several dictionaries in order (e.g. phrase dictionary first, then
+ * character dictionary).
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT Conversion {
 public:
+  /** Constructs a Conversion backed by @p dict. */
   Conversion(DictPtr _dict);
 
-  // Convert single phrase
-  std::string Convert(const std::string& phrase) const;
+  /**
+   * Converts @p phrase using prefix-match replacement and returns the result.
+   * @param phrase UTF-8 text; need not be null-terminated.
+   */
+  std::string Convert(std::string_view phrase) const;
 
-  // Convert single phrase
+  /**
+   * Converts @p phrase using prefix-match replacement and returns the result.
+   * @param phrase Null-terminated UTF-8 text.
+   */
   std::string Convert(const char* phrase) const;
 
-  // Convert single phrase and append it to output.
+  /**
+   * Converts @p phrase and appends the result to @p output.
+   * Preferred in hot paths (e.g. ConversionChain) to avoid extra allocations.
+   * @param phrase Null-terminated UTF-8 text.
+   * @param output Destination buffer; content is appended, not replaced.
+   */
   void AppendConverted(const char* phrase, std::string* output) const;
 
-  // Convert segmented text
+  /**
+   * Converts every segment in @p input and returns a new @c Segments object.
+   * Each segment is converted independently via Convert(const char*).
+   */
   SegmentsPtr Convert(const SegmentsPtr& input) const;
 
+  /** Returns the backing dictionary. */
   const DictPtr GetDict() const { return dict; }
 
 private:

--- a/src/ConversionChain.hpp
+++ b/src/ConversionChain.hpp
@@ -25,20 +25,45 @@
 
 namespace opencc {
 /**
- * Chain of conversions
- * Consists of a list of conversions. Converts input in sequence.
+ * An ordered sequence of @c Conversion objects applied to pre-segmented text.
+ *
+ * Each @c Conversion in the chain wraps one dictionary.  The chain applies
+ * them in order: the output segments of conversion N become the input of
+ * conversion N+1.  This enables priority-ordered substitution, such as
+ * applying phrase dictionaries before character dictionaries so that
+ * multi-character matches take precedence.
+ *
+ * A @c ConversionChain operates on @c Segments (output of @c Segmentation)
+ * and has no knowledge of how those segments were produced.
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT ConversionChain {
 public:
+  /** Constructs a chain from an ordered list of conversions. */
   ConversionChain(const std::list<ConversionPtr> _conversions);
 
+  /**
+   * Passes @p input through every conversion in the chain sequentially and
+   * returns the final @c Segments.
+   */
   SegmentsPtr Convert(const SegmentsPtr& input) const;
 
+  /**
+   * Converts the null-terminated @p segment through all conversions and
+   * appends the result to @p output.  This is the hot-path entry point used
+   * by @c SingleStageConverter to avoid intermediate string allocations.
+   */
   void AppendConvertedSegment(const char* segment, std::string* output) const;
 
+  /**
+   * Converts @p input through the chain and records every intermediate
+   * @c Segments after each conversion stage.
+   * @return One entry per conversion in the chain, in order.
+   */
   std::vector<SegmentsPtr> ConvertWithTrace(const SegmentsPtr& input) const;
 
+  /** Returns the list of conversions in application order. */
   const std::list<ConversionPtr> GetConversions() const { return conversions; }
 
 private:

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -28,19 +28,47 @@
 
 namespace opencc {
 /**
- * Abstract base for all converters.
+ * Abstract base for full-text converters.
+ *
+ * A @c Converter accepts a complete UTF-8 string and returns the converted
+ * result.  Internally it coordinates @c Segmentation (splitting text into
+ * words) and a @c ConversionChain (applying one or more dictionaries to each
+ * segment).  Two concrete implementations are provided:
+ *
+ *  - @c SingleStageConverter — one segmentation pass + one @c ConversionChain.
+ *  - @c PipelineConverter — passes text through a sequence of @c Converter
+ *    stages in order, each with its own segmentation and chain.
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT Converter {
 public:
   virtual ~Converter() = default;
 
+  /**
+   * Converts @p text and returns the result.
+   * @param text UTF-8 input; need not be null-terminated.
+   */
   virtual std::string Convert(std::string_view text) const = 0;
 
-  virtual ConversionInspectionResult Inspect(const std::string& text) const = 0;
+  /**
+   * Converts @p text and returns a detailed inspection result that includes
+   * the initial segmentation, per-stage intermediate segments, and final
+   * output.  Intended for debugging and tooling rather than production
+   * conversion.
+   */
+  virtual ConversionInspectionResult Inspect(std::string_view text) const = 0;
 
+  /**
+   * Returns the segmentation used by this converter, or @c nullptr if the
+   * converter has no single segmentation (e.g. @c PipelineConverter).
+   */
   virtual SegmentationPtr GetSegmentation() const = 0;
 
+  /**
+   * Returns the conversion chain used by this converter, or @c nullptr if the
+   * converter has no single chain (e.g. @c PipelineConverter).
+   */
   virtual ConversionChainPtr GetConversionChain() const = 0;
 };
 

--- a/src/MaxMatchSegmentation.cpp
+++ b/src/MaxMatchSegmentation.cpp
@@ -75,10 +75,6 @@ SegmentsPtr SegmentText(const std::shared_ptr<PrefixMatch>& prefixMatch,
 MaxMatchSegmentation::MaxMatchSegmentation(const DictPtr _dict)
     : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
-SegmentsPtr MaxMatchSegmentation::Segment(const std::string& text) const {
-  return SegmentText(prefixMatch, text);
-}
-
 SegmentsPtr MaxMatchSegmentation::Segment(std::string_view text) const {
   return SegmentText(prefixMatch, text);
 }

--- a/src/MaxMatchSegmentation.hpp
+++ b/src/MaxMatchSegmentation.hpp
@@ -35,9 +35,7 @@ public:
 
   virtual ~MaxMatchSegmentation() {}
 
-  virtual SegmentsPtr Segment(const std::string& text) const;
-
-  SegmentsPtr Segment(std::string_view text) const;
+  SegmentsPtr Segment(std::string_view text) const override;
 
   const DictPtr GetDict() const { return dict; }
 

--- a/src/PipelineConverter.cpp
+++ b/src/PipelineConverter.cpp
@@ -29,7 +29,7 @@ std::string PipelineConverter::Convert(std::string_view text) const {
 }
 
 ConversionInspectionResult
-PipelineConverter::Inspect(const std::string& text) const {
+PipelineConverter::Inspect(std::string_view text) const {
   ConversionInspectionResult result;
   result.input = text;
   result.output = Convert(text);

--- a/src/PipelineConverter.hpp
+++ b/src/PipelineConverter.hpp
@@ -25,23 +25,38 @@
 
 namespace opencc {
 /**
- * Pipeline converter: passes text through a sequence of converters in order.
+ * A @c Converter that passes text through a sequence of @c Converter stages
+ * in order, feeding the output of each stage as input to the next.
+ *
+ * This enables multi-step conversion schemes where different segmentation
+ * strategies or dictionary sets are needed at each step.  For example, the
+ * @c s2twp config first converts Simplified to Traditional (stage 1) and then
+ * applies Taiwan-specific phrase substitution (stage 2).
+ *
+ * @note @c GetConversionChain() always returns @c nullptr because a pipeline
+ * has no single chain.  @c GetSegmentation() returns the last stage's
+ * segmentation as a best-effort representative.
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT PipelineConverter : public Converter {
 public:
+  /** @param stages Ordered list of converters to apply in sequence. */
   explicit PipelineConverter(std::vector<ConverterPtr> stages)
       : stages(std::move(stages)) {}
 
   std::string Convert(std::string_view text) const override;
 
-  /** Returns an object with input/output filled and no stage detail. */
-  ConversionInspectionResult Inspect(const std::string& text) const override;
+  /**
+   * Returns an inspection result with @c input and @c output populated.
+   * Per-stage segment detail is not available at the pipeline level.
+   */
+  ConversionInspectionResult Inspect(std::string_view text) const override;
 
-  /** Returns the last stage's segmentation, or nullptr for an empty pipeline. */
+  /** Returns the last stage's segmentation, or @c nullptr for an empty pipeline. */
   SegmentationPtr GetSegmentation() const override;
 
-  /** Returns nullptr; a pipeline has no single conversion chain. */
+  /** Always returns @c nullptr; a pipeline has no single conversion chain. */
   ConversionChainPtr GetConversionChain() const override { return nullptr; }
 
 private:

--- a/src/PluginSegmentation.cpp
+++ b/src/PluginSegmentation.cpp
@@ -247,11 +247,11 @@ std::string TakeErrorMessage(const opencc_segmentation_plugin_v2* descriptor,
   throw Exception(fallbackPrefix + " '" + pluginType + "': " + message);
 }
 
-SegmentsPtr BuildSegmentsFromLengths(const std::string& text,
+SegmentsPtr BuildSegmentsFromLengths(std::string_view text,
                                      const opencc_segment_length_array_t& lengths) {
   SegmentsPtr segments(new Segments);
-  const char* bytes = text.c_str();
-  const size_t inputSize = std::strlen(bytes);
+  const char* bytes = text.data();
+  const size_t inputSize = text.size();
   size_t byteOffset = 0;
 
   for (size_t i = 0; i < lengths.segment_count; i++) {
@@ -297,7 +297,8 @@ public:
     }
   }
 
-  SegmentsPtr Segment(const std::string& text) const override {
+  SegmentsPtr Segment(std::string_view text) const override {
+    const std::string owned(text);
     opencc_segment_length_array_t segmentLengths = {};
     segmentLengths.struct_size = sizeof(segmentLengths);
     opencc_error_t error = {};
@@ -305,7 +306,7 @@ public:
     opencc_segmentation_segment_args_t args = {};
     args.struct_size = sizeof(args);
     args.handle = handle_;
-    args.utf8_text = text.c_str();
+    args.utf8_text = owned.c_str();
     args.segment_lengths = &segmentLengths;
     args.error = &error;
     const int status = plugin_->descriptor->segment(&args);

--- a/src/Segmentation.cpp
+++ b/src/Segmentation.cpp
@@ -21,9 +21,9 @@
 using namespace opencc;
 
 SegmentsPtr Segmentation::Segment(const char* text) const {
-  return Segment(std::string(text));
+  return Segment(std::string_view(text));
 }
 
-SegmentsPtr Segmentation::Segment(std::string_view text) const {
-  return Segment(std::string(text));
+SegmentsPtr Segmentation::Segment(const std::string& str) const {
+  return Segment(std::string_view(str));
 }

--- a/src/Segmentation.hpp
+++ b/src/Segmentation.hpp
@@ -25,15 +25,30 @@
 
 namespace opencc {
 /**
- * Abstract segmentation
+ * Abstract base for text segmentation.
+ *
+ * Splits a UTF-8 string into an ordered list of segments. Each segment is
+ * either a dictionary-matched word or a single unmatched code point / IDS
+ * sequence.  The primary virtual is Segment(std::string_view); the
+ * @c const @c char* and @c const @c std::string& overloads are non-virtual
+ * convenience adapters that forward to it.
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT Segmentation {
 public:
   virtual ~Segmentation() {}
-  virtual SegmentsPtr Segment(const std::string& text) const = 0;
 
+  /**
+   * Splits @p text into segments and returns them.
+   * This is the primary override point for subclasses.
+   */
+  virtual SegmentsPtr Segment(std::string_view text) const = 0;
+
+  /** Convenience overload for null-terminated C strings. */
   SegmentsPtr Segment(const char* text) const;
-  SegmentsPtr Segment(std::string_view text) const;
+
+  /** Convenience overload for std::string. */
+  SegmentsPtr Segment(const std::string& str) const;
 };
 } // namespace opencc

--- a/src/Segments.hpp
+++ b/src/Segments.hpp
@@ -20,6 +20,7 @@
 
 #include <cstring>
 #include <iterator>
+#include <string_view>
 
 #include "Common.hpp"
 
@@ -52,6 +53,11 @@ public:
   void AddSegment(const std::string& str) {
     indexes.push_back(std::make_pair(managed.size(), true));
     managed.push_back(str);
+  }
+
+  void AddSegment(std::string_view sv) {
+    indexes.push_back(std::make_pair(managed.size(), true));
+    managed.emplace_back(sv);
   }
 
   class iterator {

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -173,7 +173,7 @@ size_t SimpleConverter::Convert(const char* input, size_t length,
 }
 
 ConversionInspectionResult
-SimpleConverter::Inspect(const std::string& input) const {
+SimpleConverter::Inspect(std::string_view input) const {
   try {
     const InternalData* data = (InternalData*)internalData;
     return data->converter->Inspect(input);

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -175,7 +175,7 @@ public:
    * output string.
    * @param input Text to be inspected.
    */
-  ConversionInspectionResult Inspect(const std::string& input) const;
+  ConversionInspectionResult Inspect(std::string_view input) const;
 
 private:
   const void* internalData;

--- a/src/SimpleConverter.hpp
+++ b/src/SimpleConverter.hpp
@@ -39,8 +39,7 @@ namespace opencc {
 struct ConfigLoadOptions;
 
 /**
- * A high level converter
- * This interface does not require C++11 to compile.
+ * A high-level converter.
  * @ingroup opencc_simple_api
  */
 class OPENCC_EXPORT SimpleConverter {

--- a/src/SingleStageConverter.cpp
+++ b/src/SingleStageConverter.cpp
@@ -41,7 +41,7 @@ std::string SingleStageConverter::Convert(std::string_view text) const {
 }
 
 ConversionInspectionResult
-SingleStageConverter::Inspect(const std::string& text) const {
+SingleStageConverter::Inspect(std::string_view text) const {
   ConversionInspectionResult result;
   result.input = text;
 

--- a/src/SingleStageConverter.hpp
+++ b/src/SingleStageConverter.hpp
@@ -22,19 +22,32 @@
 
 namespace opencc {
 /**
- * Single-stage converter: one segmentation pass followed by one conversion
- * chain.
+ * A @c Converter that performs one segmentation pass followed by one
+ * @c ConversionChain.
+ *
+ * This is the standard converter produced by loading a single JSON config
+ * file.  It:
+ *  1. Segments the input using the supplied @c Segmentation (or treats the
+ *     entire input as one segment when @p segmentation is @c nullptr).
+ *  2. Passes each segment through the @c ConversionChain, which applies one
+ *     or more dictionaries in order.
+ *
  * @ingroup opencc_cpp_api
  */
 class OPENCC_EXPORT SingleStageConverter : public Converter {
 public:
+  /**
+   * @param segmentation  Segmentation strategy to use, or @c nullptr to skip
+   *   segmentation and treat the whole input as a single segment.
+   * @param conversionChain  Ordered dictionary chain applied to each segment.
+   */
   SingleStageConverter(SegmentationPtr segmentation,
                        ConversionChainPtr conversionChain)
       : segmentation(segmentation), conversionChain(conversionChain) {}
 
   std::string Convert(std::string_view text) const override;
 
-  ConversionInspectionResult Inspect(const std::string& text) const override;
+  ConversionInspectionResult Inspect(std::string_view text) const override;
 
   SegmentationPtr GetSegmentation() const override { return segmentation; }
 


### PR DESCRIPTION
Replace const std::string& with std::string_view across all read-only text parameters in the core conversion pipeline, and expand class/method documentation to clarify architectural roles.

Detailed Changes:

- **Segmentation**:
  - Flip the pure virtual from Segment(const std::string&) to Segment(std::string_view); keep const char* and const std::string& as non-virtual convenience adapters that forward to it.
  - MaxMatchSegmentation: drop the redundant Segment(const std::string&) override; mark the string_view overload override.
  - JiebaSegmentation: same consolidation as MaxMatchSegmentation.
  - PluginSegmentationAdapter: change override to string_view; construct a std::string internally to satisfy the null-terminated C plugin API.
  - BuildSegmentsFromLengths (PluginSegmentation.cpp): accept string_view, use data()/size() instead of c_str()/strlen.
  - Add AddSegment(std::string_view) to Segments and include <string_view>.

- **Conversion**:
  - Replace Convert(const std::string& phrase) with Convert(std::string_view), implemented with a length-based loop (pstr < phraseEnd) so no null-termination is required.
  - Convert(const char*) now delegates to Convert(string_view(phrase)).
  - AppendConverted(const char*, std::string*) retains its own null-terminated loop as it is the hot path called by ConversionChain.

- **Inspect**:
  - Converter::Inspect, SingleStageConverter::Inspect, PipelineConverter::Inspect, and SimpleConverter::Inspect all change from const std::string& to std::string_view.

- **Doxygen documentation**:
  - Segmentation.hpp: document the primary virtual vs. adapter distinction.
  - Conversion.hpp: describe single-dictionary/single-segment role; document all four Convert/AppendConverted overloads including hot-path note.
  - ConversionChain.hpp: explain ordered composition and phrase-before-character priority; document Convert, AppendConvertedSegment, and ConvertWithTrace.
  - Converter.hpp: describe architecture (Segmentation + ConversionChain coordination), list concrete subclasses, note nullptr returns from GetSegmentation/GetConversionChain.
  - SingleStageConverter.hpp: document two-step flow and nullptr segmentation behaviour; add constructor parameter docs.
  - PipelineConverter.hpp: explain multi-stage purpose with s2twp as example; document Inspect limitations and nullptr GetConversionChain.