### PR TITLE
Fix legacy 64-bit OCD layout detection on big-endian platforms

### DIFF
--- a/src/BinaryDict.cpp
+++ b/src/BinaryDict.cpp
@@ -71,14 +71,12 @@ uint64_t ReadField(const char* data, size_t size, size_t* offset,
 //     non-zero whenever the dictionary has entries, and an empty dictionary
 //     is exactly 12 bytes long.
 //   - Legacy 64-bit layout: the first field is an 8-byte numItems whose high
-//     4 bytes are zero for any realistic dictionary.
+//     32 bits are zero for any realistic dictionary.
 size_t DetectFieldWidth(const char* data, size_t size) {
   if (size < 8) {
     return sizeof(uint32_t);
   }
-  const bool highBytesZero =
-      data[4] == 0 && data[5] == 0 && data[6] == 0 && data[7] == 0;
-  if (highBytesZero && size != 3 * sizeof(uint32_t)) {
+  if (LooksLikeLegacy64Field(data) && size != 3 * sizeof(uint32_t)) {
     return sizeof(uint64_t);
   }
   return sizeof(uint32_t);

--- a/src/BinaryDict.hpp
+++ b/src/BinaryDict.hpp
@@ -18,10 +18,28 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstring>
+
 #include "Common.hpp"
 #include "SerializableDict.hpp"
 
 namespace opencc {
+// Returns true if the 8 bytes at `bytes` look like an 8-byte integer field
+// from the legacy 64-bit OCD layout rather than two fixed-width uint32_t
+// fields. Legacy files were written with native size_t fields in native byte
+// order, so the probe is loaded as a native uint64_t: a legacy field has
+// zero high 32 bits, while for a fixed-width file the high half is one of
+// the two uint32 fields (or the start of the darts array), non-zero for any
+// realistic dictionary. Works on both little- and big-endian hosts; legacy
+// files themselves remain readable only on hosts of the byte order that
+// wrote them.
+inline bool LooksLikeLegacy64Field(const void* bytes) {
+  uint64_t word;
+  std::memcpy(&word, bytes, sizeof(word));
+  return (word >> 32) == 0;
+}
+
 /**
  * Binary dictionary for faster deserialization
  * @ingroup opencc_cpp_api

--- a/src/DartsDict.cpp
+++ b/src/DartsDict.cpp
@@ -234,20 +234,19 @@ DartsDictPtr DartsDict::NewFromFile(FILE* fp) {
           ? static_cast<size_t>(fileEnd - currentOffset)
           : 0;
 
-  // Detect the dartsSize field width by reading 8 bytes and checking
-  // whether bytes [4..7] are all zero.
+  // Detect the dartsSize field width by reading 8 bytes.
   //   - Old 64-bit build: dartsSize field is uint64_t (8 bytes); high 32 bits
-  //     are zero for any realistic file size → bytes [4..7] == 0.
+  //     are zero for any realistic file size.
   //   - Current build (any word size) or old 32-bit build: dartsSize field is
-  //     uint32_t (4 bytes); bytes [4..7] are the first 4 bytes of the darts
-  //     array (non-zero for any valid array whose root unit has a non-zero
-  //     offset).
+  //     uint32_t (4 bytes); the other half of the probe is either the first
+  //     4 bytes of the darts array (non-zero for any valid array whose root
+  //     unit has a non-zero offset) or dartsSize itself, so the native
+  //     uint64_t load has non-zero high bits.
   uint8_t probe[8];
   if (fread(probe, 1, 8, fp) != 8) {
     throw InvalidFormat("Invalid OpenCC dictionary header (dartsSize)");
   }
-  bool is64bit =
-      (probe[4] == 0 && probe[5] == 0 && probe[6] == 0 && probe[7] == 0);
+  bool is64bit = LooksLikeLegacy64Field(probe);
 
   if (is64bit) {
     uint64_t dartsSize64;
@@ -340,8 +339,7 @@ DartsDictPtr DartsDict::NewFromBuffer(const char* data, size_t size) {
   uint8_t probe[8];
   memcpy(probe, data + offset, 8);
   offset += 8;
-  bool is64bit =
-      (probe[4] == 0 && probe[5] == 0 && probe[6] == 0 && probe[7] == 0);
+  bool is64bit = LooksLikeLegacy64Field(probe);
 
   if (is64bit) {
     uint64_t dartsSize64;


### PR DESCRIPTION
Fixes #1471.

## Problem

The BinaryDict and DartsDict deserializers detect the legacy 64-bit OCD layout by checking whether probe bytes `[4..7]` are all zero. That assumes the high half of a native `uint64_t` sits at bytes `[4..7]`, which is only true on little-endian hosts. On big-endian platforms (s390x, ppc64, sparc64, hppa) the high half is at bytes `[0..3]`, so a legacy file is always misdetected as fixed-width: the first `uint32_t` read picks up the zero high half, `numItems`/`dartsSize` come out as 0, and the dictionary silently loads as empty. This is what breaks the five legacy-layout tests on Debian's big-endian buildds.

## Fix

Replace the byte-offset idiom at all three sites (`BinaryDict.cpp` `DetectFieldWidth`, `DartsDict.cpp` `NewFromFile` and `NewFromBuffer`) with a shared `LooksLikeLegacy64Field()` helper in the private header `BinaryDict.hpp`: load the 8-byte probe as a native `uint64_t` via `memcpy` and check `(word >> 32) == 0`. Since legacy files are written in native byte order by construction, a native load recovers the original value on either byte order:

- **Little-endian**: `word >> 32` is exactly bytes `[4..7]` — identical to the current behavior, zero change.
- **Big-endian**: a legacy field loads back to its true value with zero high bits; a fixed-width file's high half is the first `uint32` field (`numItems`/`dartsSize`), non-zero for any non-empty dictionary. The empty-dictionary corner case is already excluded by the existing `size != 3 * sizeof(uint32_t)` guard.

No changes to the legacy read paths themselves (`ReadField`, `LegacyUnit64`, `ValidateLegacy64`) — those already do native loads of natively-written data. Legacy `.ocd` files remain same-byte-order-only by construction; `.ocd2` is unaffected.

## Verification

- arm64 (little-endian): `//src:binary_dict_test` and `//src:darts_dict_test` pass via Bazel, 22/22 before and after.
- s390x (big-endian, QEMU user emulation, Debian Sid, CMake build): `BinaryDictTest` 10/10 and `DartsDictTest` 12/12 pass, including the five tests failing on the Debian buildds (`AcceptsLegacy64BitLayout`, `RejectsHugeValueTotalLength`, `LoadsLegacy64bitFormat`, `Legacy64PrefixSearchBeyond64Matches`, `Legacy64SerializeToFileThrows`). The test fixtures are generated at runtime with native writes, so they exercise the real big-endian legacy layout.

@hosiet a confirmation run on a real Debian porterbox would still be welcome.