### PR TITLE
Remove redundant mmseg segmentation from single-stage configs

### DIFF
--- a/data/config/hk2t.json
+++ b/data/config/hk2t.json
@@ -3,10 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": { "type": "ocd2", "file": "HKVariantsRevPhrases.ocd2" }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/jp2t.json
+++ b/data/config/jp2t.json
@@ -3,10 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": { "type": "ocd2", "file": "JPShinjitaiPhrases.ocd2" }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/s2t.json
+++ b/data/config/s2t.json
@@ -3,17 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": {
-      "type": "group",
-      "match_policy": "union",
-      "dicts": [
-        { "type": "ocd2", "file": "STPhrases.ocd2" },
-        { "type": "ocd2", "file": "STPhrases_GeneratedFromRegionalPhrases.ocd2" }
-      ]
-    }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/t2hk.json
+++ b/data/config/t2hk.json
@@ -3,17 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": {
-      "type": "group",
-      "match_policy": "short_circuit",
-      "dicts": [
-        { "type": "ocd2", "file": "HKVariantsPhrases.ocd2" },
-        { "type": "ocd2", "file": "HKVariants.ocd2" }
-      ]
-    }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/t2s.json
+++ b/data/config/t2s.json
@@ -3,10 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": { "type": "ocd2", "file": "TSPhrases.ocd2" }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/t2tw.json
+++ b/data/config/t2tw.json
@@ -3,17 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": {
-      "type": "group",
-      "match_policy": "short_circuit",
-      "dicts": [
-        { "type": "ocd2", "file": "TWVariantsPhrases.ocd2" },
-        { "type": "ocd2", "file": "TWVariants.ocd2" }
-      ]
-    }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/data/config/tw2t.json
+++ b/data/config/tw2t.json
@@ -3,10 +3,6 @@
   "normalization": [
     { "dict": { "type": "ocd2", "file": "CJK_Compatibility_Ideographs.ocd2" } }
   ],
-  "segmentation": {
-    "type": "mmseg",
-    "dict": { "type": "ocd2", "file": "TWVariantsRevPhrases.ocd2" }
-  },
   "conversion_chain": [
     {
       "dict": {

--- a/src/tools/CommandLineMain.cpp
+++ b/src/tools/CommandLineMain.cpp
@@ -694,6 +694,12 @@ int CommandLineMain(std::vector<std::string> args) {
     }
     measurement.loadMs +=
         DurationToMilliseconds(std::chrono::steady_clock::now() - loadStart);
+    if (outputMode == OutputMode::Segmentation &&
+        converter->GetSegmentation() == nullptr) {
+      std::cerr << "error: this configuration has no segmentation step; "
+                   "--segmentation is not supported.\n";
+      return 1;
+    }
     bool lineByLine = inputFileName.IsNull();
     measurement.lineByLine = lineByLine;
     measurement.outputMode = outputMode;

--- a/test/CommandLineConvertTest.cpp
+++ b/test/CommandLineConvertTest.cpp
@@ -767,7 +767,7 @@ TEST_F(CommandLineConvertTest, WritesMeasuredResultJson) {
 }
 
 TEST_F(CommandLineConvertTest, SegmentationOutputIsJson) {
-  const std::string config = "s2t";
+  const std::string config = "s2twp";
   const std::string inputFile = InputFile("segmentation_test");
   const std::string outputFile = OutputFile("segmentation_test");
 
@@ -855,6 +855,20 @@ TEST_F(CommandLineConvertTest, SegmentationAndInspectAreMutuallyExclusive) {
   EXPECT_NE(0, exitCode);
 }
 
+TEST_F(CommandLineConvertTest, SegmentationFailsWhenConfigHasNoSegmentation) {
+  // s2t has no segmentation step; --segmentation should exit non-zero.
+  const std::string config = "s2t";
+  const std::string inputFile = InputFile("seg_no_seg_test");
+  const std::string outputFile = OutputFile("seg_no_seg_test");
+  {
+    std::ofstream ofs(inputFile, std::ios::binary);
+    ASSERT_TRUE(ofs.is_open());
+    ofs << "开放中文转换\n";
+  }
+  EXPECT_NE(0, system(TestCommandWithFlags(config, inputFile, outputFile,
+                                           "--segmentation").c_str()));
+}
+
 TEST_F(CommandLineConvertTest, MeasuredResultIncludesOutputMode) {
   const std::string config = "s2t";
   const std::string inputFile = InputFile("inspect_measured_test");
@@ -891,7 +905,7 @@ TEST_F(CommandLineConvertTest, MeasuredResultIncludesOutputMode) {
 // tokens; none of those tokens should already be Traditional Chinese unless
 // the conversion chain ran.
 TEST_F(CommandLineConvertTest, SegmentationDoesNotRunConversionChain) {
-  const std::string config = "s2t";
+  const std::string config = "s2twp";
   const std::string inputFile = InputFile("seg_no_convert_test");
   const std::string outputFile = OutputFile("seg_no_convert_test");
 
@@ -935,7 +949,7 @@ TEST_F(CommandLineConvertTest, SegmentationDoesNotRunConversionChain) {
 // Verify that a multi-line input in --segmentation mode produces exactly one
 // JSON object per input line with no spurious extra record at EOF.
 TEST_F(CommandLineConvertTest, SegmentationNoSpuriousEofRecord) {
-  const std::string config = "s2t";
+  const std::string config = "s2twp";
   const std::string inputFile = InputFile("seg_eof_test");
   const std::string outputFile = OutputFile("seg_eof_test");
 


### PR DESCRIPTION
For configs with a single conversion chain stage, the mmseg segmentation step is mathematically equivalent to the conversion's own greedy longest-prefix-match scan: both use the same greedy strategy, and the segmentation dict is a subset of the conversion dict. Removing the segmentation key lets SingleStageConverter take the existing `segmentation == nullptr` fast-path, eliminating one full pass over the input for these seven configs (s2t, t2s, t2hk, t2tw, hk2t, jp2t, tw2t).

Detailed Changes:
- **Configs**: remove `segmentation` from s2t.json, t2s.json, t2hk.json, t2tw.json, hk2t.json, jp2t.json, tw2t.json.
- **CLI**: add early check in CommandLineMain — when `--segmentation` is requested but the loaded config has no segmentation step, exit with a clear error instead of crashing on a null dereference.
- **Tests**: switch the three `--segmentation` functional tests from s2t (which no longer has a segmentation step) to s2twp; add a new test asserting that `--segmentation` with a no-segmentation config exits non-zero.