### PR TITLE
t2s: add 遶 -> 绕 conversion

### DIFF
--- a/data/dictionary/TSCharacters.txt
+++ b/data/dictionary/TSCharacters.txt
@@ -3022,6 +3022,7 @@
 # @tofu-risk: not covered by PingFang/Source Han baseline: 𫐷 U+2B437
 遱	遱 𫐷
 遲	迟
+遶	绕
 遷	迁
 選	选
 遺	遗

--- a/test/testcases/testcases.json
+++ b/test/testcases/testcases.json
@@ -1623,6 +1623,13 @@
       }
     },
     {
+      "id": "rao_variant",
+      "input": "江流宛轉遶芳甸",
+      "expected": {
+        "t2s": "江流宛转绕芳甸"
+      }
+    },
+    {
       "id": "hk_computer_phrases_s2hkp",
       "input": "鼠标 光标 硬盘",
       "expected": {


### PR DESCRIPTION
通規 1755 號字「绕」（繞）的異體字「遶」

https://dict.revised.moe.edu.tw/dictView.jsp?ID=9213&la=0&powerMode=0

多用於古詩句，例如：
張若虛《春江花月夜》：江流宛轉遶芳甸，月照花林皆似霰。