### PR TITLE
ci(msvc): drop Win32 x86 CI target (#1150)

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -23,10 +23,6 @@ jobs:
             cmake_arch: x64
             package_suffix: x64
             can_run_binaries: true
-          - arch: amd64_x86
-            cmake_arch: Win32
-            package_suffix: x86
-            can_run_binaries: true
           - arch: amd64_arm64
             cmake_arch: ARM64
             package_suffix: arm64


### PR DESCRIPTION
Closes #1150.

## Summary

Remove the 32-bit Windows (Win32 / x86) entry from the MSVC CI matrix.

Owner @BYVoid approved the proposal on the issue (`Ok`). Release artifacts already omit x86 prebuilt binaries, so this job only spent CI minutes without matching published products. Source-level x86 builds are unchanged; only the CI matrix entry is removed.

## Change

In `.github/workflows/msvc.yml`, drop the matrix include:

- `arch: amd64_x86` / `cmake_arch: Win32` / `package_suffix: x86`

Kept:

- `amd64` (x64, run binaries + tests)
- `amd64_arm64` (ARM64 compile-only)

Same direction as earlier Node CI cleanup in #960 (drop Windows x86 there).

## Test plan

- [x] Diff limited to `.github/workflows/msvc.yml` (4 lines removed)
- [x] YAML still has x64 + ARM64 matrix entries only
- [ ] GitHub Actions MSVC workflow on this PR (authoritative)

## Evidence

Issue consensus:

- Proposal: https://github.com/BYVoid/OpenCC/issues/1150
- Owner reply: `Ok` (https://github.com/BYVoid/OpenCC/issues/1150#issuecomment-4323072435)

Local check before publish:

`
git diff origin/master...HEAD --stat
 .github/workflows/msvc.yml | 4 ----
 1 file changed, 4 deletions(-)

git show HEAD:.github/workflows/msvc.yml | Select-String -Pattern 'amd64|Win32|x86'
          - arch: amd64
          - arch: amd64_arm64
`

No covering open PR for #1150 / Win32 x86 drop at publish time (`gh pr list -R BYVoid/OpenCC --state open --search ...`).

Please treat the MSVC workflow run on this PR as the authoritative verification.

## AI assistance

This change was developed with AI assistance (Cursor / Grok) and checked locally as shown above.

Made with [Cursor](https://cursor.com)