### PR TITLE
Sign Windows release binaries on tag builds

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -11,7 +11,7 @@ on:
         description: "Release version or tag, for example 1.2.0, 1.2.1-rc1, 1.2.1-alpha1, or ver.1.2.0"
         required: false
       sign_windows_binaries:
-        description: "Sign Windows binaries with SignPath before packaging"
+        description: "Sign Windows binaries with SignPath before packaging (tag builds always sign)"
         required: true
         type: boolean
         default: false
@@ -84,7 +84,7 @@ jobs:
             -PrepareOnly
 
       - name: Create unsigned SignPath input
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_windows_binaries }}
+        if: ${{ inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path release/signpath | Out-Null
@@ -94,7 +94,7 @@ jobs:
             -CompressionLevel Optimal
 
       - name: Upload unsigned SignPath input
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_windows_binaries }}
+        if: ${{ inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/') }}
         id: upload-unsigned-signpath-input
         uses: actions/upload-artifact@v7
         with:
@@ -104,7 +104,7 @@ jobs:
           if-no-files-found: error
 
       - name: Submit SignPath signing request
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_windows_binaries }}
+        if: ${{ inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/') }}
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -114,11 +114,14 @@ jobs:
           artifact-configuration-slug: opencc-winget-portable-win32-x64
           github-artifact-id: ${{ steps.upload-unsigned-signpath-input.outputs.artifact-id }}
           wait-for-completion: true
+          # The release-signing policy requires a human approver; the action's
+          # 600s default is not enough to notice the request and approve it.
+          wait-for-completion-timeout-in-seconds: 1800
           skip-decompress: true
           output-artifact-directory: release/signpath-signed
 
       - name: Restore signed portable staging
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_windows_binaries }}
+        if: ${{ inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           $signedRoot = "release/signpath-signed"
@@ -142,7 +145,7 @@ jobs:
           }
 
       - name: Verify signed portable files
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_windows_binaries }}
+        if: ${{ inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           $files = @(


### PR DESCRIPTION
The five SignPath steps in `release-winget.yml` were gated on `github.event_name == 'workflow_dispatch'`, so the run triggered by pushing a `ver.*` tag skipped signing entirely — while `Upload to GitHub release` (gated only on `startsWith(github.ref, 'refs/tags/')`) still uploaded the portable zip to the release.

That is how the 1.4.1 Windows zip shipped unsigned: run `29196952454` shows all five signing steps as `skipped`. README and NEWS now state that Windows binaries are Authenticode-signed from 1.4.2 on, so the default path has to actually sign.

## Changes

- Gate the signing steps on `inputs.sign_windows_binaries || startsWith(github.ref, 'refs/tags/')`. A tag build always signs, and a failed signing request fails the job rather than silently producing an unsigned artifact. Manual dispatch on a non-tag ref is unchanged and still opt-in.
- Set `wait-for-completion-timeout-in-seconds: 1800`. The `release-signing` policy requires a human approver (confirmed in run `32588647662`, where approval took ~2m40s), and the action's default is 600s.
- Note in the input description that tag builds always sign.

## Verification

`release-signing` was exercised end to end in run `32588647662` (dry-run) and `32589112455` (publish); both Windows npm binaries came back `signed by CN=SignPath Foundation, ...; status: Valid`. The winget artifact configuration (`opencc-winget-portable-win32-x64`) has not yet been signed under `release-signing` — the first `ver.*` tag after this merge will be its first run, and it will need a manual approval.