### PR TITLE
Stabilize Doxygen page anchor IDs across build paths

### DIFF
--- a/doc/opencc.doxy.in
+++ b/doc/opencc.doxy.in
@@ -180,7 +180,7 @@ FULL_PATH_NAMES        = NO
 # will be relative from the directory where Doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -189,7 +189,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = @CMAKE_SOURCE_DIR@
 
 # If the SHORT_NAMES tag is set to YES, Doxygen will generate much shorter (but
 # less readable) file names. This can be useful if your file system doesn't


### PR DESCRIPTION
Set `STRIP_FROM_PATH`/`STRIP_FROM_INC_PATH` to the source root so Markdown page anchor IDs (e.g. `README`) no longer embed the absolute build path, making the generated documentation reproducible regardless of where the source tree is built.

Fixes #649