### PR TITLE
Fix test suite compilation and sandbox compatibility

### DIFF
--- a/src/BinaryDictTest.cpp
+++ b/src/BinaryDictTest.cpp
@@ -24,7 +24,7 @@ namespace opencc {
 class BinaryDictTest : public TextDictTestBase {
 protected:
   BinaryDictTest()
-      : binDict(new BinaryDict(textDict->GetLexicon())), fileName("dict.bin"){};
+      : binDict(new BinaryDict(textDict->GetLexicon())), fileName(::testing::TempDir() + "/dict.bin"){};
 
   // Write a crafted binary file for BinaryDict with controllable fields.
   // FIELD selects the integer field width: uint32_t for the fixed-width
@@ -36,7 +36,7 @@ protected:
       uint64_t valueTotalLength, const std::string& valueBuffer,
       const std::vector<std::tuple<uint64_t, uint64_t, std::vector<uint64_t>>>&
           items) {
-    const std::string path = "crafted_binary_dict.bin";
+    const std::string path = ::testing::TempDir() + "/crafted_binary_dict.bin";
     FILE* fp = fopen(path.c_str(), "wb");
     const auto writeField = [fp](uint64_t value) {
       FIELD field = static_cast<FIELD>(value);

--- a/src/DartsDictTest.cpp
+++ b/src/DartsDictTest.cpp
@@ -30,13 +30,13 @@ class DartsDictTest : public TextDictTestBase {
 protected:
   DartsDictTest()
       : dartsDict(DartsDict::NewFromDict(*textDict.get())),
-        fileName("dict.ocd"){};
+        fileName(::testing::TempDir() + "/dict.ocd"){};
 
   // Write a crafted 32-bit-format OCD file with a controllable dartsSize.
   // A non-zero fakeFirstUnit is appended so probe[4..7] are not all zero,
   // ensuring the 32-bit detection path is taken even for malformed files.
   static std::string WriteMalformedDartsFile(uint32_t dartsSize) {
-    const std::string path = "malformed_darts.ocd";
+    const std::string path = ::testing::TempDir() + "/malformed_darts.ocd";
     FILE* fp = fopen(path.c_str(), "wb");
     const char* header = "OPENCCDARTS1";
     fwrite(header, sizeof(char), strlen(header), fp);

--- a/src/LexiconAnnotationTest.cpp
+++ b/src/LexiconAnnotationTest.cpp
@@ -26,7 +26,10 @@ namespace opencc {
 
 class LexiconAnnotationTest : public ::testing::Test {
 protected:
-  const std::string testFileName = "test_annotation_dict.txt";
+  LexiconAnnotationTest()
+      : testFileName(::testing::TempDir() + "/test_annotation_dict.txt") {}
+
+  const std::string testFileName;
 
   void TearDown() override { remove(testFileName.c_str()); }
 };
@@ -107,7 +110,7 @@ TEST_F(LexiconAnnotationTest, SerializeIgnoresComments) {
   fclose(readFp);
 
   // Serialize back
-  const std::string outputFileName = "test_annotation_dict_output.txt";
+  const std::string outputFileName = ::testing::TempDir() + "/test_annotation_dict_output.txt";
   FILE* outFp = fopen(outputFileName.c_str(), "w");
   dict->SerializeToFile(outFp);
   fclose(outFp);

--- a/src/MarisaDictTest.cpp
+++ b/src/MarisaDictTest.cpp
@@ -27,11 +27,11 @@ namespace opencc {
 class MarisaDictTest : public TextDictTestBase {
 protected:
   MarisaDictTest()
-      : dict(MarisaDict::NewFromDict(*textDict)), fileName("dict.ocd2"){};
+      : dict(MarisaDict::NewFromDict(*textDict)), fileName(::testing::TempDir() + "/dict.ocd2"){};
 
   // Write a crafted OCD2 file with a valid header but corrupt trie data.
   static std::string WriteMalformedMarisaFile() {
-    const std::string path = "malformed_marisa.ocd2";
+    const std::string path = ::testing::TempDir() + "/malformed_marisa.ocd2";
     FILE* fp = fopen(path.c_str(), "wb");
     const char* header = "OPENCC_MARISA_0.2.5";
     fwrite(header, sizeof(char), strlen(header), fp);

--- a/src/PrefixMatchTest.cpp
+++ b/src/PrefixMatchTest.cpp
@@ -35,7 +35,7 @@ class PrefixMatchTest : public TextDictTestBase {
 protected:
   PrefixMatchTest()
       : marisaDict(MarisaDict::NewFromDict(*textDict)),
-        fileName("prefix_match_dict.ocd2") {
+        fileName(::testing::TempDir() + "/prefix_match_dict.ocd2") {
     marisaDict->opencc::SerializableDict::SerializeToFile(fileName);
   }
 

--- a/src/SerializedValuesTest.cpp
+++ b/src/SerializedValuesTest.cpp
@@ -28,7 +28,7 @@ class SerializedValuesTest : public TextDictTestBase {
 protected:
   SerializedValuesTest()
       : binDict(new SerializedValues(textDict->GetLexicon())),
-        fileName("dict.bin"){};
+        fileName(::testing::TempDir() + "/dict.bin"){};
 
   // Write a crafted binary file for testing malformed input handling.
   // Format: uint32 numItems, uint32 valueTotalLength, char[] valueBuffer,
@@ -38,7 +38,7 @@ protected:
                                         const std::string& valueBuffer,
                                         const std::vector<std::vector<uint16_t>>&
                                             itemValueBytes) {
-    const std::string path = "malformed_test.bin";
+    const std::string path = ::testing::TempDir() + "/malformed_test.bin";
     FILE* fp = fopen(path.c_str(), "wb");
     fwrite(&numItems, sizeof(uint32_t), 1, fp);
     fwrite(&valueTotalLength, sizeof(uint32_t), 1, fp);

--- a/src/TextDictTest.cpp
+++ b/src/TextDictTest.cpp
@@ -23,7 +23,7 @@ namespace opencc {
 
 class TextDictTest : public TextDictTestBase {
 protected:
-  TextDictTest() : fileName("dict.txt"){};
+  TextDictTest() : fileName(::testing::TempDir() + "/dict.txt"){};
 
   const std::string fileName;
 };

--- a/test/PortableUtil.hpp
+++ b/test/PortableUtil.hpp
@@ -22,6 +22,7 @@
 #include <direct.h>
 #else
 #include <unistd.h>
+#include <stdlib.h>
 #endif
 
 namespace opencc {


### PR DESCRIPTION
- Explicitly include <stdlib.h> in test/PortableUtil.hpp. The POSIX functions `setenv` and `unsetenv` are declared in <stdlib.h>. Relying on <unistd.h> to transitively include it fails in environments with stricter C++ standards or different libc implementations.
- Replace hardcoded relative/tmp test output paths with `::testing::TempDir()`. This ensures tests do not fail when run concurrently, on read-only filesystems, or within strict build sandboxes (like Bazel test environments).