### PR TITLE
Complete PipelineConverter::Inspect, fix NUL-safe JSON, and eliminate hot-path copies

### DIFF
--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -26,13 +26,13 @@ using namespace opencc;
 Conversion::Conversion(DictPtr _dict)
     : dict(_dict), prefixMatch(new PrefixMatch(_dict)) {}
 
-std::string Conversion::Convert(std::string_view phrase) const {
+void Conversion::AppendConverted(std::string_view phrase,
+                                  std::string* output) const {
   if (phrase.empty()) {
-    return std::string();
+    return;
   }
-  std::string buffer;
   const size_t phraseLength = phrase.size();
-  buffer.reserve(phraseLength + phraseLength / 5);
+  output->reserve(output->size() + phraseLength + phraseLength / 5);
 
   const char* phraseData = phrase.data();
   const char* phraseEnd = phraseData + phraseLength;
@@ -51,16 +51,24 @@ std::string Conversion::Convert(std::string_view phrase) const {
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      buffer.append(pstr, matchedLength);
+      output->append(pstr, matchedLength);
     } else {
       matchedLength = matched.keyLength;
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      buffer.append(matched.value.data(), matched.value.size());
+      output->append(matched.value.data(), matched.value.size());
     }
     pstr += matchedLength;
   }
+}
+
+std::string Conversion::Convert(std::string_view phrase) const {
+  if (phrase.empty()) {
+    return std::string();
+  }
+  std::string buffer;
+  AppendConverted(phrase, &buffer);
   return buffer;
 }
 
