### PR TITLE
ci(msvc): drop Win32 x86 CI target (#1150)

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -23,10 +23,6 @@ jobs:
             cmake_arch: x64
             package_suffix: x64
             can_run_binaries: true
-          - arch: amd64_x86
-            cmake_arch: Win32
-            package_suffix: x86
-            can_run_binaries: true
           - arch: amd64_arm64
             cmake_arch: ARM64
             package_suffix: arm64


### PR DESCRIPTION
Closes #1150.

## Summary

Remove the 32-bit Windows (Win32 / x86) entry from the MSVC CI matrix.

Owner @BYVoid approved the proposal on the issue (`Ok`). Release artifacts already omit x86 prebuilt binaries, so this job only spent CI minutes without matching published products. Source-level x86 builds are unchanged; only the CI matrix entry is removed.

## Change

In `.github/workflows/msvc.yml`, drop the `amd64_x86` / Win32 matrix entry. Keep `amd64` (x64) and `amd64_arm64` (ARM64).

## Why reopen

Previous PR #1456 was closed without merge by @frankslin; `master` still includes the Win32 matrix entry.

## AI assistance

Assisted by Cursor/Grok. Human: Stan Shih (stantheman0128).

## Verification / Evidence

Diff is a one-entry CI matrix removal. No dictionary/runtime change. Confirmed `master` still contains `amd64_x86` / `cmake_arch: Win32` before this PR.