### PR TITLE
Honor legacy Python executable CMake option

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(DEFINED PYTHON_EXECUTABLE AND NOT DEFINED Python3_EXECUTABLE)
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
+endif()
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 set(OPENCC_DICT_BIN opencc_dict)


### PR DESCRIPTION
Map PYTHON_EXECUTABLE to Python3_EXECUTABLE before locating Python so existing packaging scripts continue to select the intended interpreter.

----

[data/CMakeLists.txt](https://github.com/BYVoid/OpenCC/blob/38959525c3dc11cfc3da401de412f1c544316d11/data/CMakeLists.txt#L1) 目前已經改用 CMake 的 FindPython3，實際使用的是 Python3_EXECUTABLE；但不少既有 packaging 腳本和舊 CMake 慣例仍傳 PYTHON_EXECUTABLE。如果不作映射，CMake 會忽略這個變數、發出 unused warning，並可能選到另一個非預期的 Python interpreter。OpenCC 的 dictionary generation scripts 依賴 Python，所以此 interpreter selection 應該可控。

Homebrew formula 即一個實例：
https://github.com/Homebrew/homebrew-core/blob/903002c316be3210924e1c11859275e28b0cc309/Formula/o/opencc.rb#L26