@@ -69,42 +77,7 @@ std::string Conversion::Convert(const char* phrase) const {
 }
 
 void Conversion::AppendConverted(const char* phrase, std::string* output) const {
-  // Calculate string end to prevent reading beyond null terminator
-  const char* phraseEnd = phrase;
-  while (*phraseEnd != '\0') {
-    phraseEnd++;
-  }
-  const size_t phraseLength = phraseEnd - phrase;
-  output->reserve(output->size() + phraseLength + phraseLength / 5);
-
-  for (const char* pstr = phrase; *pstr != '\0';) {
-    size_t remainingLength = phraseEnd - pstr;
-    const PrefixMatchView matched =
-        prefixMatch->MatchPrefixView(pstr, remainingLength);
-    size_t matchedLength;
-    if (!matched.matched) {
-      matchedLength =
-          UTF8Util::NextIdeographicDescriptionSequenceLength(pstr,
-                                                             remainingLength);
-      if (matchedLength == 0) {
-        matchedLength = UTF8Util::NextCharLength(pstr);
-      }
-      // Ensure we don't read beyond the null terminator
-      if (matchedLength > remainingLength) {
-        matchedLength = remainingLength;
-      }
-      output->append(pstr, matchedLength);
-    } else {
-      matchedLength = matched.keyLength;
-      // Defensive: ensure dictionary key length does not exceed remaining input
-      // (MatchPrefix should already guarantee this, but defense in depth)
-      if (matchedLength > remainingLength) {
-        matchedLength = remainingLength;
-      }
-      output->append(matched.value.data(), matched.value.size());
-    }
-    pstr += matchedLength;
-  }
+  AppendConverted(std::string_view(phrase), output);
 }
 
 SegmentsPtr Conversion::Convert(const SegmentsPtr& input) const {

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -38,8 +38,8 @@ std::string Conversion::Convert(std::string_view phrase) const {
   const char* phraseEnd = phraseData + phraseLength;
   for (const char* pstr = phraseData; pstr < phraseEnd;) {
     size_t remainingLength = phraseEnd - pstr;
-    const PrefixMatch::Match matched =
-        prefixMatch->MatchPrefix(pstr, remainingLength);
+    const PrefixMatchView matched =
+        prefixMatch->MatchPrefixView(pstr, remainingLength);
     size_t matchedLength;
     if (!matched.matched) {
       matchedLength =
@@ -57,7 +57,7 @@ std::string Conversion::Convert(std::string_view phrase) const {
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      buffer.append(*matched.value);
+      buffer.append(matched.value.data(), matched.value.size());
     }
     pstr += matchedLength;
   }
@@ -79,8 +79,8 @@ void Conversion::AppendConverted(const char* phrase, std::string* output) const 
 
   for (const char* pstr = phrase; *pstr != '\0';) {
     size_t remainingLength = phraseEnd - pstr;
-    const PrefixMatch::Match matched =
-        prefixMatch->MatchPrefix(pstr, remainingLength);
+    const PrefixMatchView matched =
+        prefixMatch->MatchPrefixView(pstr, remainingLength);
     size_t matchedLength;
     if (!matched.matched) {
       matchedLength =
@@ -101,7 +101,7 @@ void Conversion::AppendConverted(const char* phrase, std::string* output) const 
       if (matchedLength > remainingLength) {
         matchedLength = remainingLength;
       }
-      output->append(*matched.value);
+      output->append(matched.value.data(), matched.value.size());
     }
     pstr += matchedLength;
   }

--- a/src/Conversion.hpp
+++ b/src/Conversion.hpp
@@ -60,6 +60,13 @@ public:
   /**
    * Converts @p phrase and appends the result to @p output.
    * Preferred in hot paths (e.g. ConversionChain) to avoid extra allocations.
+   * @param phrase UTF-8 text; need not be null-terminated.
+   * @param output Destination buffer; content is appended, not replaced.
+   */
+  void AppendConverted(std::string_view phrase, std::string* output) const;
+
+  /**
+   * Converts @p phrase and appends the result to @p output.
    * @param phrase Null-terminated UTF-8 text.
    * @param output Destination buffer; content is appended, not replaced.
    */

--- a/src/ConversionChain.cpp
+++ b/src/ConversionChain.cpp
@@ -63,6 +63,9 @@ void ConversionChain::AppendConvertedSegment(const char* segment,
 
 void ConversionChain::AppendConvertedSegment(std::string_view segment,
                                              std::string* output) const {
+  if (segment.empty()) {
+    return;
+  }
   if (conversions.empty()) {
     output->append(segment.data(), segment.size());
     return;

--- a/src/ConversionChain.cpp
+++ b/src/ConversionChain.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <list>
+#include <string_view>
 
 #include "ConversionChain.hpp"
 #include "Segments.hpp"
@@ -38,6 +39,32 @@ void ConversionChain::AppendConvertedSegment(const char* segment,
                                              std::string* output) const {
   if (conversions.empty()) {
     output->append(segment);
+    return;
+  }
+
+  auto conversion = conversions.begin();
+  auto lastConversion = conversions.end();
+  --lastConversion;
+  if (conversion == lastConversion) {
+    (*conversion)->AppendConverted(segment, output);
+    return;
+  }
+
+  std::string converted;
+  (*conversion)->AppendConverted(segment, &converted);
+  ++conversion;
+  for (; conversion != lastConversion; ++conversion) {
+    std::string next;
+    (*conversion)->AppendConverted(converted.c_str(), &next);
+    converted.swap(next);
+  }
+  (*lastConversion)->AppendConverted(converted.c_str(), output);
+}
+
+void ConversionChain::AppendConvertedSegment(std::string_view segment,
+                                             std::string* output) const {
+  if (conversions.empty()) {
+    output->append(segment.data(), segment.size());
     return;
   }
 

--- a/src/ConversionChain.hpp
+++ b/src/ConversionChain.hpp
@@ -57,6 +57,15 @@ public:
   void AppendConvertedSegment(const char* segment, std::string* output) const;
 
   /**
+   * Like @c AppendConvertedSegment(const char*, std::string*) but accepts the
+   * segment as a @c string_view, avoiding a copy when the caller already has a
+   * non-null-terminated view (e.g. @c SingleStageConverter with no
+   * segmentation).
+   */
+  void AppendConvertedSegment(std::string_view segment,
+                              std::string* output) const;
+
+  /**
    * Converts @p input through the chain and records every intermediate
    * @c Segments after each conversion stage.
    * @return One entry per conversion in the chain, in order.

--- a/src/ConversionChainTest.cpp
+++ b/src/ConversionChainTest.cpp
@@ -167,13 +167,46 @@ TEST_F(PipelineConverterTest, GetSegmentationEmptyPipelineReturnsNullptr) {
   EXPECT_EQ(nullptr, pipeline.GetSegmentation());
 }
 
-TEST_F(PipelineConverterTest, InspectReturnsInputOutputWithNoStageDetail) {
+TEST_F(PipelineConverterTest, InspectPopulatesPipelineStages) {
   PipelineConverter pipeline({stage1, stage2});
   const ConversionInspectionResult result = pipeline.Inspect(utf8("钅"));
+
+  // Pipeline-level fields
   EXPECT_EQ(utf8("钅"), result.input);
   EXPECT_EQ(utf8("金"), result.output);
+  // segments/stages are SingleStageConverter concepts; empty at pipeline level
   EXPECT_TRUE(result.segments.empty());
   EXPECT_TRUE(result.stages.empty());
+
+  // Each child stage is fully inspected
+  ASSERT_EQ(2u, result.pipelineStages.size());
+
+  // Stage 1: 钅 → 釒
+  EXPECT_EQ(utf8("钅"), result.pipelineStages[0].input);
+  EXPECT_EQ(utf8("釒"), result.pipelineStages[0].output);
+  EXPECT_FALSE(result.pipelineStages[0].segments.empty());
+  EXPECT_FALSE(result.pipelineStages[0].stages.empty());
+  EXPECT_TRUE(result.pipelineStages[0].pipelineStages.empty());
+
+  // Stage 2: 釒 → 金, and its input must equal stage 1's output
+  EXPECT_EQ(result.pipelineStages[0].output, result.pipelineStages[1].input);
+  EXPECT_EQ(utf8("金"), result.pipelineStages[1].output);
+  EXPECT_FALSE(result.pipelineStages[1].stages.empty());
+  EXPECT_TRUE(result.pipelineStages[1].pipelineStages.empty());
+}
+
+TEST_F(PipelineConverterTest, InspectEmptyPipelineReturnsTrivialResult) {
+  PipelineConverter pipeline({});
+  const ConversionInspectionResult result = pipeline.Inspect(utf8("钅"));
+  EXPECT_EQ(utf8("钅"), result.input);
+  EXPECT_EQ(utf8("钅"), result.output);
+  EXPECT_TRUE(result.pipelineStages.empty());
+}
+
+TEST_F(PipelineConverterTest, InspectOutputMatchesConvert) {
+  PipelineConverter pipeline({stage1, stage2});
+  const ConversionInspectionResult result = pipeline.Inspect(utf8("钅"));
+  EXPECT_EQ(pipeline.Convert(utf8("钅")), result.output);
 }
 
 } // namespace opencc

--- a/src/ConversionInspection.hpp
+++ b/src/ConversionInspection.hpp
@@ -33,15 +33,41 @@ struct ConversionInspectionStage {
 };
 
 /**
- * Full inspection result for a single input text.
- * Contains the original input, initial segments after segmentation,
- * per-stage conversion results, and the final output.
+ * Full inspection result returned by Converter::Inspect().
+ *
+ * The fields that are populated depend on the concrete Converter type:
+ *
+ * - @b SingleStageConverter fills @c segments (initial segmentation),
+ *   @c stages (per-Conversion trace through the ConversionChain), and
+ *   @c output.  @c pipelineStages is empty.
+ *
+ * - @b PipelineConverter fills @c pipelineStages (one entry per child
+ *   Converter, each with its own fully populated result) and @c output.
+ *   @c segments and @c stages are empty at the pipeline level.
+ *
+ * In both cases @c input and @c output are always populated.
+ *
  * @ingroup opencc_cpp_api
  */
 struct ConversionInspectionResult {
+  /** The original input text passed to Inspect(). */
   std::string input;
+
+  /** Initial segmentation produced by this converter's Segmentation.
+   *  Non-empty only for SingleStageConverter. */
   std::vector<std::string> segments;
+
+  /** Per-dictionary-stage trace through this converter's ConversionChain.
+   *  Non-empty only for SingleStageConverter. */
   std::vector<ConversionInspectionStage> stages;
+
+  /** Per-child-converter inspection results for a PipelineConverter.
+   *  Each entry is the full result of the corresponding pipeline stage;
+   *  the structure is naturally recursive for nested pipelines.
+   *  Empty for SingleStageConverter. */
+  std::vector<ConversionInspectionResult> pipelineStages;
+
+  /** The final converted output of this converter. Always populated. */
   std::string output;
 };
 

--- a/src/MaxMatchSegmentation.cpp
+++ b/src/MaxMatchSegmentation.cpp
@@ -43,8 +43,8 @@ SegmentsPtr SegmentText(const std::shared_ptr<PrefixMatch>& prefixMatch,
   const char* textEnd = text.data() + text.length();
   for (const char* pstr = text.data(); pstr < textEnd;) {
     size_t remainingLength = textEnd - pstr;
-    const PrefixMatch::Match matched =
-        prefixMatch->MatchPrefix(pstr, remainingLength);
+    const PrefixMatchView matched =
+        prefixMatch->MatchPrefixView(pstr, remainingLength);
     size_t matchedLength;
     if (!matched.matched) {
       matchedLength =
@@ -61,7 +61,7 @@ SegmentsPtr SegmentText(const std::shared_ptr<PrefixMatch>& prefixMatch,
     } else {
       clearBuffer();
       matchedLength = matched.keyLength;
-      segments->AddSegment(*matched.key);
+      segments->AddSegment(matched.key);
       segStart = pstr + matchedLength;
     }
     pstr += matchedLength;

--- a/src/PipelineConverter.cpp
+++ b/src/PipelineConverter.cpp
@@ -32,7 +32,16 @@ ConversionInspectionResult
 PipelineConverter::Inspect(std::string_view text) const {
   ConversionInspectionResult result;
   result.input = text;
-  result.output = Convert(text);
+
+  std::string current(text);
+  result.pipelineStages.reserve(stages.size());
+  for (const ConverterPtr& stage : stages) {
+    ConversionInspectionResult stageResult = stage->Inspect(current);
+    current = stageResult.output;
+    result.pipelineStages.push_back(std::move(stageResult));
+  }
+
+  result.output = current;
   return result;
 }
 

--- a/src/PrefixMatch.hpp
+++ b/src/PrefixMatch.hpp
@@ -40,10 +40,17 @@ public:
   Match MatchPrefix(const char* word, size_t len) const;
 
   /**
-   * Like MatchPrefix but returns non-owning string_view fields.
-   * key is valid for the lifetime of the caller's input buffer.
-   * value is valid for the lifetime of the underlying dictionary (fast-path)
-   * or the lifetime of this PrefixMatch (table-path).
+   * Like MatchPrefix but returns non-owning string_view fields without
+   * copying key or value into thread-local storage.
+   *
+   * Lifetime of the returned views:
+   *  - @b key: points into the caller's input buffer (fast-path singleDict,
+   *    where both MarisaDict and DartsDict return a slice of @p word) or into
+   *    PrefixMatch-owned table storage (table-path LeafMatcher).  Callers
+   *    must not assume one or the other; copy if the key needs to outlive the
+   *    current input position.
+   *  - @b value: valid for the lifetime of the underlying dictionary
+   *    (fast-path) or the lifetime of this PrefixMatch's tables (table-path).
    */
   PrefixMatchView MatchPrefixView(const char* word, size_t len) const;
 

--- a/src/SimpleConverter.cpp
+++ b/src/SimpleConverter.cpp
@@ -145,7 +145,7 @@ std::string SimpleConverter::Convert(const char* input) const {
 
 std::string SimpleConverter::Convert(const char* input, size_t length) const {
   if (length == static_cast<size_t>(-1)) {
-    return Convert(std::string(input));
+    return Convert(std::string_view(input));
   } else {
     return Convert(UTF8Util::FromSubstr(input, length));
   }

--- a/src/SingleStageConverter.cpp
+++ b/src/SingleStageConverter.cpp
@@ -28,9 +28,7 @@ std::string SingleStageConverter::Convert(std::string_view text) const {
   std::string converted;
   converted.reserve(text.length() + text.length() / 5);
   if (segmentation == nullptr) {
-    // AppendConvertedSegment requires null-termination; copy once for this path
-    const std::string owned(text);
-    conversionChain->AppendConvertedSegment(owned.c_str(), &converted);
+    conversionChain->AppendConvertedSegment(text, &converted);
     return converted;
   }
   const SegmentsPtr& segments = segmentation->Segment(text);

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -311,12 +311,13 @@ std::string SerializeSegmentationResultJson(
   return buffer.GetString();
 }
 
-// Serializes the full inspection result as a JSON object with "input",
-// "segments", "stages", and "output" fields. Used with --inspect mode.
-std::string SerializeInspectionResultJson(
-    const ConversionInspectionResult& result) {
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+// Writes a ConversionInspectionResult as a JSON object into writer.
+// Handles both SingleStageConverter results (segments + stages) and
+// PipelineConverter results (pipelineStages), and is called recursively
+// for nested pipeline stages.
+template <typename Writer>
+void WriteInspectionResultJson(Writer& writer,
+                               const ConversionInspectionResult& result) {
   writer.StartObject();
   writer.Key("input");
   writer.String(result.input.c_str());
@@ -341,9 +342,24 @@ std::string SerializeInspectionResultJson(
     writer.EndObject();
   }
   writer.EndArray();
+  writer.Key("pipelineStages");
+  writer.StartArray();
+  for (const auto& ps : result.pipelineStages) {
+    WriteInspectionResultJson(writer, ps);
+  }
+  writer.EndArray();
   writer.Key("output");
   writer.String(result.output.c_str());
   writer.EndObject();
+}
+
+// Serializes the full inspection result as a JSON object. Used with
+// --inspect mode. Handles both single-stage and pipeline converters.
+std::string SerializeInspectionResultJson(
+    const ConversionInspectionResult& result) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  WriteInspectionResultJson(writer, result);
   return buffer.GetString();
 }
 

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -300,11 +300,11 @@ std::string SerializeSegmentationResultJson(
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   writer.StartObject();
   writer.Key("input");
-  writer.String(result.input.c_str());
+  writer.String(result.input.c_str(), result.input.size());
   writer.Key("segments");
   writer.StartArray();
   for (const auto& seg : result.segments) {
-    writer.String(seg.c_str());
+    writer.String(seg.c_str(), seg.size());
   }
   writer.EndArray();
   writer.EndObject();
@@ -320,11 +320,11 @@ void WriteInspectionResultJson(Writer& writer,
                                const ConversionInspectionResult& result) {
   writer.StartObject();
   writer.Key("input");
-  writer.String(result.input.c_str());
+  writer.String(result.input.c_str(), result.input.size());
   writer.Key("segments");
   writer.StartArray();
   for (const auto& seg : result.segments) {
-    writer.String(seg.c_str());
+    writer.String(seg.c_str(), seg.size());
   }
   writer.EndArray();
   writer.Key("stages");
@@ -336,7 +336,7 @@ void WriteInspectionResultJson(Writer& writer,
     writer.Key("segments");
     writer.StartArray();
     for (const auto& seg : stage.segments) {
-      writer.String(seg.c_str());
+      writer.String(seg.c_str(), seg.size());
     }
     writer.EndArray();
     writer.EndObject();
@@ -349,7 +349,7 @@ void WriteInspectionResultJson(Writer& writer,
   }
   writer.EndArray();
   writer.Key("output");
-  writer.String(result.output.c_str());
+  writer.String(result.output.c_str(), result.output.size());
   writer.EndObject();
 }
 


### PR DESCRIPTION
## Summary

  Three interlocking improvements to the conversion pipeline, building on the string_view API
  unification in #1359:

  - Inspect: PipelineConverter::Inspect now returns a fully recursive result.
  ConversionInspectionResult gains a pipelineStages field that carries each stage's own inspect
  result, so callers can trace what each stage of e.g. s2twp did independently. JSON serialisation
  in opencc --inspect emits the nested structure and is now NUL-byte safe (writer.String(ptr, len)
  throughout).
  - Performance — prefix matching: Hot-path calls to MatchPrefix (which copies key/value into
  thread_local std::string) are replaced by MatchPrefixView (returns non-owning string_view) in
  MaxMatchSegmentation::SegmentText, Conversion::Convert, and Conversion::AppendConverted.
  SimpleConverter::Convert(const char*, size_t=-1) also avoids a redundant std::string construction
  on the default-length path.
  - Performance — append path: A new Conversion::AppendConverted(string_view, std::string*) overload
  consolidates the duplicated prefix-match loop body; Convert(string_view) and
  AppendConverted(const char*) both delegate to it. ConversionChain::AppendConvertedSegment gains a
  matching string_view overload whose first conversion stage uses AppendConverted(string_view)
  directly. SingleStageConverter::Convert no longer constructs a std::string owned(text) when
  segmentation == nullptr; it passes the string_view straight through. An empty-string_view guard
  prevents UB (append(nullptr, 0)) in the identity (empty-chain) path.

## Detailed Changes

  - ConversionInspectionResult: pipelineStages: vector<ConversionInspectionResult> added; existing
  segments/stages remain SingleStageConverter-only.
  - PipelineConverter::Inspect: iterates stages, threads each result's output as the next stage's
  input, collects into pipelineStages.
  - CommandLineMain: recursive WriteInspectionResultJson template handles nested pipeline stages;
  all writer.String calls on user text use the (ptr, len) overload.
  - PrefixMatch::MatchPrefixView doc: key lifetime clarified — fast-path points into the caller's
  input buffer; table-path points into PrefixMatch-owned table storage.
  - Conversion: AppendConverted(string_view, std::string*) is now the single loop implementation;
  Convert(string_view) and AppendConverted(const char*) delegate to it.
  - ConversionChain: AppendConvertedSegment(string_view, std::string*) added; first stage uses
  AppendConverted(string_view), subsequent intermediate std::string results continue via c_str().
  - SingleStageConverter: segmentation == nullptr path calls AppendConvertedSegment(string_view)
  directly, no copy.
  - Tests: ConversionChainTest extended with InspectPopulatesPipelineStages,
  InspectEmptyPipelineReturnsTrivialResult, InspectOutputMatchesConvert.

## Tested

  - [x] bazel test //src/... //data/... //test/... //node/... //plugins/... //node/... — 102/102 pass
  - [x] Manual: opencc --inspect -c s2twp produces nested JSON with per-stage segments and stages
  arrays
  - [x] Manual: opencc --inspect output remains valid JSON when input contains NUL bytes