### PR TITLE
Integrate cppjieba dictionary conversion into opencc_dict

### DIFF
--- a/plugins/jieba/BUILD.bazel
+++ b/plugins/jieba/BUILD.bazel
@@ -75,13 +75,13 @@ genrule(
         "//plugins/jieba/deps/cppjieba:dict/user.dict.utf8",
     ],
     outs = ["jieba_dict/jieba_merged.ocd2"],
-    cmd = "$(location :cppjieba_dict) -i $(location //plugins/jieba/deps/cppjieba:dict/jieba.dict.utf8) -i $(location //plugins/jieba/deps/cppjieba:dict/user.dict.utf8) -o $@",
-    tools = [":cppjieba_dict"],
+    cmd = "$(location :opencc_jieba_dict_build_tool) -i $(location //plugins/jieba/deps/cppjieba:dict/jieba.dict.utf8) -i $(location //plugins/jieba/deps/cppjieba:dict/user.dict.utf8) -o $@",
+    tools = [":opencc_jieba_dict_build_tool"],
 )
 
 cc_binary(
-    name = "cppjieba_dict",
-    srcs = ["tools/cppjieba_dict.cpp"],
+    name = "opencc_jieba_dict_build_tool",
+    srcs = ["tools/JiebaDictBuildTool.cpp"],
     deps = [
         "//src:dict_lib",
         "//src:dict_entry_lib",

--- a/plugins/jieba/CMakeLists.txt
+++ b/plugins/jieba/CMakeLists.txt
@@ -86,8 +86,8 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     src/JiebaSegmentationPlugin.cpp
   )
   target_link_libraries(opencc_jieba PRIVATE OpenCC::OpenCC)
-  add_executable(cppjieba_dict tools/cppjieba_dict.cpp)
-  target_link_libraries(cppjieba_dict PRIVATE OpenCC::OpenCC)
+  add_executable(opencc_jieba_dict_build_tool tools/JiebaDictBuildTool.cpp)
+  target_link_libraries(opencc_jieba_dict_build_tool PRIVATE OpenCC::OpenCC)
 else()
   add_library(opencc_jieba SHARED
     src/JiebaSegmentation.cpp
@@ -99,12 +99,12 @@ else()
     ${PROJECT_BINARY_DIR}/src
   )
   target_link_libraries(opencc_jieba PRIVATE libopencc)
-  add_executable(cppjieba_dict tools/cppjieba_dict.cpp)
-  target_include_directories(cppjieba_dict PRIVATE
+  add_executable(opencc_jieba_dict_build_tool tools/JiebaDictBuildTool.cpp)
+  target_include_directories(opencc_jieba_dict_build_tool PRIVATE
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_BINARY_DIR}/src
   )
-  target_link_libraries(cppjieba_dict PRIVATE libopencc)
+  target_link_libraries(opencc_jieba_dict_build_tool PRIVATE libopencc)
 endif()
 target_compile_definitions(opencc_jieba PRIVATE OPENCC_PLUGIN_BUILD)
 
@@ -163,14 +163,14 @@ if (WIN32 AND OPENCC_CAN_RUN_CPPJIEBA_DICT)
   endif()
 
   add_custom_target(
-    copy_opencc_to_cppjieba_dict
+    copy_opencc_to_jieba_dict_build_tool
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:${_opencc_runtime_target}>
-            $<TARGET_FILE_DIR:cppjieba_dict>
-    DEPENDS cppjieba_dict
-    COMMENT "Copying OpenCC runtime to directory of cppjieba_dict"
+            $<TARGET_FILE_DIR:opencc_jieba_dict_build_tool>
+    DEPENDS opencc_jieba_dict_build_tool
+    COMMENT "Copying OpenCC runtime to directory of opencc_jieba_dict_build_tool"
   )
-  set(JIEBA_MERGED_DICT_WIN32_DEPENDS copy_opencc_to_cppjieba_dict)
+  set(JIEBA_MERGED_DICT_WIN32_DEPENDS copy_opencc_to_jieba_dict_build_tool)
 else()
   set(JIEBA_MERGED_DICT_WIN32_DEPENDS)
 endif()
@@ -179,13 +179,13 @@ if (OPENCC_CAN_RUN_CPPJIEBA_DICT)
   add_custom_command(
     OUTPUT "${JIEBA_MERGED_DICT}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${JIEBA_MERGED_DICT_DIR}"
-    COMMAND $<TARGET_FILE:cppjieba_dict>
+    COMMAND $<TARGET_FILE:opencc_jieba_dict_build_tool>
             -i "${CMAKE_CURRENT_SOURCE_DIR}/deps/cppjieba/dict/jieba.dict.utf8"
             -i "${CMAKE_CURRENT_SOURCE_DIR}/deps/cppjieba/dict/user.dict.utf8"
             -o "${JIEBA_MERGED_DICT}"
     DEPENDS
       ${JIEBA_MERGED_DICT_WIN32_DEPENDS}
-      cppjieba_dict
+      opencc_jieba_dict_build_tool
       "${CMAKE_CURRENT_SOURCE_DIR}/deps/cppjieba/dict/jieba.dict.utf8"
       "${CMAKE_CURRENT_SOURCE_DIR}/deps/cppjieba/dict/user.dict.utf8"
     VERBATIM
@@ -206,7 +206,8 @@ if (WIN32)
   endif()
   if (_opencc_target_type STREQUAL "STATIC_LIBRARY")
     target_compile_definitions(opencc_jieba PRIVATE Opencc_BUILT_AS_STATIC)
-    target_compile_definitions(cppjieba_dict PRIVATE Opencc_BUILT_AS_STATIC)
+    target_compile_definitions(opencc_jieba_dict_build_tool PRIVATE
+      Opencc_BUILT_AS_STATIC)
   endif()
 endif()
 
@@ -225,11 +226,6 @@ if (BUILD_OPENCC_JIEBA_PLUGIN AND OPENCC_ENABLE_INSTALL)
     LIBRARY DESTINATION ${DIR_PLUGIN}
     ARCHIVE DESTINATION ${DIR_PLUGIN}
     RUNTIME DESTINATION ${DIR_PLUGIN}
-  )
-
-  install(
-    TARGETS cppjieba_dict
-    RUNTIME DESTINATION bin
   )
 
   if (OPENCC_CAN_RUN_CPPJIEBA_DICT)

--- a/plugins/jieba/tools/JiebaDictBuildTool.cpp
+++ b/plugins/jieba/tools/JiebaDictBuildTool.cpp
@@ -51,7 +51,8 @@ using opencc::Optional;
 using opencc::SerializableDict;
 
 void PrintUsage(std::ostream& os) {
-  os << "Usage: cppjieba_dict -i <dict> [-i <dict> ...] -o <output.ocd2>"
+  os << "Usage: opencc_jieba_dict_build_tool -i <dict> [-i <dict> ...] "
+        "-o <output.ocd2>"
      << std::endl
      << "  -i <dict>         Input dictionary file. The first -i is parsed as"
      << std::endl
@@ -85,20 +86,20 @@ bool IsCommentOrEmpty(const std::string& line) {
   return true;
 }
 
-std::vector<std::string> ParseBaseDictValues(const std::vector<std::string>& tokens,
-                                             size_t line_number) {
+std::vector<std::string>
+ParseBaseDictValues(const std::vector<std::string>& tokens, size_t lineNumber) {
   if (tokens.size() != 3) {
     throw std::runtime_error("invalid base dict line " +
-                             std::to_string(line_number));
+                             std::to_string(lineNumber));
   }
   return std::vector<std::string>{tokens[1], tokens[2], "base"};
 }
 
-std::vector<std::string> ParseUserDictValues(const std::vector<std::string>& tokens,
-                                             size_t line_number) {
+std::vector<std::string>
+ParseUserDictValues(const std::vector<std::string>& tokens, size_t lineNumber) {
   if (tokens.empty() || tokens.size() > 3) {
     throw std::runtime_error("invalid user dict line " +
-                             std::to_string(line_number));
+                             std::to_string(lineNumber));
   }
   if (tokens.size() == 1) {
     return std::vector<std::string>{"", "", "user_default"};
@@ -111,12 +112,12 @@ std::vector<std::string> ParseUserDictValues(const std::vector<std::string>& tok
 
 class LexiconDict : public Dict {
 public:
-  explicit LexiconDict(std::vector<std::unique_ptr<DictEntry> > entries)
-      : lexicon_(new Lexicon(std::move(entries))), max_length_(0) {
+  explicit LexiconDict(std::vector<std::unique_ptr<DictEntry>> entries)
+      : lexicon_(new Lexicon(std::move(entries))), maxLength_(0) {
     for (size_t i = 0; i < lexicon_->Length(); ++i) {
       const DictEntry* entry = lexicon_->At(i);
-      if (entry->KeyLength() > max_length_) {
-        max_length_ = entry->KeyLength();
+      if (entry->KeyLength() > maxLength_) {
+        maxLength_ = entry->KeyLength();
       }
     }
   }
@@ -134,18 +135,18 @@ public:
 
   Optional<const DictEntry*> MatchPrefix(const char* word,
                                          size_t len) const override {
-    const size_t capped_len = len < max_length_ ? len : max_length_;
+    const size_t cappedLen = len < maxLength_ ? len : maxLength_;
     const DictEntry* best = nullptr;
-    size_t best_length = 0;
+    size_t bestLength = 0;
     for (size_t i = 0; i < lexicon_->Length(); ++i) {
       const DictEntry* entry = lexicon_->At(i);
-      const size_t entry_length = entry->KeyLength();
-      if (entry_length > capped_len || entry_length <= best_length) {
+      const size_t entryLength = entry->KeyLength();
+      if (entryLength > cappedLen || entryLength <= bestLength) {
         continue;
       }
-      if (std::string(word, entry_length) == entry->Key()) {
+      if (std::string(word, entryLength) == entry->Key()) {
         best = entry;
-        best_length = entry_length;
+        bestLength = entryLength;
       }
     }
     if (best == nullptr) {
@@ -156,60 +157,60 @@ public:
 
   std::vector<const DictEntry*> MatchAllPrefixes(const char* word,
                                                  size_t len) const override {
-    const size_t capped_len = len < max_length_ ? len : max_length_;
+    const size_t cappedLen = len < maxLength_ ? len : maxLength_;
     std::vector<const DictEntry*> matches;
     for (size_t i = 0; i < lexicon_->Length(); ++i) {
       const DictEntry* entry = lexicon_->At(i);
-      const size_t entry_length = entry->KeyLength();
-      if (entry_length > capped_len) {
+      const size_t entryLength = entry->KeyLength();
+      if (entryLength > cappedLen) {
         continue;
       }
-      if (std::string(word, entry_length) == entry->Key()) {
+      if (std::string(word, entryLength) == entry->Key()) {
         matches.push_back(entry);
       }
     }
     return matches;
   }
 
-  size_t KeyMaxLength() const override { return max_length_; }
+  size_t KeyMaxLength() const override { return maxLength_; }
 
   LexiconPtr GetLexicon() const override { return lexicon_; }
 
 private:
   LexiconPtr lexicon_;
-  size_t max_length_;
+  size_t maxLength_;
 };
 
 void LoadBaseDict(const std::string& path,
-                  std::map<std::string, std::vector<std::string> >& entries) {
+                  std::map<std::string, std::vector<std::string>>& entries) {
   std::ifstream ifs(path.c_str());
   if (!ifs.is_open()) {
     throw std::runtime_error("failed to open base dict: " + path);
   }
 
   std::string line;
-  size_t line_number = 0;
+  size_t lineNumber = 0;
   while (std::getline(ifs, line)) {
-    ++line_number;
+    ++lineNumber;
     if (IsCommentOrEmpty(line)) {
       continue;
     }
     const std::vector<std::string> tokens = SplitWhitespace(line);
-    entries[tokens[0]] = ParseBaseDictValues(tokens, line_number);
+    entries[tokens[0]] = ParseBaseDictValues(tokens, lineNumber);
   }
 }
 
 void LoadUserDict(const std::string& path,
-                  std::map<std::string, std::vector<std::string> >& entries) {
+                  std::map<std::string, std::vector<std::string>>& entries) {
   std::ifstream ifs(path.c_str());
   if (!ifs.is_open()) {
     throw std::runtime_error("failed to open user dict: " + path);
   }
 
   std::string line;
-  size_t line_number = 0;
+  size_t lineNumber = 0;
   while (std::getline(ifs, line)) {
-    ++line_number;
+    ++lineNumber;
     if (IsCommentOrEmpty(line)) {
       continue;
     }
@@ -217,85 +218,87 @@ void LoadUserDict(const std::string& path,
     if (tokens.empty()) {
       continue;
     }
-    entries[tokens[0]] = ParseUserDictValues(tokens, line_number);
+    entries[tokens[0]] = ParseUserDictValues(tokens, lineNumber);
   }
 }
 
-void WriteOcd2(const std::map<std::string, std::vector<std::string> >& entries,
-               const std::string& output_path) {
-  std::vector<std::unique_ptr<DictEntry> > lexicon_entries;
-  lexicon_entries.reserve(entries.size());
-  for (std::map<std::string, std::vector<std::string> >::const_iterator it =
-           entries.begin();
-       it != entries.end(); ++it) {
-    lexicon_entries.push_back(
-        std::unique_ptr<DictEntry>(DictEntryFactory::New(it->first, it->second)));
+void WriteOcd2(const std::map<std::string, std::vector<std::string>>& entries,
+               const std::string& outputPath) {
+  std::vector<std::unique_ptr<DictEntry>> lexiconEntries;
+  lexiconEntries.reserve(entries.size());
+  for (const auto& entry : entries) {
+    lexiconEntries.push_back(std::unique_ptr<DictEntry>(
+        DictEntryFactory::New(entry.first, entry.second)));
   }
 
-  LexiconDict dict(std::move(lexicon_entries));
-  MarisaDictPtr marisa_dict = MarisaDict::NewFromDict(dict);
-  static_cast<const SerializableDict&>(*marisa_dict).SerializeToFile(output_path);
+  LexiconDict dict(std::move(lexiconEntries));
+  MarisaDictPtr marisaDict = MarisaDict::NewFromDict(dict);
+  static_cast<const SerializableDict&>(*marisaDict).SerializeToFile(outputPath);
 }
 
-}  // namespace
+} // namespace
 
 int main(int argc, char** argv) {
-  std::vector<std::string> input_paths;
-  std::string output_path;
+  std::vector<std::string> inputPaths;
+  std::string outputPath;
 
   for (int i = 1; i < argc; ++i) {
     const std::string arg = argv[i];
     if (arg == "-i") {
       if (i + 1 >= argc) {
-        std::cerr << "cppjieba_dict: missing value after -i" << std::endl;
+        std::cerr << "opencc_jieba_dict_build_tool: missing value after -i"
+                  << std::endl;
         PrintUsage(std::cerr);
         return 1;
       }
-      input_paths.push_back(argv[++i]);
+      inputPaths.push_back(argv[++i]);
       continue;
     }
     if (arg == "-o") {
       if (i + 1 >= argc) {
-        std::cerr << "cppjieba_dict: missing value after -o" << std::endl;
+        std::cerr << "opencc_jieba_dict_build_tool: missing value after -o"
+                  << std::endl;
         PrintUsage(std::cerr);
         return 1;
       }
-      if (!output_path.empty()) {
-        std::cerr << "cppjieba_dict: exactly one -o is required" << std::endl;
+      if (!outputPath.empty()) {
+        std::cerr << "opencc_jieba_dict_build_tool: exactly one -o is required"
+                  << std::endl;
         PrintUsage(std::cerr);
         return 1;
       }
-      output_path = argv[++i];
+      outputPath = argv[++i];
       continue;
     }
 
-    std::cerr << "cppjieba_dict: unknown argument: " << arg << std::endl;
+    std::cerr << "opencc_jieba_dict_build_tool: unknown argument: " << arg
+              << std::endl;
     PrintUsage(std::cerr);
     return 1;
   }
 
-  if (input_paths.empty()) {
-    std::cerr << "cppjieba_dict: at least one -i is required" << std::endl;
+  if (inputPaths.empty()) {
+    std::cerr << "opencc_jieba_dict_build_tool: at least one -i is required"
+              << std::endl;
     PrintUsage(std::cerr);
     return 1;
   }
-  if (output_path.empty()) {
-    std::cerr << "cppjieba_dict: exactly one -o is required" << std::endl;
+  if (outputPath.empty()) {
+    std::cerr << "opencc_jieba_dict_build_tool: exactly one -o is required"
+              << std::endl;
     PrintUsage(std::cerr);
     return 1;
   }
 
   try {
-    std::map<std::string, std::vector<std::string> > entries;
-    LoadBaseDict(input_paths.front(), entries);
-    for (size_t i = 1; i < input_paths.size(); ++i) {
-      LoadUserDict(input_paths[i], entries);
+    std::map<std::string, std::vector<std::string>> entries;
+    LoadBaseDict(inputPaths.front(), entries);
+    for (size_t i = 1; i < inputPaths.size(); ++i) {
+      LoadUserDict(inputPaths[i], entries);
     }
-    WriteOcd2(entries, output_path);
-    std::cout << "Wrote " << entries.size() << " entries to " << output_path
-              << std::endl;
+    WriteOcd2(entries, outputPath);
   } catch (const std::exception& e) {
-    std::cerr << "cppjieba_dict: " << e.what() << std::endl;
+    std::cerr << "opencc_jieba_dict_build_tool: " << e.what() << std::endl;
     return 1;
   }
 

--- a/scripts/build-deb-packages.sh
+++ b/scripts/build-deb-packages.sh
@@ -245,7 +245,7 @@ main() {
     -DOpenCC_DIR="$opencc_package_dir" \
     "${cmake_cross_args[@]}"
   if [ "$is_cross_build" = TRUE ]; then
-    cmake --build "$plugin_build_dir" --target opencc_jieba cppjieba_dict
+    cmake --build "$plugin_build_dir" --target opencc_jieba
   else
     cmake --build "$plugin_build_dir"
   fi

--- a/src/DictConverter.cpp
+++ b/src/DictConverter.cpp
@@ -16,7 +16,13 @@
  * limitations under the License.
  */
 
+#include <cctype>
+#include <fstream>
+#include <map>
+#include <sstream>
+
 #include "DictConverter.hpp"
+#include "DictEntry.hpp"
 #include "Exception.hpp"
 #include "Lexicon.hpp"
 #include "MarisaDict.hpp"
@@ -29,9 +35,101 @@
 
 using namespace opencc;
 
+namespace {
+
+std::vector<std::string> SplitWhitespace(const std::string& line) {
+  std::vector<std::string> tokens;
+  std::istringstream iss(line);
+  std::string token;
+  while (iss >> token) {
+    tokens.push_back(token);
+  }
+  return tokens;
+}
+
+bool IsCommentOrEmpty(const std::string& line) {
+  if (line.empty()) {
+    return true;
+  }
+  for (size_t i = 0; i < line.size(); ++i) {
+    const unsigned char ch = static_cast<unsigned char>(line[i]);
+    if (!std::isspace(ch)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<std::string> ParseCppJiebaBaseValues(
+    const std::vector<std::string>& tokens, size_t lineNumber) {
+  if (tokens.size() != 3) {
+    throw InvalidFormat("Invalid cppjieba_utf8 base dict line: " +
+                        std::to_string(lineNumber));
+  }
+  return std::vector<std::string>{tokens[1], tokens[2], "base"};
+}
+
+std::vector<std::string> ParseCppJiebaUserValues(
+    const std::vector<std::string>& tokens, size_t lineNumber) {
+  if (tokens.empty() || tokens.size() > 3) {
+    throw InvalidFormat("Invalid cppjieba_utf8 user dict line: " +
+                        std::to_string(lineNumber));
+  }
+  if (tokens.size() == 1) {
+    return std::vector<std::string>{"", "", "user_default"};
+  }
+  if (tokens.size() == 2) {
+    return std::vector<std::string>{"", tokens[1], "user_default"};
+  }
+  return std::vector<std::string>{tokens[1], tokens[2], "user_freq"};
+}
+
+void LoadCppJiebaUtf8Dict(
+    const std::string& path, bool isBaseDict,
+    std::map<std::string, std::vector<std::string>>& entries) {
+  std::ifstream ifs(path.c_str());
+  if (!ifs.is_open()) {
+    throw FileNotFound(path);
+  }
+
+  std::string line;
+  size_t lineNumber = 0;
+  while (std::getline(ifs, line)) {
+    ++lineNumber;
+    if (IsCommentOrEmpty(line)) {
+      continue;
+    }
+    const std::vector<std::string> tokens = SplitWhitespace(line);
+    entries[tokens[0]] =
+        isBaseDict ? ParseCppJiebaBaseValues(tokens, lineNumber)
+                   : ParseCppJiebaUserValues(tokens, lineNumber);
+  }
+}
+
+DictPtr LoadCppJiebaUtf8Dictionaries(
+    const std::vector<std::string>& inputFileNames) {
+  if (inputFileNames.empty()) {
+    throw InvalidFormat("cppjieba_utf8 requires at least one input dictionary.");
+  }
+
+  std::map<std::string, std::vector<std::string>> entries;
+  LoadCppJiebaUtf8Dict(inputFileNames.front(), true, entries);
+  for (size_t i = 1; i < inputFileNames.size(); ++i) {
+    LoadCppJiebaUtf8Dict(inputFileNames[i], false, entries);
+  }
+
+  LexiconPtr lexicon(new Lexicon);
+  for (const auto& entry : entries) {
+    lexicon->Add(DictEntryFactory::New(entry.first, entry.second));
+  }
+  return TextDictPtr(new TextDict(lexicon));
+}
+
+} // namespace
+
 DictPtr LoadDictionary(const std::string& format,
                        const std::string& inputFileName) {
-  if (format == "text") {
+  if (format == "text" || format == "text_space") {
     FILE* fp = nullptr;
 #if defined(_WIN32) || defined(_WIN64)
     fp = _wfopen(internal::WideFromUtf8(inputFileName).c_str(), L"r");
@@ -41,7 +139,8 @@ DictPtr LoadDictionary(const std::string& format,
     if (!fp) {
       throw FileNotFound(inputFileName);
     }
-    DictPtr dict = TextDict::NewFromFile(fp);
+    DictPtr dict = format == "text" ? TextDict::NewFromFile(fp)
+                                    : TextDict::NewFromFile(fp, ' ');
     fclose(fp);
     return dict;
   } else if (format == "ocd") {
@@ -72,7 +171,24 @@ void ConvertDictionary(const std::string& inputFileName,
                        const std::string& outputFileName,
                        const std::string& formatFrom,
                        const std::string& formatTo) {
-  DictPtr dictFrom = LoadDictionary(formatFrom, inputFileName);
+  ConvertDictionary(std::vector<std::string>{inputFileName}, outputFileName,
+                    formatFrom, formatTo);
+}
+
+void ConvertDictionary(const std::vector<std::string>& inputFileNames,
+                       const std::string& outputFileName,
+                       const std::string& formatFrom,
+                       const std::string& formatTo) {
+  DictPtr dictFrom;
+  if (formatFrom == "cppjieba_utf8") {
+    dictFrom = LoadCppJiebaUtf8Dictionaries(inputFileNames);
+  } else {
+    if (inputFileNames.size() != 1) {
+      throw InvalidFormat("Dictionary format '" + formatFrom +
+                          "' requires exactly one input dictionary.");
+    }
+    dictFrom = LoadDictionary(formatFrom, inputFileNames.front());
+  }
   SerializableDictPtr dictTo = ConvertDict(formatTo, dictFrom);
   dictTo->SerializeToFile(outputFileName);
 }

--- a/src/DictConverter.hpp
+++ b/src/DictConverter.hpp
@@ -29,4 +29,9 @@ OPENCC_EXPORT void ConvertDictionary(const std::string& inputFileName,
                                      const std::string& outputFileName,
                                      const std::string& formatFrom,
                                      const std::string& formatTo);
+
+OPENCC_EXPORT void ConvertDictionary(
+    const std::vector<std::string>& inputFileNames,
+    const std::string& outputFileName, const std::string& formatFrom,
+    const std::string& formatTo);
 } // namespace opencc

--- a/src/Lexicon.cpp
+++ b/src/Lexicon.cpp
@@ -24,12 +24,13 @@ namespace opencc {
 
 namespace {
 
-DictEntry* ParseKeyValues(const char* buff, size_t lineNum) {
+DictEntry* ParseKeyValues(const char* buff, size_t lineNum,
+                          char keyValueDelimiter) {
   size_t length;
   if (buff == nullptr || UTF8Util::IsLineEndingOrFileEnding(*buff)) {
     return nullptr;
   }
-  const char* pbuff = UTF8Util::FindNextInline(buff, '\t');
+  const char* pbuff = UTF8Util::FindNextInline(buff, keyValueDelimiter);
   if (UTF8Util::IsLineEndingOrFileEnding(*pbuff)) {
     throw InvalidTextDictionary("Tabular not found " + std::string(buff),
                                 lineNum);
@@ -77,6 +78,10 @@ bool Lexicon::IsUnique(std::string* dupkey) {
 }
 
 LexiconPtr Lexicon::ParseLexiconFromFile(FILE* fp) {
+  return ParseLexiconFromFile(fp, '\t');
+}
+
+LexiconPtr Lexicon::ParseLexiconFromFile(FILE* fp, char keyValueDelimiter) {
   const int ENTRY_BUFF_SIZE = 4096;
   char buff[ENTRY_BUFF_SIZE];
   LexiconPtr lexicon(new Lexicon);
@@ -88,7 +93,7 @@ LexiconPtr Lexicon::ParseLexiconFromFile(FILE* fp) {
       lineNum++;
       continue;
     }
-    DictEntry* entry = ParseKeyValues(buff, lineNum);
+    DictEntry* entry = ParseKeyValues(buff, lineNum, keyValueDelimiter);
     if (entry != nullptr) {
       lexicon->Add(entry);
     }
@@ -119,7 +124,7 @@ LexiconPtr Lexicon::ParseLexiconFromBuffer(const char* data, size_t size) {
     }
     if (!line.empty() && line.front() != '#') {
       line.push_back('\n');
-      DictEntry* entry = ParseKeyValues(line.c_str(), lineNum);
+      DictEntry* entry = ParseKeyValues(line.c_str(), lineNum, '\t');
       if (entry != nullptr) {
         lexicon->Add(entry);
       }

--- a/src/Lexicon.hpp
+++ b/src/Lexicon.hpp
@@ -63,6 +63,7 @@ public:
   }
 
   static LexiconPtr ParseLexiconFromFile(FILE* fp);
+  static LexiconPtr ParseLexiconFromFile(FILE* fp, char keyValueDelimiter);
   static LexiconPtr ParseLexiconFromBuffer(const char* data, size_t size);
 
 private:

--- a/src/TextDict.cpp
+++ b/src/TextDict.cpp
@@ -47,7 +47,12 @@ TextDictPtr TextDict::NewFromSortedFile(FILE* fp) {
 }
 
 TextDictPtr TextDict::NewFromFile(FILE* fp) {
-  const LexiconPtr& lexicon = Lexicon::ParseLexiconFromFile(fp);
+  return NewFromFile(fp, '\t');
+}
+
+TextDictPtr TextDict::NewFromFile(FILE* fp, char keyValueDelimiter) {
+  const LexiconPtr& lexicon =
+      Lexicon::ParseLexiconFromFile(fp, keyValueDelimiter);
   lexicon->Sort();
   std::string dupkey;
   if (!lexicon->IsUnique(&dupkey)) {

--- a/src/TextDict.hpp
+++ b/src/TextDict.hpp
@@ -50,6 +50,7 @@ public:
   static TextDictPtr NewFromDict(const Dict& dict);
 
   static TextDictPtr NewFromFile(FILE* fp);
+  static TextDictPtr NewFromFile(FILE* fp, char keyValueDelimiter);
 
   static TextDictPtr NewFromBuffer(const char* data, size_t size);
 

--- a/src/tools/DictConverter.cpp
+++ b/src/tools/DictConverter.cpp
@@ -29,21 +29,24 @@ int main(int argc, const char* argv[]) {
     CmdLineOutput cmdLineOutput;
     cmd.setOutput(&cmdLineOutput);
 
-    std::vector<std::string> dictFormats{"text", "ocd2", "ocd"};
-    TCLAP::ValuesConstraint<std::string> allowedVals(dictFormats);
+    std::vector<std::string> inputFormats{"text", "text_space", "ocd2", "ocd",
+                                          "cppjieba_utf8"};
+    TCLAP::ValuesConstraint<std::string> allowedInputVals(inputFormats);
+    std::vector<std::string> outputFormats{"text", "ocd2", "ocd"};
+    TCLAP::ValuesConstraint<std::string> allowedOutputVals(outputFormats);
 
     TCLAP::ValueArg<std::string> toArg("t", "to", "Output format",
                                        true /* required */, "" /* default */,
-                                       &allowedVals /* type */, cmd);
+                                       &allowedOutputVals /* type */, cmd);
     TCLAP::ValueArg<std::string> fromArg("f", "from", "Input format",
                                          true /* required */, "" /* default */,
-                                         &allowedVals /* type */, cmd);
+                                         &allowedInputVals /* type */, cmd);
     TCLAP::ValueArg<std::string> outputArg(
         "o", "output", "Path to output dictionary", true /* required */,
         "" /* default */, "file" /* type */, cmd);
-    TCLAP::ValueArg<std::string> inputArg(
+    TCLAP::MultiArg<std::string> inputArg(
         "i", "input", "Path to input dictionary", true /* required */,
-        "" /* default */, "file" /* type */, cmd);
+        "file" /* type */, cmd);
     cmd.parse(argc, argv);
     ConvertDictionary(inputArg.getValue(), outputArg.getValue(),
                       fromArg.getValue(), toArg.getValue());


### PR DESCRIPTION
Add cppjieba_utf8 as an opencc_dict input format so Jieba merged dictionaries are produced by the standard dictionary tool. Remove the private cppjieba_dict helper and update CMake, Bazel, and Debian packaging rules to use opencc_dict.