### PR TITLE
Keep common Simplified 么 words intact in tw2t/tw2s conversion for compatibility

### DIFF
--- a/data/dictionary/TWVariants.txt
+++ b/data/dictionary/TWVariants.txt
@@ -47,4 +47,9 @@
 鍼	針
 鮎	鯰
 麪	麵
+# 么 as a secondary candidate backs the Simplified 么 phrase exceptions in
+# TWVariantsRevPhrases.txt (issue #1469); the generated TWVariantsRev.txt
+# then lists 么 -> 幺 麼 while 幺 stays the default via @reverse-prefer.
+# @reverse-prefer: 么 幺
+麼	麼 么
 齶	顎

--- a/data/dictionary/TWVariantsRevPhrases.txt
+++ b/data/dictionary/TWVariantsRevPhrases.txt
@@ -61,6 +61,8 @@
 人才輩出	人才輩出
 人才難得	人才難得
 人盡其才	人盡其才
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+什么	什麼
 仙才	仙才
 伊核	伊核
 作育英才	作育英才
@@ -304,6 +306,8 @@
 增量參數	增量參數
 外才	外才
 外核	外核
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+多么	多麼
 多事逞才	多事逞才
 多才	多才
 多才多藝	多才多藝
@@ -336,6 +340,8 @@
 女秀才	女秀才
 女貌郎才	女貌郎才
 奴才	奴才
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+好么	好麼
 妙才	妙才
 學優才贍	學優才贍
 學淺才疏	學淺才疏
@@ -392,6 +398,8 @@
 志大才疏	志大才疏
 志大才短	志大才短
 志廣才疏	志廣才疏
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+怎么	怎麼
 恃才傲物	恃才傲物
 恃才矜己	恃才矜己
 恃才自專	恃才自專
@@ -760,6 +768,8 @@
 瑣才	瑣才
 甄才品能	甄才品能
 甄選人才	甄選人才
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+甚么	甚麼
 男才女貌	男才女貌
 畎畝下才	畎畝下才
 留針	留針
@@ -919,6 +929,8 @@
 補針	補針
 製麵	製麪
 西洋參	西洋參
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+要么	要麼
 見縫插針	見縫插針
 討針線	討針線
 詠雪之才	詠雪之才
@@ -958,9 +970,13 @@
 辯才	辯才
 辯才天	辯才天
 辯才無礙	辯才無礙
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+这么	这麼
 迴紋針	迴紋針
 退針	退針
 逆時針	逆時針
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+這么	這麼
 通人達才	通人達才
 通才	通才
 通才教育	通才教育
@@ -977,6 +993,8 @@
 遺才	遺才
 避雷針	避雷針
 邊核	邊核
+# intentionally kept for compatibility - https://github.com/BYVoid/OpenCC/issues/1469
+那么	那麼
 郎才女姿	郎才女姿
 郎才女貌	郎才女貌
 鄧艾吃	鄧艾吃

--- a/test/testcases/testcases.json
+++ b/test/testcases/testcases.json
@@ -467,6 +467,14 @@
       }
     },
     {
+      "id": "BYVoid_OpenCC_Issue_1469_simplified_me_passthrough",
+      "input": "什么 怎么 这么 那么 多么 要么 好么 甚么 這么 老么",
+      "expected": {
+        "tw2s": "什么 怎么 这么 那么 多么 要么 好么 甚么 这么 老幺",
+        "tw2t": "什麼 怎麼 这麼 那麼 多麼 要麼 好麼 甚麼 這麼 老幺"
+      }
+    },
+    {
       "id": "case_063_s2x",
       "input": "赛后复盘 覆盘难照",
       "expected": {


### PR DESCRIPTION
The generated TWVariantsRev dictionary maps `么` -> `幺` (reversing the Taiwan-standard `幺` -> `么` variant), which corrupted already-Simplified input such as `什么` into `什幺` in tw2t, tw2s and tw2sp (issue #1469).

Add phrase exceptions mapping `什么`/`怎么`/`这么`/`那么`/`多么`/`要么`/`好么`/`甚么`/`這么` to their Traditional `麼` forms in TWVariantsRevPhrases.txt, with inline comments so they are not mistaken for typos.

tw2t now outputs proper Traditional (`什么` -> `什麼`), tw2s reaches the expected Simplified form via the TS stage, and genuine 幺(yao1) words like `老么` still convert to `老幺`.