### PR TITLE
Replace add_definitions(/W4) with add_compile_options to avoid rc.exe breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,10 +294,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-O0 -g3)
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  add_definitions(
-    /W4
-    /D "_CRT_SECURE_NO_WARNINGS"
-  )
+  add_compile_options(/W4)
+  add_definitions(/D "_CRT_SECURE_NO_WARNINGS")
 endif()
 
 if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
librime exposes this latent bug by building OpenCC with Ninja: add_definitions(/W4) propagates /W4 into the RC file compile command, causing rc.exe to fail with RC1106. OpenCC's own CI uses the Visual Studio generator (MSBuild), which keeps C++ and RC compiler flags in separate vcxproj sections, so the issue was not visible there.