### PR TITLE
Default SignPath signing to the release-signing policy

### DIFF
--- a/.github/workflows/release-npm-binaries.yml
+++ b/.github/workflows/release-npm-binaries.yml
@@ -24,10 +24,13 @@ on:
         type: boolean
         default: false
       signpath_signing_policy_slug:
-        description: SignPath signing policy slug to use when signing is enabled
+        description: SignPath signing policy to use when signing is enabled
         required: true
-        type: string
-        default: test-signing
+        type: choice
+        options:
+          - release-signing
+          - test-signing
+        default: release-signing
 
 env:
   SIGNPATH_PROJECT_SLUG: OpenCC
@@ -139,7 +142,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ inputs.signpath_signing_policy_slug || 'test-signing' }}
+          signing-policy-slug: ${{ inputs.signpath_signing_policy_slug || 'release-signing' }}
           artifact-configuration-slug: npm-opencc-jieba-win32-x64
           github-artifact-id: ${{ steps.upload-unsigned-jieba-dll.outputs.artifact-id }}
           wait-for-completion: true
@@ -352,7 +355,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ inputs.signpath_signing_policy_slug || 'test-signing' }}
+          signing-policy-slug: ${{ inputs.signpath_signing_policy_slug || 'release-signing' }}
           artifact-configuration-slug: npm-opencc-node-win32-x64
           github-artifact-id: ${{ steps.upload-unsigned-opencc-node.outputs.artifact-id }}
           wait-for-completion: true

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -16,9 +16,12 @@ on:
         type: boolean
         default: false
       signpath_signing_policy_slug:
-        description: "SignPath signing policy slug to use when signing is enabled"
+        description: "SignPath signing policy to use when signing is enabled"
         required: true
-        type: string
+        type: choice
+        options:
+          - release-signing
+          - test-signing
         default: release-signing
 
 concurrency:


### PR DESCRIPTION
Now that release signing is validated, make release-signing the default SignPath policy for both the WinGet and npm binary release workflows, and turn the policy input into a two-option dropdown (release-signing / test-signing) instead of a free-text field.

Detailed Changes:
- **release-npm-binaries**: Default the policy input to release-signing and update both signing-request fallbacks.
- **release-winget**: Default fallback already release-signing; convert the input.
- **Both**: Change signpath_signing_policy_slug to type: choice with release-signing and test-signing options.